### PR TITLE
Atualiza exportação de dados filtrados na tabela dinâmica

### DIFF
--- a/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
+++ b/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
@@ -235,15 +235,20 @@ console.log("handleTableContextMenu: ", event)
 
 onBtExport() {
   try {
-    // Obter os nós da linha após a filtragem
-    const nodes = this.gridApi.getRenderedNodes();
+    // Obter os dados das linhas filtradas percorrendo todos os nós disponíveis
+    const dados: any[] = [];
+    this.gridApi.forEachNodeAfterFilter((node) => {
+      if (node.data) {
+        dados.push(node.data);
+      }
+    });
 
-    // Extrair os dados de cada nó
-    const dados = nodes.map(node => node.data);
+    // Converter os dados coletados para JSON antes da exportação
+    const jsonData = JSON.parse(JSON.stringify(dados));
 
     // Preparar as colunas para exportação
     const columns = this.columns.map(column => ({ [column]: '' }));
-    const exportData = dados.length ? dados : columns;
+    const exportData = jsonData.length ? jsonData : columns;
 
     // Usar a biblioteca XLSX para exportar os dados
     const ws: XLSX.WorkSheet = XLSX.utils.json_to_sheet(exportData);


### PR DESCRIPTION
## Summary
- utiliza a API forEachNodeAfterFilter para coletar todas as linhas filtradas
- garante que os dados exportados sejam convertidos para JSON antes da geração da planilha com XLSX

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8986b59848327bd88e4f9918f618a