### PR TITLE
Adiciona validações e mensagens amigáveis para autenticação

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/AuthenticationDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/AuthenticationDTO.java
@@ -1,7 +1,15 @@
 package br.com.cloudport.servicoautenticacao.dto;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 public class AuthenticationDTO {
+    @NotBlank(message = "O login é obrigatório.")
+    @Size(min = 3, max = 100, message = "O login deve ter entre 3 e 100 caracteres.")
     private String login;
+
+    @NotBlank(message = "A senha é obrigatória.")
+    @Size(min = 6, max = 255, message = "A senha deve ter pelo menos 6 caracteres.")
     private String password;
 
     public AuthenticationDTO() {}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/RegisterDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/RegisterDTO.java
@@ -3,10 +3,21 @@ package br.com.cloudport.servicoautenticacao.dto;
 
 import java.util.Set;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+
 public class RegisterDTO {
+    @NotBlank(message = "O login é obrigatório.")
+    @Size(min = 3, max = 100, message = "O login deve ter entre 3 e 100 caracteres.")
     private String login;
+
+    @NotBlank(message = "A senha é obrigatória.")
+    @Size(min = 6, max = 255, message = "A senha deve ter pelo menos 6 caracteres.")
     private String password;
-    private Set<String> roles;
+
+    @NotEmpty(message = "Informe ao menos uma role.")
+    private Set<@NotBlank(message = "A role não pode ser vazia.") String> roles;
 
     public RegisterDTO() {}
 

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/GlobalExceptionHandler.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/GlobalExceptionHandler.java
@@ -5,8 +5,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -23,6 +28,23 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
         logger.warn("IllegalArgumentException encontrada no GlobalExceptionHandler: ", ex);
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        logger.warn("Erro de validação encontrado no GlobalExceptionHandler: ", ex);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("mensagem", "Erro de validação dos dados enviados.");
+
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(error.getField(), error.getDefaultMessage());
+        }
+
+        body.put("erros", fieldErrors);
+
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
     }
     
     @ExceptionHandler(DataIntegrityViolationException.class)

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
@@ -93,6 +93,19 @@ class AuthenticationControllerTest {
     }
 
     @Test
+    void login_invalidPayload_returnsBadRequestWithMessages() throws Exception {
+        AuthenticationDTO dto = new AuthenticationDTO("", "");
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensagem").value("Erro de validação dos dados enviados."))
+                .andExpect(jsonPath("$.erros.login").value("O login é obrigatório."))
+                .andExpect(jsonPath("$.erros.password").value("A senha é obrigatória."));
+    }
+
+    @Test
     void register_duplicateLogin() throws Exception {
         when(userRepository.findByLogin("john"))
                 .thenReturn(Optional.of(new User()));
@@ -103,6 +116,20 @@ class AuthenticationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void register_invalidPayload_returnsBadRequestWithMessages() throws Exception {
+        RegisterDTO dto = new RegisterDTO("", "", Collections.emptySet());
+
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensagem").value("Erro de validação dos dados enviados."))
+                .andExpect(jsonPath("$.erros.login").value("O login é obrigatório."))
+                .andExpect(jsonPath("$.erros.password").value("A senha é obrigatória."))
+                .andExpect(jsonPath("$.erros.roles").value("Informe ao menos uma role."));
     }
 
     @Test


### PR DESCRIPTION
## Resumo
- aplica validações com mensagens claras nos DTOs de autenticação e registro
- ajusta o tratamento global de erros para responder 400 com detalhes de validação
- adiciona testes cobrindo payloads inválidos no login e no registro

## Testes
- mvn test *(falha por bloqueio ao baixar dependências do Spring Boot Starter Parent)*

------
https://chatgpt.com/codex/tasks/task_e_68d902371bdc832780b8e76e461c436f