### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ O projeto depende das seguintes bibliotecas e ferramentas:
 - **Spring Security OAuth2 Client**: Facilita a criação de aplicações que são clientes de provedores OAuth 2.0.
 - **Spring Security OAuth2 Resource Server**: Facilita a criação de aplicações que são servidores de recursos OAuth 2.0.
 
-- **Dowload para iniciar o microsserviço**:
+- **Download para iniciar o microsserviço**:
 [Link para o Spring Initializr](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.1.1&packaging=jar&jvmVersion=11&groupId=br.com.cloudport&artifactId=servico-autenticacao&name=servico-autenticacao&description=Servi%C3%A7o%20respons%C3%A1vel%20pela%20autentica%C3%A7%C3%A3o%20e%20autoriza%C3%A7%C3%A3o%20de%20usu%C3%A1rios%20na%20aplica%C3%A7%C3%A3o%20CloudPort.&packageName=br.com.cloudport.servico-autenticacao&dependencies=web,data-jpa,security,postgresql,devtools,lombok,validation,flyway,oauth2-client,oauth2-resource-server)
 
 ### Como Rodar o Projeto


### PR DESCRIPTION
## Summary
- correct a typo in the download instructions

## Testing
- `npm run test` *(fails: Missing script)*
- `mvn -q -f backend/servico-autenticacao/pom.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc74bd87883279f2301831b0c6596