### PR TITLE
Handle missing roles during user registration

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationController.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationController.java
@@ -13,6 +13,7 @@ import br.com.cloudport.servicoautenticacao.repositories.UserRoleRepository;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -62,7 +64,7 @@ public class AuthenticationController {
         Set<UserRole> roles = data.getRoles().stream()
                               .map(roleName -> {
                                   Role role = roleRepository.findByName(roleName)
-                                          .orElseThrow(() -> new IllegalArgumentException("Role " + roleName + " not found"));
+                                          .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Role " + roleName + " not found"));
                                   return new UserRole(null, role);
                               })
                               .collect(Collectors.toSet());

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
@@ -129,4 +129,18 @@ class AuthenticationControllerTest {
         assertNotNull(savedRole.getUser());
         assertEquals("john", savedRole.getUser().getLogin());
     }
+
+    @Test
+    void register_roleNotFound() throws Exception {
+        when(userRepository.findByLogin("john")).thenReturn(Optional.empty());
+        when(roleRepository.findByName("UNKNOWN")).thenReturn(Optional.empty());
+
+        RegisterDTO dto = new RegisterDTO("john", "pass", Collections.singleton("UNKNOWN"));
+
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Role UNKNOWN not found"));
+    }
 }


### PR DESCRIPTION
## Summary
- replace the IllegalArgumentException in the registration flow with a 404 ResponseStatusException when a role cannot be found
- keep user creation logic unchanged while ensuring a clear error message is returned for missing roles
- add a controller test that validates the not-found response and message for registrations with unknown roles

## Testing
- mvn test *(fails: Could not download parent POM due to 403 from repo.maven.apache.org in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90239e9d08327a747fb4e815c0ce5