### PR TITLE
Handle invalid tokens gracefully in authentication service

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/SecurityFilter.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/SecurityFilter.java
@@ -5,7 +5,6 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,25 +13,37 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Component
 public class SecurityFilter extends OncePerRequestFilter {
-    @Autowired
-    TokenService tokenService;
-    @Autowired
-    UserRepository userRepository;
+    private final TokenService tokenService;
+    private final UserRepository userRepository;
+
+    public SecurityFilter(TokenService tokenService, UserRepository userRepository) {
+        this.tokenService = tokenService;
+        this.userRepository = userRepository;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         var token = this.recoverToken(request);
-        if(token != null){
-            var login = tokenService.validateToken(token);
-            UserDetails user = userRepository.findByLogin(login)
-                                             .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + login));
-
-            var authentication = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        if(token == null){
+            filterChain.doFilter(request, response);
+            return;
         }
+
+        Optional<String> login = tokenService.validateToken(token);
+        if(login.isEmpty()){
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        UserDetails user = userRepository.findByLogin(login.get())
+                                         .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + login.get()));
+
+        var authentication = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
         filterChain.doFilter(request, response);
     }
 

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/TokenService.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/TokenService.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import java.util.Optional;
 
 @Service
 public class TokenService {
@@ -32,16 +33,17 @@ public class TokenService {
         }
     }
 
-    public String validateToken(String token){
+    public Optional<String> validateToken(String token){
         try {
             Algorithm algorithm = Algorithm.HMAC256(secret);
-            return JWT.require(algorithm)
+            var subject = JWT.require(algorithm)
                     .withIssuer("auth-api")
                     .build()
                     .verify(token)
                     .getSubject();
+            return Optional.ofNullable(subject);
         } catch (JWTVerificationException exception){
-            return "";
+            return Optional.empty();
         }
     }
 

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/ServicoAutenticacaoApplicationTests.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/ServicoAutenticacaoApplicationTests.java
@@ -9,6 +9,7 @@ import br.com.cloudport.servicoautenticacao.config.TokenService;
 import br.com.cloudport.servicoautenticacao.model.User;
 
 import java.util.HashSet;
+import java.util.Optional;
 
 @SpringBootTest
 class ServicoAutenticacaoApplicationTests {
@@ -25,13 +26,13 @@ class ServicoAutenticacaoApplicationTests {
         User user = new User("test", "pass", new HashSet<>());
         String token = tokenService.generateToken(user);
         assertNotNull(token);
-        assertEquals(user.getLogin(), tokenService.validateToken(token));
+        assertEquals(Optional.of(user.getLogin()), tokenService.validateToken(token));
     }
 
     @Test
     void invalidTokenReturnsEmpty() {
         String invalidToken = "invalid";
-        assertEquals("", tokenService.validateToken(invalidToken));
+        assertTrue(tokenService.validateToken(invalidToken).isEmpty());
     }
 
 }

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/config/SecurityFilterTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/config/SecurityFilterTest.java
@@ -1,0 +1,47 @@
+package br.com.cloudport.servicoautenticacao.config;
+
+import br.com.cloudport.servicoautenticacao.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SecurityFilterTest {
+
+    private TokenService tokenService;
+    private UserRepository userRepository;
+    private SecurityFilter securityFilter;
+
+    @BeforeEach
+    void setUp() {
+        tokenService = mock(TokenService.class);
+        userRepository = mock(UserRepository.class);
+        securityFilter = new SecurityFilter(tokenService, userRepository);
+    }
+
+    @Test
+    void invalidTokenShouldNotInvokeRepositoryAndReturnUnauthorized() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/products");
+        request.addHeader("Authorization", "Bearer invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        when(tokenService.validateToken("invalid-token")).thenReturn(Optional.empty());
+
+        securityFilter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+        verify(userRepository, never()).findByLogin(any());
+        assertNull(filterChain.getRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- adjust `TokenService` to return `Optional` when token verification fails instead of an empty string
- update `SecurityFilter` to skip repository lookups for invalid tokens and return 401 without authenticating
- extend test coverage to assert invalid tokens remain unauthorized and avoid repository queries

## Testing
- `mvn test` *(fails: unable to download dependencies from Maven Central – HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9022f8af88327bfa53ad38ae84e75