### PR TITLE
Corrige propagação do token no modelo de usuário

### DIFF
--- a/frontend/cloudport/src/app/componentes/model/user.model.spec.ts
+++ b/frontend/cloudport/src/app/componentes/model/user.model.spec.ts
@@ -1,0 +1,25 @@
+import { User } from './user.model';
+
+describe('User model', () => {
+  it('deve preencher as propriedades fornecidas no construtor', () => {
+    const user = new User('1', 'João', 'token-123', 'joao@example.com', 'senha', 'ADMIN');
+
+    expect(user.id).toBe('1');
+    expect(user.nome).toBe('João');
+    expect(user.token).toBe('token-123');
+    expect(user.email).toBe('joao@example.com');
+    expect(user.senha).toBe('senha');
+    expect(user.perfil).toBe('ADMIN');
+  });
+
+  it('deve permitir instanciar com valores padrão', () => {
+    const user = new User();
+
+    expect(user.id).toBe('');
+    expect(user.nome).toBe('');
+    expect(user.token).toBe('');
+    expect(user.email).toBe('');
+    expect(user.senha).toBe('');
+    expect(user.perfil).toBe('');
+  });
+});

--- a/frontend/cloudport/src/app/componentes/model/user.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/user.model.ts
@@ -9,7 +9,7 @@ export class User {
     ) {
       this.id = id;
       this.nome = nome;
-      this.token = nome;
+      this.token = token;
       this.email = email;
       this.senha = senha;
       this.perfil = perfil;

--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
@@ -15,7 +15,8 @@ export class AuthenticationService {
 
     constructor(private http: HttpClient) {
         const storedData = localStorage.getItem('currentUser');
-        const currentUser = storedData ? JSON.parse(storedData) : null;
+        const currentUserData = storedData ? JSON.parse(storedData) : null;
+        const currentUser = currentUserData ? this.mapToUser(currentUserData) : null;
         this.currentUserSubject = new BehaviorSubject<User | null>(currentUser);
         this.currentUser = this.currentUserSubject.asObservable();
         this.menuStatus = new BehaviorSubject<boolean>(!!currentUser);
@@ -29,7 +30,8 @@ export class AuthenticationService {
     login(login: string, password: string) {
         const url = `${environment.baseApiUrl}/auth/login`;
         return this.http.post<any>(url, { login, password })
-            .pipe(map(user => {
+            .pipe(map(response => {
+                const user = this.mapToUser(response);
                 // store user details and jwt token in local storage to keep user logged in between page refreshes
                 localStorage.setItem('currentUser', JSON.stringify(user));
                 this.currentUserSubject.next(user);
@@ -61,5 +63,22 @@ export class AuthenticationService {
 
     getMenuStatusValue(): boolean {
         return this.menuStatus.getValue();
+    }
+
+    private mapToUser(data: any): User {
+        if (!data) {
+            return new User();
+        }
+
+        const source = data.data ?? data;
+
+        return new User(
+            source.id ?? data.id ?? '',
+            source.nome ?? source.name ?? data.nome ?? '',
+            source.token ?? data.token ?? '',
+            source.email ?? data.email ?? '',
+            source.senha ?? data.senha ?? '',
+            source.perfil ?? data.perfil ?? ''
+        );
     }
 }

--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/jwt.interceptor.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/jwt.interceptor.ts
@@ -12,11 +12,11 @@ export class JwtInterceptor implements HttpInterceptor {
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         // add authorization header with jwt token if available
         let currentUser:any = this.authenticationService.currentUserValue;
-        
-        if (currentUser && currentUser.data.token) {
+
+        if (currentUser && currentUser.token) {
             request = request.clone({
                 setHeaders: {
-                    Authorization: `Bearer ${currentUser.data.token}`
+                    Authorization: `Bearer ${currentUser.token}`
                 }
             });
         }


### PR DESCRIPTION
## Summary
- Corrige a atribuição do token no modelo `User` e adiciona testes unitários para o construtor
- Mapeia as respostas de autenticação para instâncias do modelo garantindo que o token seja persistido
- Atualiza o interceptor JWT para utilizar a nova estrutura do modelo ao enviar o cabeçalho de autorização

## Testing
- npm test -- --watch=false *(falhou: ng não encontrado no ambiente de execução)*

------
https://chatgpt.com/codex/tasks/task_e_68d90243923083279e93675dcd27b65e