### PR TITLE
Remove redundant persistence API dependencies from auth service

### DIFF
--- a/backend/servico-autenticacao/pom.xml
+++ b/backend/servico-autenticacao/pom.xml
@@ -45,20 +45,10 @@
 			<version>3.0.0</version>
 		</dependency>
 
-		<dependency>
-			<groupId>jakarta.persistence</groupId>
-			<artifactId>jakarta.persistence-api</artifactId>
-			<version>3.0.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.persistence</groupId>
-			<artifactId>javax.persistence-api</artifactId>
-			<version>2.2</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
## Summary
- remove redundant manual jakarta and javax persistence API dependencies from the authentication service module
- rely on spring-boot-starter-data-jpa to provide the necessary persistence APIs

## Testing
- mvn dependency:tree *(fails: unable to download parent POM from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9023edb848327a8219c4e048eb1b9