### PR TITLE
Fix user role persistence during registration

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationController.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationController.java
@@ -9,6 +9,7 @@ import br.com.cloudport.servicoautenticacao.model.Role;
 import br.com.cloudport.servicoautenticacao.repositories.RoleRepository;
 import br.com.cloudport.servicoautenticacao.config.TokenService;
 import br.com.cloudport.servicoautenticacao.repositories.UserRepository;
+import br.com.cloudport.servicoautenticacao.repositories.UserRoleRepository;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -34,6 +35,8 @@ public class AuthenticationController {
     private RoleRepository roleRepository;
     @Autowired
     private TokenService tokenService;
+    @Autowired
+    private UserRoleRepository userRoleRepository;
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDTO> login(@RequestBody @Valid AuthenticationDTO data){
@@ -63,11 +66,14 @@ public class AuthenticationController {
                                   return new UserRole(null, role);
                               })
                               .collect(Collectors.toSet());
-    
+
         User newUser = new User(data.getLogin(), encryptedPassword, roles);
-    
+
+        roles.forEach(role -> role.setUser(newUser));
+
         this.userRepository.save(newUser);
-    
+        this.userRoleRepository.saveAll(roles);
+
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
@@ -8,8 +8,10 @@ import br.com.cloudport.servicoautenticacao.model.User;
 import br.com.cloudport.servicoautenticacao.model.UserRole;
 import br.com.cloudport.servicoautenticacao.repositories.RoleRepository;
 import br.com.cloudport.servicoautenticacao.repositories.UserRepository;
+import br.com.cloudport.servicoautenticacao.repositories.UserRoleRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -26,6 +28,9 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -49,6 +54,9 @@ class AuthenticationControllerTest {
 
     @MockBean
     private TokenService tokenService;
+
+    @MockBean
+    private UserRoleRepository userRoleRepository;
 
     @Test
     void login_success() throws Exception {
@@ -110,5 +118,15 @@ class AuthenticationControllerTest {
                 .andExpect(status().isOk());
 
         verify(userRepository).save(any(User.class));
+
+        ArgumentCaptor<Iterable<UserRole>> rolesCaptor = ArgumentCaptor.forClass(Iterable.class);
+        verify(userRoleRepository).saveAll(rolesCaptor.capture());
+
+        Iterable<UserRole> savedRoles = rolesCaptor.getValue();
+        assertNotNull(savedRoles);
+        assertTrue(savedRoles.iterator().hasNext());
+        UserRole savedRole = savedRoles.iterator().next();
+        assertNotNull(savedRole.getUser());
+        assertEquals("john", savedRole.getUser().getLogin());
     }
 }


### PR DESCRIPTION
## Summary
- ensure registration links UserRole entities to the created user before persisting
- persist the associated roles explicitly through the UserRole repository
- extend the controller test to verify that saved roles contain the user reference

## Testing
- ./mvnw test *(fails: Maven wrapper download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a3210fe08327ab269b4298a2693a