### PR TITLE
Refatora relacionamento entre roles e user roles

### DIFF
--- a/backend/servico-autenticacao/pom.xml
+++ b/backend/servico-autenticacao/pom.xml
@@ -65,11 +65,16 @@
 			<version>5.7.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/model/Role.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/model/Role.java
@@ -3,11 +3,12 @@ package br.com.cloudport.servicoautenticacao.model;
 import lombok.Getter;
 import lombok.Setter;
 import javax.persistence.*;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.HashSet; // Make sure to import this
 
 
 @Entity
+@Table(name = "roles")
 @Getter
 @Setter
 public class Role {
@@ -18,7 +19,7 @@ public class Role {
     @Column
     private String name;
 
-    @ManyToMany(mappedBy = "roles")
+    @OneToMany(mappedBy = "role", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<UserRole> userRoles = new HashSet<>();
 
     // Default constructor

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/model/UserRole.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/model/UserRole.java
@@ -4,10 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import java.util.Set;
 import javax.persistence.*;
 
 @Entity
+@Table(name = "user_roles")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -24,11 +24,6 @@ public class UserRole {
     @ManyToOne
     @JoinColumn(name = "role_id")
     private Role role;
-
-
-    @ManyToMany
-    private Set<Role> roles;
-
     @Enumerated(EnumType.STRING)
     private StatusEnum statusEnum;
 

--- a/backend/servico-autenticacao/src/main/resources/db/migration/V3__create-roles-user_roles-tables.sql
+++ b/backend/servico-autenticacao/src/main/resources/db/migration/V3__create-roles-user_roles-tables.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS roles (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+    id BIGSERIAL PRIMARY KEY,
+    user_id UUID NOT NULL,
+    role_id BIGINT NOT NULL,
+    status_enum VARCHAR(255),
+    CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_user_roles_role FOREIGN KEY (role_id) REFERENCES roles (id)
+);
+
+ALTER TABLE users DROP COLUMN IF EXISTS role;

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/repositories/RoleRepositoryTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/repositories/RoleRepositoryTest.java
@@ -1,0 +1,52 @@
+package br.com.cloudport.servicoautenticacao.repositories;
+
+import br.com.cloudport.servicoautenticacao.model.Role;
+import br.com.cloudport.servicoautenticacao.model.StatusEnum;
+import br.com.cloudport.servicoautenticacao.model.User;
+import br.com.cloudport.servicoautenticacao.model.UserRole;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.HashSet;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class RoleRepositoryTest {
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserRoleRepository userRoleRepository;
+
+    @Test
+    void findByNameLoadsRoleWithRelatedUserRoles() {
+        Role role = roleRepository.save(new Role("ADMIN"));
+
+        User user = new User(UUID.randomUUID(), "john.doe", "secret", new HashSet<>());
+        userRepository.save(user);
+
+        UserRole relation = new UserRole(user, role);
+        relation.setStatusEnum(StatusEnum.ACTIVE);
+        user.getRoles().add(relation);
+        role.getUserRoles().add(relation);
+        userRoleRepository.save(relation);
+
+        Role persisted = roleRepository.findByName("ADMIN").orElseThrow();
+
+        assertThat(persisted.getName()).isEqualTo("ADMIN");
+        assertThat(persisted.getUserRoles())
+                .hasSize(1)
+                .allSatisfy(userRole -> {
+                    assertThat(userRole.getUser().getId()).isEqualTo(user.getId());
+                    assertThat(userRole.getRole().getId()).isEqualTo(role.getId());
+                    assertThat(userRole.getStatusEnum()).isEqualTo(StatusEnum.ACTIVE);
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- Ajusta a entidade Role para utilizar relacionamento one-to-many com UserRole e define a tabela dedicada
- Remove o campo many-to-many obsoleto em UserRole e alinha os nomes de tabela com a nova migração
- Cria migração para as tabelas roles e user_roles, adiciona dependência H2 e teste JPA que valida a carga de papéis via repositório

## Testing
- mvn test *(falha: acesso ao repositório Maven bloqueado - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d90231dea48327988599b6737a7943