### PR TITLE
Fix dynamic table context menu handling

### DIFF
--- a/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.html
+++ b/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.html
@@ -26,7 +26,6 @@
       (gridReady)="onGridReady($event)"
       (cellClicked)="onCellClicked($event)"
       (cellDoubleClicked)="onCellDoubleClicked($event)"
-      (cellContextMenu)="onCellRightClicked($event)"
       (rowClicked)="onRowClicked($event)"
       (cellContextMenu)="onCellContextMenu($event)"
     >

--- a/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
+++ b/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
@@ -162,26 +162,17 @@ console.log("handleTableContextMenu: ", event)
   
 
   onCellContextMenu(event: any): void {
-
-
-
-  
     const mouseEvent = event.event as MouseEvent;
     mouseEvent.preventDefault(); // Previne o menu de contexto padrão dentro da tabela
+
+    if (mouseEvent.button !== 2) {
+      return; // Ignora se não for o botão direito do mouse
+    }
+
+    mouseEvent.stopPropagation();
+
     const row = event.data; // Acessa os dados da linha clicada
     console.log('DynamicTableComponent onCellContextMenu: Emitindo evento de clique com o botão direito do mouse', { event: mouseEvent, row }); // Depuração
-    this.rightClick.emit({ event: mouseEvent, row });
-  }
-
-
-  onCellRightClicked(event: any) {
-    event.event.preventDefault();
-    const mouseEvent = event.event as MouseEvent;
-    const row = event.data; // Acessa os dados da linha clicada
-    mouseEvent.stopPropagation();
-    mouseEvent.preventDefault();
-    if (mouseEvent.button !== 2) return; // Ignora se não for o botão direito do mouse
-    console.log('DynamicTableComponent onCellRightClicked: Emitindo evento de clique com o botão direito do mouse', { event: mouseEvent, row }); // Depuração
     this.rightClick.emit({ event: mouseEvent, row });
   }
 


### PR DESCRIPTION
## Summary
- point the AG Grid cellContextMenu binding to a single handler
- ensure the handler prevents the default browser menu, validates the mouse button, and emits the custom rightClick event

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d89bd795608327b410b74b3758efc5