### PR TITLE
Adjust context menu closing behavior in dynamic table

### DIFF
--- a/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.html
+++ b/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.html
@@ -1,7 +1,6 @@
 <!--dynamic-table.component.html-->
-<div class="grid-container" 
+<div class="grid-container"
 (click)="closeContextMenu($event)"
-(contextmenu)="closeContextMenu($event)"
 >
   <div class="btn-group" role="group" aria-label="Basic example">
     <img class="icon" src="../../../assets/images/excel-4954.svg" alt="Excel" width="20" height="20" (click)="onBtExport()"/>

--- a/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
+++ b/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
@@ -214,9 +214,15 @@ console.log("handleTableContextMenu: ", event)
 
 
   closeContextMenu(event: MouseEvent): void {
-    // Verifique se o clique foi fora do menu de contexto e feche-o
-    // Você pode adicionar lógica adicional aqui para determinar quando fechar o menu
-    this.rightClick.emit(null); // Emita um evento nulo para fechar o menu
+    const target = event?.target as Node | null;
+    const clickedInsideGrid = !!(target && this.gridTable?.nativeElement?.contains(target));
+
+    const contextMenuElement = document.querySelector('.context-menu');
+    const clickedInsideMenu = !!(target && contextMenuElement?.contains(target));
+
+    if (!clickedInsideGrid && !clickedInsideMenu) {
+      this.rightClick.emit(null);
+    }
   }
   
 


### PR DESCRIPTION
## Summary
- remove the contextmenu binding from the dynamic table container so right clicks within the grid no longer trigger closing
- update the closeContextMenu handler to only emit when the click happens outside the grid or the context menu element

## Testing
- not run (not possible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d89868eac08327ab5703bf203e7b7d