### PR TITLE
Remover dependência jjwt em serviço de autenticação

### DIFF
--- a/backend/servico-autenticacao/pom.xml
+++ b/backend/servico-autenticacao/pom.xml
@@ -84,11 +84,6 @@
                         <version>42.5.5</version>
 		</dependency>
 		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt</artifactId>
-			<version>0.9.1</version>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-log4j2</artifactId>
 		</dependency>


### PR DESCRIPTION
## Summary
- remover a dependência io.jsonwebtoken:jjwt não utilizada do serviço de autenticação
- manter apenas a biblioteca com.auth0:java-jwt como implementação de JWT

## Testing
- ./mvnw test *(falhou: o Maven Wrapper não conseguiu baixar dependências por falta de acesso à rede)*

------
https://chatgpt.com/codex/tasks/task_e_68d9023fa89883278b4a9999c93b56bb