### PR TITLE
Ajusta inicialização do usuário admin e adiciona teste de integração

### DIFF
--- a/backend/servico-autenticacao/pom.xml
+++ b/backend/servico-autenticacao/pom.xml
@@ -65,11 +65,16 @@
 			<version>5.7.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java
@@ -39,12 +39,12 @@ public class UserInitializer implements CommandLineRunner {
 
         if (!userRepository.findByLogin(adminLogin).isPresent()) {
             User adminUser = new User(adminLogin, adminPassword, roles);
-            userRepository.save(adminUser);
 
-            // Set user to each UserRole and save
             for (UserRole userRole : roles) {
                 userRole.setUser(adminUser);
             }
+
+            userRepository.save(adminUser);
         }
     }
 }

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/config/UserInitializerIntegrationTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/config/UserInitializerIntegrationTest.java
@@ -1,0 +1,43 @@
+package br.com.cloudport.servicoautenticacao.config;
+
+import br.com.cloudport.servicoautenticacao.model.User;
+import br.com.cloudport.servicoautenticacao.model.UserRole;
+import br.com.cloudport.servicoautenticacao.repositories.UserRepository;
+import br.com.cloudport.servicoautenticacao.repositories.UserRoleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserInitializerIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserRoleRepository userRoleRepository;
+
+    @Test
+    void initialAdminUserHasPersistedRoles() {
+        User adminUser = userRepository.findByLogin("gitpod").orElse(null);
+        assertNotNull(adminUser, "Usuário administrador inicial não foi criado");
+
+        assertNotNull(adminUser.getRoles(), "Coleção de papéis não deve ser nula");
+        assertFalse(adminUser.getRoles().isEmpty(), "Usuário administrador deve possuir ao menos um papel associado");
+        adminUser.getRoles().forEach(userRole -> {
+            assertNotNull(userRole.getUser(), "UserRole deve manter referência ao usuário");
+            assertEquals(adminUser.getId(), userRole.getUser().getId(), "UserRole deve estar vinculado ao usuário administrador");
+        });
+
+        List<UserRole> persistedRoles = userRoleRepository.findAll();
+        assertFalse(persistedRoles.isEmpty(), "Deve haver registros de vínculo usuário-papel persistidos");
+        persistedRoles.forEach(userRole -> {
+            assertNotNull(userRole.getId(), "UserRole deve possuir identificador persistido");
+            assertNotNull(userRole.getUser(), "UserRole persistido deve estar vinculado a um usuário");
+        });
+    }
+}

--- a/backend/servico-autenticacao/src/test/resources/application.properties
+++ b/backend/servico-autenticacao/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:h2:mem:servicoautenticacao;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.open-in-view=false
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false


### PR DESCRIPTION
## Summary
- garante que os vínculos UserRole recebam o usuário antes da persistência do admin inicial
- configura propriedades de teste com H2 e adiciona verificação de integração do usuário inicial

## Testing
- `mvn test` *(falhou: bloqueio de rede para baixar dependências Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68d9023546cc8327878c4577089d0a43