### PR TITLE
Use environment variable for API URL

### DIFF
--- a/frontend/cloudport/src/app/componentes/role/role-tabela/role-tabela.component.ts
+++ b/frontend/cloudport/src/app/componentes/role/role-tabela/role-tabela.component.ts
@@ -1,7 +1,7 @@
 /* role.component.ts */
 import { Component, OnInit, ViewChild  } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { environment } from '../../service/endpoint';
+import { environment } from '../../../../environments/environment';
 import { AuthenticationService } from '../../service/servico-autenticacao/authentication.service';
 import { catchError } from 'rxjs/operators';
 import { throwError } from 'rxjs';
@@ -215,7 +215,8 @@ closeContextMenu(event: MouseEvent) {
       })
     };
 
-    this.http.get<any[]>(`${environment.role.getAll}`, httpOptions)
+    const url = `${environment.baseApiUrl}/api/roles`;
+    this.http.get<any[]>(url, httpOptions)
       .pipe(catchError((error: any) => {
         window.alert(error.message); // Aqui o popup é criado
         return throwError(error);
@@ -249,7 +250,8 @@ closeContextMenu(event: MouseEvent) {
     // Aplica trim(), toUpperCase() e substitui espaços por sublinhados
     const roleName = this.roleName.trim().toUpperCase().replace(' ', '_');
 
-    this.http.post(`${environment.role.create}`, { name: roleName }, httpOptions)
+    const createUrl = `${environment.baseApiUrl}/api/roles`;
+    this.http.post(createUrl, { name: roleName }, httpOptions)
         .pipe(catchError((error: any) => {
             window.alert(error.message); // Aqui o popup é criado
             return throwError(error);
@@ -275,7 +277,8 @@ closeContextMenu(event: MouseEvent) {
     // Aplica trim(), toUpperCase() e substitui espaços por sublinhados roleName
     const roleName = this.roleName.trim().toUpperCase().replace(' ', '_');
 
-    this.http.put(`${environment.role.update(roleId)}`, { name: roleName}, httpOptions)
+    const updateUrl = `${environment.baseApiUrl}/api/roles/${roleId}`;
+    this.http.put(updateUrl, { name: roleName}, httpOptions)
         .pipe(catchError((error: any) => {
             window.alert(error.message); // Aqui o popup é criado
             return throwError(error);
@@ -298,7 +301,8 @@ closeContextMenu(event: MouseEvent) {
         })
     };
 
-    this.http.delete(`${environment.role.delete(roleId)}`, httpOptions)
+    const deleteUrl = `${environment.baseApiUrl}/api/roles/${roleId}`;
+    this.http.delete(deleteUrl, httpOptions)
       .pipe(catchError((error: any) => {
           if (error.status === 409) {
               window.alert('Não é possível deletar o Role pois ele ainda está sendo referenciado por um User.'); 

--- a/frontend/cloudport/src/app/componentes/service/endpoint.ts
+++ b/frontend/cloudport/src/app/componentes/service/endpoint.ts
@@ -1,4 +1,6 @@
-const baseLink = 'https://8080-diogo2806-cloudport-z3o7260rnlo.ws-us104.gitpod.io';
+import { environment as env } from '../../../environments/environment';
+
+const baseLink = env.baseApiUrl;
 
 export const environment = {
     auth: {

--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { User } from '../../model/user.model';
-import { environment } from '../endpoint';
+import { environment } from '../../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class AuthenticationService {
@@ -24,7 +24,8 @@ export class AuthenticationService {
     }
 
     login(login: string, password: string) {
-        return this.http.post<any>(environment.auth.login, { login, password })
+        const url = `${environment.baseApiUrl}/auth/login`;
+        return this.http.post<any>(url, { login, password })
             .pipe(map(user => {
                 // store user details and jwt token in local storage to keep user logged in between page refreshes
                 localStorage.setItem('currentUser', JSON.stringify(user));

--- a/frontend/cloudport/src/environments/environment.prod.ts
+++ b/frontend/cloudport/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  baseApiUrl: 'https://8080-diogo2806-cloudport-z3o7260rnlo.ws-us104.gitpod.io'
+};

--- a/frontend/cloudport/src/environments/environment.ts
+++ b/frontend/cloudport/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  baseApiUrl: 'https://8080-diogo2806-cloudport-z3o7260rnlo.ws-us104.gitpod.io'
+};


### PR DESCRIPTION
## Summary
- add Angular environment files
- reference `environment.baseApiUrl` when building endpoints
- clean up URL construction in services and components

## Testing
- `npm test --prefix frontend/cloudport --silent -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc9560374832783404b659a8d5a3f