### PR TITLE
Emit grid ready event with payload

### DIFF
--- a/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
+++ b/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
@@ -47,7 +47,7 @@ export class DynamicTableComponent implements OnInit, AfterViewInit {
   @Output() rightClick = new EventEmitter<any>();
   @Input() selectedTab: string = '';
   @ViewChild('gridTable') gridTable!: ElementRef;
-  @Output() gridReady = new EventEmitter<void>();
+  @Output() gridReady = new EventEmitter<GridReadyEvent>();
 
   @Output() createRole = new EventEmitter<void>();
 
@@ -228,11 +228,11 @@ console.log("handleTableContextMenu: ", event)
 
   
 
-  onGridReady(params: any) {
+  onGridReady(params: GridReadyEvent) {
     this.gridApi = params.api;
    // this.gridTable.nativeElement.addEventListener('contextmenu', this.handleTableContextMenu.bind(this));
-  
-    //this.gridReady.emit();
+
+    this.gridReady.emit(params);
 
 }
 

--- a/frontend/cloudport/src/app/componentes/role/role-tabela/role-tabela.component.html
+++ b/frontend/cloudport/src/app/componentes/role/role-tabela/role-tabela.component.html
@@ -7,7 +7,7 @@
     [data]="roles"
     [selectedTab]="selectedTab"
     (rightClick)="handleRoleRightClick($event, contextMenu)"
-    (gridReady)="onGridTableReady()">
+    (gridReady)="onGridTableReady($event)">
 </app-dynamic-table>
 
 

--- a/frontend/cloudport/src/app/componentes/role/role-tabela/role-tabela.component.ts
+++ b/frontend/cloudport/src/app/componentes/role/role-tabela/role-tabela.component.ts
@@ -13,6 +13,7 @@ import { Renderer2 } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { PopupService } from '../../service/popupService';
 import { ModalComponent } from '../../modal/modal.component';
+import { GridReadyEvent } from 'ag-grid-community';
 
 function logMethod(target: any, key: string, descriptor: PropertyDescriptor) {
   const originalMethod = descriptor.value;
@@ -82,8 +83,8 @@ export class RoleTabelaComponent  implements OnInit, AfterViewInit {
     
 }
 
-onGridTableReady() {
-  console.log('Classe RoleComponent: Método onGridTableReady chamado.');
+onGridTableReady(event: GridReadyEvent) {
+  console.log('Classe RoleComponent: Método onGridTableReady chamado.', event);
   const tableElement = this.gridTable.nativeElement; // Referência direta ao elemento da tabela ag-Grid
   this.renderer.listen(tableElement, 'contextmenu', (event) => {
     event.preventDefault(); // Previne o menu de contexto padrão


### PR DESCRIPTION
## Summary
- emit the ag-Grid GridReadyEvent from DynamicTableComponent when the grid initializes
- update RoleTabelaComponent to receive the grid ready payload and log its invocation
- wire the role table template to forward the gridReady event arguments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89bd9d9b48327bd77f1cf4f0be8a4