### PR TITLE
Remove credenciais sensíveis e documenta variáveis de ambiente

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ O projeto depende das seguintes bibliotecas e ferramentas:
 1. Clone o projeto para o seu ambiente local.
 2. Certifique-se de que você tem o Maven e o JDK 17 instalados.
 3. Navegue até a raiz do projeto via linha de comando.
-4. Execute `createdb servico_autenticacao`.
-5. Execute `mvn spring-boot:run`.
+4. Copie o arquivo `env.example` para `.env` e ajuste as variáveis de ambiente de acordo com sua infraestrutura (RabbitMQ, PostgreSQL e chaves JWT).
+5. Exporte as variáveis definidas no `.env` para o seu shell (`export $(grep -v '^#' .env | xargs)` em ambientes Unix) ou configure-as no serviço de execução da aplicação.
+6. Execute `createdb servico_autenticacao`.
+7. Execute `mvn spring-boot:run`.
 
 ### Contribuição
 

--- a/backend/servico-autenticacao/src/main/resources/application.properties
+++ b/backend/servico-autenticacao/src/main/resources/application.properties
@@ -1,13 +1,13 @@
 # RabbitMQ Configuration
-spring.rabbitmq.host=localhost
-spring.rabbitmq.port=5672
-spring.rabbitmq.username=gitpod
-spring.rabbitmq.password=gitpod
+spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:change-me}
+spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD:change-me}
 
 # PostgreSQL Configuration
-spring.datasource.url=jdbc:postgresql://localhost:5432/servico_autenticacao
-spring.datasource.username=gitpod
-spring.datasource.password=gitpod
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/servico_autenticacao}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:change-me}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:change-me}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Hibernate Configuration
@@ -15,11 +15,11 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialec
 spring.jpa.hibernate.ddl-auto = update
 
 # Spring Security Configuration
-spring.security.user.name=gitpod
-spring.security.user.password=gitpod
-jwt.secret=gitpod
+spring.security.user.name=${SPRING_SECURITY_USER_NAME:change-me}
+spring.security.user.password=${SPRING_SECURITY_USER_PASSWORD:change-me}
+jwt.secret=${JWT_SECRET:change-me}
 
-api.security.token.secret=${JWT_SECRET:my-secret-key}
+api.security.token.secret=${JWT_SECRET:change-me}
 
 spring.jpa.open-in-view=false
 spring.mvc.cors.allowed-origins=*

--- a/env.example
+++ b/env.example
@@ -1,0 +1,20 @@
+# Variáveis de ambiente para o serviço de autenticação
+# Preencha com os valores do seu ambiente antes de executar a aplicação.
+
+# RabbitMQ
+SPRING_RABBITMQ_HOST=localhost
+SPRING_RABBITMQ_PORT=5672
+SPRING_RABBITMQ_USERNAME=seu_usuario
+SPRING_RABBITMQ_PASSWORD=sua_senha
+
+# PostgreSQL
+SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/servico_autenticacao
+SPRING_DATASOURCE_USERNAME=seu_usuario
+SPRING_DATASOURCE_PASSWORD=sua_senha
+
+# Usuário padrão do Spring Security (opcional)
+SPRING_SECURITY_USER_NAME=usuario_admin
+SPRING_SECURITY_USER_PASSWORD=senha_admin
+
+# Segredo JWT compartilhado entre os serviços
+JWT_SECRET=altere-esta-chave-super-secreta


### PR DESCRIPTION
## Summary
- substitui credenciais e segredos do `application.properties` por placeholders baseados em variáveis de ambiente
- adiciona `env.example` com orientações para configuração das variáveis sensíveis
- atualiza o README com instruções para carregar as variáveis antes de iniciar o serviço

## Testing
- mvn -q test *(falhou: status 403 ao baixar dependências do Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d9023cf8ac8327abf4286704cef586