### PR TITLE
Ajusta controle de exibição do menu baseado na autenticação

### DIFF
--- a/frontend/cloudport/src/app/componentes/header/header.component.html
+++ b/frontend/cloudport/src/app/componentes/header/header.component.html
@@ -6,7 +6,7 @@
               <h1 class="display-4 mt-3">CloudPort</h1>
               <app-navbar></app-navbar>
           </div>
-          <button class="btn btn-outline-danger btn-sm" (click)="logout()">Logout</button>
+          <button *ngIf="mostrarMenu" class="btn btn-outline-danger btn-sm" (click)="logout()">Logout</button>
       </div>
   </div>
 </div>

--- a/frontend/cloudport/src/app/componentes/header/header.component.ts
+++ b/frontend/cloudport/src/app/componentes/header/header.component.ts
@@ -1,16 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AuthenticationService } from '../service/servico-autenticacao/authentication.service';
 import { Router, ActivatedRoute, RouteReuseStrategy } from '@angular/router';
 import { CustomReuseStrategy } from '../tab-content/customreusestrategy';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css']
 })
-export class HeaderComponent {
+export class HeaderComponent implements OnInit, OnDestroy {
 
   userToken: string = '';
+  mostrarMenu: boolean = false;
+  private menuStatusSubscription?: Subscription;
 
   constructor(
     private route: ActivatedRoute,
@@ -22,6 +25,18 @@ export class HeaderComponent {
     if (currentUser && currentUser.token) {
       this.userToken = currentUser.token;
     }
+  }
+
+
+  ngOnInit(): void {
+    this.mostrarMenu = this.authenticationService.getMenuStatusValue();
+    this.menuStatusSubscription = this.authenticationService.currentMenuStatus.subscribe(status => {
+      this.mostrarMenu = status;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.menuStatusSubscription?.unsubscribe();
   }
 
 

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -1,7 +1,8 @@
-import { Component, HostListener, ElementRef } from '@angular/core';
+import { Component, HostListener, ElementRef, OnDestroy, OnInit } from '@angular/core';
 import { AuthenticationService } from '../service/servico-autenticacao/authentication.service';
 import { Router, ActivatedRoute } from '@angular/router';
 import { TabService } from './TabService';
+import { Subscription } from 'rxjs';
 
 function logMethod(target: any, key: string, descriptor: PropertyDescriptor) {
   const originalMethod = descriptor.value;
@@ -19,9 +20,10 @@ function logMethod(target: any, key: string, descriptor: PropertyDescriptor) {
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.css']
 })
-export class NavbarComponent {
+export class NavbarComponent implements OnInit, OnDestroy {
   mostrarMenu: boolean = false;
   private readonly validChildRoutes = new Set(['role']);
+  private menuStatusSubscription?: Subscription;
 
   constructor(
       private authenticationService: AuthenticationService,
@@ -35,12 +37,15 @@ export class NavbarComponent {
 
   ngOnInit(): void {
       console.log("Classe NavbarComponent: Método ngOnInit iniciado.");
-      this.authenticationService.currentMenuStatus.subscribe(
+      this.mostrarMenu = this.authenticationService.getMenuStatusValue();
+      this.menuStatusSubscription = this.authenticationService.currentMenuStatus.subscribe(
           mostrar => this.mostrarMenu = mostrar
       );
-
-      this.mostrarMenu = true;
       console.log("Classe NavbarComponent: Método ngOnInit finalizado.");
+  }
+
+  ngOnDestroy(): void {
+      this.menuStatusSubscription?.unsubscribe();
   }
 
   // ... (resto do código)

--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
@@ -10,13 +10,16 @@ import { environment } from '../../../../environments/environment';
 export class AuthenticationService {
     private currentUserSubject: BehaviorSubject<User | null>;
     public currentUser: Observable<User | null>;
-    private menuStatus = new BehaviorSubject<boolean>(false);
-    public currentMenuStatus = this.menuStatus.asObservable();
+    private menuStatus: BehaviorSubject<boolean>;
+    public currentMenuStatus: Observable<boolean>;
 
     constructor(private http: HttpClient) {
         const storedData = localStorage.getItem('currentUser');
-        this.currentUserSubject = new BehaviorSubject<User | null>(storedData ? JSON.parse(storedData) : null);
+        const currentUser = storedData ? JSON.parse(storedData) : null;
+        this.currentUserSubject = new BehaviorSubject<User | null>(currentUser);
         this.currentUser = this.currentUserSubject.asObservable();
+        this.menuStatus = new BehaviorSubject<boolean>(!!currentUser);
+        this.currentMenuStatus = this.menuStatus.asObservable();
     }
 
     public get currentUserValue(): User | null {
@@ -36,6 +39,7 @@ export class AuthenticationService {
 
     logout() {
         // remove user from local storage to log user out
+        this.updateMenuStatus(false);
         localStorage.removeItem('currentUser');
         localStorage.removeItem('username');
         this.currentUserSubject.next(null);
@@ -53,5 +57,9 @@ export class AuthenticationService {
 
     updateMenuStatus(status: boolean) {
         this.menuStatus.next(status);
+    }
+
+    getMenuStatusValue(): boolean {
+        return this.menuStatus.getValue();
     }
 }


### PR DESCRIPTION
## Summary
- sincroniza o estado inicial do menu com o BehaviorSubject do serviço de autenticação
- atualiza navbar e header para reagirem dinamicamente ao status do menu e ocultar o botão de logout quando necessário
- garante que o logout também atualize o status do menu antes de redirecionar

## Testing
- ⚠️ `npm install` *(falha: 403 Forbidden ao baixar @ag-grid-enterprise/excel-export)*

------
https://chatgpt.com/codex/tasks/task_e_68d87aa4bca88327ae22e67b5f2e0b54