### PR TITLE
Oculta header e footer na rota de login

### DIFF
--- a/frontend/cloudport/src/app/app.component.html
+++ b/frontend/cloudport/src/app/app.component.html
@@ -1,7 +1,7 @@
-<app-header></app-header>
+<app-header *ngIf="showChrome"></app-header>
 
 <main>
-    <router-outlet></router-outlet> 
+    <router-outlet></router-outlet>
 </main>
 
-<app-footer></app-footer>
+<app-footer *ngIf="showChrome"></app-footer>

--- a/frontend/cloudport/src/app/app.component.ts
+++ b/frontend/cloudport/src/app/app.component.ts
@@ -1,14 +1,38 @@
-import { Component } from '@angular/core';
-import { LoginComponent } from './componentes/login/login.component';
+import { Component, OnDestroy } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   title = 'cloudport';
+  showChrome = true;
+  private readonly destroy$ = new Subject<void>();
 
- 
+  constructor(private router: Router) {
+    this.updateChromeVisibility(this.router.url);
 
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((event: NavigationEnd) => {
+        this.updateChromeVisibility(event.urlAfterRedirects ?? event.url);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private updateChromeVisibility(url: string): void {
+    const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
+    this.showChrome = !normalizedUrl.startsWith('/login');
+  }
 }

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -32,12 +32,12 @@ export class NavbarComponent implements OnInit, OnDestroy {
       private eRef: ElementRef
   ) {
     console.log("Classe NavbarComponent: Método construtor chamado.");
+    this.mostrarMenu = this.authenticationService.getMenuStatusValue();
   }
 
 
   ngOnInit(): void {
       console.log("Classe NavbarComponent: Método ngOnInit iniciado.");
-      this.mostrarMenu = this.authenticationService.getMenuStatusValue();
       this.menuStatusSubscription = this.authenticationService.currentMenuStatus.subscribe(
           mostrar => this.mostrarMenu = mostrar
       );


### PR DESCRIPTION
## Summary
- controla exibição do header e footer no AppComponent com base nos eventos de navegação do Router
- exibe header e footer apenas quando a navegação não está na rota de login
- mantém o Navbar alinhado ao estado inicial emitido pelo AuthenticationService

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d895635e908327970aa92a7b78a01b