### PR TITLE
Add token service test

### DIFF
--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/ServicoAutenticacaoApplicationTests.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/ServicoAutenticacaoApplicationTests.java
@@ -1,13 +1,31 @@
 package br.com.cloudport.servicoautenticacao;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.*;
+
+import br.com.cloudport.servicoautenticacao.config.TokenService;
+import br.com.cloudport.servicoautenticacao.model.User;
+
+import java.util.HashSet;
 
 @SpringBootTest
 class ServicoAutenticacaoApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private TokenService tokenService;
+
+    @Test
+    void contextLoads() {
+    }
+
+    @Test
+    void generateAndValidateToken() {
+        User user = new User("test", "pass", new HashSet<>());
+        String token = tokenService.generateToken(user);
+        assertNotNull(token);
+        assertEquals(user.getLogin(), tokenService.validateToken(token));
+    }
 
 }


### PR DESCRIPTION
## Summary
- autowire `TokenService` in `ServicoAutenticacaoApplicationTests`
- add a new test that generates and validates a token

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685dc748319c83278263ecadb1c674a4