### PR TITLE
feat: estruturar domínio e migrações do gate

### DIFF
--- a/backend/servico-gate/pom.xml
+++ b/backend/servico-gate/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
@@ -55,6 +59,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
     <build>

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/AgendamentoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/AgendamentoDTO.java
@@ -1,0 +1,254 @@
+package br.com.cloudport.servicogate.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+public class AgendamentoDTO {
+
+    private Long id;
+    private String codigo;
+    private String tipoOperacao;
+    private String tipoOperacaoDescricao;
+    private String status;
+    private String statusDescricao;
+    private Long transportadoraId;
+    private String transportadoraNome;
+    private Long motoristaId;
+    private String motoristaNome;
+    private Long veiculoId;
+    private String placaVeiculo;
+    private Long janelaAtendimentoId;
+    private LocalDate dataJanela;
+    private LocalTime horaInicioJanela;
+    private LocalTime horaFimJanela;
+    private LocalDateTime horarioPrevistoChegada;
+    private LocalDateTime horarioPrevistoSaida;
+    private LocalDateTime horarioRealChegada;
+    private LocalDateTime horarioRealSaida;
+    private String observacoes;
+    private List<DocumentoAgendamentoDTO> documentos;
+    private GatePassDTO gatePass;
+
+    public AgendamentoDTO() {
+    }
+
+    public AgendamentoDTO(Long id, String codigo, String tipoOperacao, String tipoOperacaoDescricao,
+                           String status, String statusDescricao, Long transportadoraId,
+                           String transportadoraNome, Long motoristaId, String motoristaNome,
+                           Long veiculoId, String placaVeiculo, Long janelaAtendimentoId,
+                           LocalDate dataJanela, LocalTime horaInicioJanela, LocalTime horaFimJanela,
+                           LocalDateTime horarioPrevistoChegada, LocalDateTime horarioPrevistoSaida,
+                           LocalDateTime horarioRealChegada, LocalDateTime horarioRealSaida,
+                           String observacoes, List<DocumentoAgendamentoDTO> documentos,
+                           GatePassDTO gatePass) {
+        this.id = id;
+        this.codigo = codigo;
+        this.tipoOperacao = tipoOperacao;
+        this.tipoOperacaoDescricao = tipoOperacaoDescricao;
+        this.status = status;
+        this.statusDescricao = statusDescricao;
+        this.transportadoraId = transportadoraId;
+        this.transportadoraNome = transportadoraNome;
+        this.motoristaId = motoristaId;
+        this.motoristaNome = motoristaNome;
+        this.veiculoId = veiculoId;
+        this.placaVeiculo = placaVeiculo;
+        this.janelaAtendimentoId = janelaAtendimentoId;
+        this.dataJanela = dataJanela;
+        this.horaInicioJanela = horaInicioJanela;
+        this.horaFimJanela = horaFimJanela;
+        this.horarioPrevistoChegada = horarioPrevistoChegada;
+        this.horarioPrevistoSaida = horarioPrevistoSaida;
+        this.horarioRealChegada = horarioRealChegada;
+        this.horarioRealSaida = horarioRealSaida;
+        this.observacoes = observacoes;
+        this.documentos = documentos;
+        this.gatePass = gatePass;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public String getTipoOperacao() {
+        return tipoOperacao;
+    }
+
+    public void setTipoOperacao(String tipoOperacao) {
+        this.tipoOperacao = tipoOperacao;
+    }
+
+    public String getTipoOperacaoDescricao() {
+        return tipoOperacaoDescricao;
+    }
+
+    public void setTipoOperacaoDescricao(String tipoOperacaoDescricao) {
+        this.tipoOperacaoDescricao = tipoOperacaoDescricao;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatusDescricao() {
+        return statusDescricao;
+    }
+
+    public void setStatusDescricao(String statusDescricao) {
+        this.statusDescricao = statusDescricao;
+    }
+
+    public Long getTransportadoraId() {
+        return transportadoraId;
+    }
+
+    public void setTransportadoraId(Long transportadoraId) {
+        this.transportadoraId = transportadoraId;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+
+    public void setTransportadoraNome(String transportadoraNome) {
+        this.transportadoraNome = transportadoraNome;
+    }
+
+    public Long getMotoristaId() {
+        return motoristaId;
+    }
+
+    public void setMotoristaId(Long motoristaId) {
+        this.motoristaId = motoristaId;
+    }
+
+    public String getMotoristaNome() {
+        return motoristaNome;
+    }
+
+    public void setMotoristaNome(String motoristaNome) {
+        this.motoristaNome = motoristaNome;
+    }
+
+    public Long getVeiculoId() {
+        return veiculoId;
+    }
+
+    public void setVeiculoId(Long veiculoId) {
+        this.veiculoId = veiculoId;
+    }
+
+    public String getPlacaVeiculo() {
+        return placaVeiculo;
+    }
+
+    public void setPlacaVeiculo(String placaVeiculo) {
+        this.placaVeiculo = placaVeiculo;
+    }
+
+    public Long getJanelaAtendimentoId() {
+        return janelaAtendimentoId;
+    }
+
+    public void setJanelaAtendimentoId(Long janelaAtendimentoId) {
+        this.janelaAtendimentoId = janelaAtendimentoId;
+    }
+
+    public LocalDate getDataJanela() {
+        return dataJanela;
+    }
+
+    public void setDataJanela(LocalDate dataJanela) {
+        this.dataJanela = dataJanela;
+    }
+
+    public LocalTime getHoraInicioJanela() {
+        return horaInicioJanela;
+    }
+
+    public void setHoraInicioJanela(LocalTime horaInicioJanela) {
+        this.horaInicioJanela = horaInicioJanela;
+    }
+
+    public LocalTime getHoraFimJanela() {
+        return horaFimJanela;
+    }
+
+    public void setHoraFimJanela(LocalTime horaFimJanela) {
+        this.horaFimJanela = horaFimJanela;
+    }
+
+    public LocalDateTime getHorarioPrevistoChegada() {
+        return horarioPrevistoChegada;
+    }
+
+    public void setHorarioPrevistoChegada(LocalDateTime horarioPrevistoChegada) {
+        this.horarioPrevistoChegada = horarioPrevistoChegada;
+    }
+
+    public LocalDateTime getHorarioPrevistoSaida() {
+        return horarioPrevistoSaida;
+    }
+
+    public void setHorarioPrevistoSaida(LocalDateTime horarioPrevistoSaida) {
+        this.horarioPrevistoSaida = horarioPrevistoSaida;
+    }
+
+    public LocalDateTime getHorarioRealChegada() {
+        return horarioRealChegada;
+    }
+
+    public void setHorarioRealChegada(LocalDateTime horarioRealChegada) {
+        this.horarioRealChegada = horarioRealChegada;
+    }
+
+    public LocalDateTime getHorarioRealSaida() {
+        return horarioRealSaida;
+    }
+
+    public void setHorarioRealSaida(LocalDateTime horarioRealSaida) {
+        this.horarioRealSaida = horarioRealSaida;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+
+    public List<DocumentoAgendamentoDTO> getDocumentos() {
+        return documentos;
+    }
+
+    public void setDocumentos(List<DocumentoAgendamentoDTO> documentos) {
+        this.documentos = documentos;
+    }
+
+    public GatePassDTO getGatePass() {
+        return gatePass;
+    }
+
+    public void setGatePass(GatePassDTO gatePass) {
+        this.gatePass = gatePass;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/DocumentoAgendamentoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/DocumentoAgendamentoDTO.java
@@ -1,0 +1,51 @@
+package br.com.cloudport.servicogate.dto;
+
+public class DocumentoAgendamentoDTO {
+
+    private Long id;
+    private String tipoDocumento;
+    private String numero;
+    private String urlDocumento;
+
+    public DocumentoAgendamentoDTO() {
+    }
+
+    public DocumentoAgendamentoDTO(Long id, String tipoDocumento, String numero, String urlDocumento) {
+        this.id = id;
+        this.tipoDocumento = tipoDocumento;
+        this.numero = numero;
+        this.urlDocumento = urlDocumento;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTipoDocumento() {
+        return tipoDocumento;
+    }
+
+    public void setTipoDocumento(String tipoDocumento) {
+        this.tipoDocumento = tipoDocumento;
+    }
+
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+
+    public String getUrlDocumento() {
+        return urlDocumento;
+    }
+
+    public void setUrlDocumento(String urlDocumento) {
+        this.urlDocumento = urlDocumento;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/EnumResponseDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/EnumResponseDTO.java
@@ -1,0 +1,31 @@
+package br.com.cloudport.servicogate.dto;
+
+public class EnumResponseDTO {
+
+    private String codigo;
+    private String descricao;
+
+    public EnumResponseDTO() {
+    }
+
+    public EnumResponseDTO(String codigo, String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/GateEventDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/GateEventDTO.java
@@ -1,0 +1,95 @@
+package br.com.cloudport.servicogate.dto;
+
+import java.time.LocalDateTime;
+
+public class GateEventDTO {
+
+    private Long id;
+    private String status;
+    private String statusDescricao;
+    private String motivoExcecao;
+    private String motivoExcecaoDescricao;
+    private String observacao;
+    private String usuarioResponsavel;
+    private LocalDateTime registradoEm;
+
+    public GateEventDTO() {
+    }
+
+    public GateEventDTO(Long id, String status, String statusDescricao, String motivoExcecao,
+                         String motivoExcecaoDescricao, String observacao, String usuarioResponsavel,
+                         LocalDateTime registradoEm) {
+        this.id = id;
+        this.status = status;
+        this.statusDescricao = statusDescricao;
+        this.motivoExcecao = motivoExcecao;
+        this.motivoExcecaoDescricao = motivoExcecaoDescricao;
+        this.observacao = observacao;
+        this.usuarioResponsavel = usuarioResponsavel;
+        this.registradoEm = registradoEm;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatusDescricao() {
+        return statusDescricao;
+    }
+
+    public void setStatusDescricao(String statusDescricao) {
+        this.statusDescricao = statusDescricao;
+    }
+
+    public String getMotivoExcecao() {
+        return motivoExcecao;
+    }
+
+    public void setMotivoExcecao(String motivoExcecao) {
+        this.motivoExcecao = motivoExcecao;
+    }
+
+    public String getMotivoExcecaoDescricao() {
+        return motivoExcecaoDescricao;
+    }
+
+    public void setMotivoExcecaoDescricao(String motivoExcecaoDescricao) {
+        this.motivoExcecaoDescricao = motivoExcecaoDescricao;
+    }
+
+    public String getObservacao() {
+        return observacao;
+    }
+
+    public void setObservacao(String observacao) {
+        this.observacao = observacao;
+    }
+
+    public String getUsuarioResponsavel() {
+        return usuarioResponsavel;
+    }
+
+    public void setUsuarioResponsavel(String usuarioResponsavel) {
+        this.usuarioResponsavel = usuarioResponsavel;
+    }
+
+    public LocalDateTime getRegistradoEm() {
+        return registradoEm;
+    }
+
+    public void setRegistradoEm(LocalDateTime registradoEm) {
+        this.registradoEm = registradoEm;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/GatePassDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/GatePassDTO.java
@@ -1,0 +1,85 @@
+package br.com.cloudport.servicogate.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GatePassDTO {
+
+    private Long id;
+    private String codigo;
+    private String status;
+    private String statusDescricao;
+    private LocalDateTime dataEntrada;
+    private LocalDateTime dataSaida;
+    private List<GateEventDTO> eventos;
+
+    public GatePassDTO() {
+    }
+
+    public GatePassDTO(Long id, String codigo, String status, String statusDescricao,
+                       LocalDateTime dataEntrada, LocalDateTime dataSaida, List<GateEventDTO> eventos) {
+        this.id = id;
+        this.codigo = codigo;
+        this.status = status;
+        this.statusDescricao = statusDescricao;
+        this.dataEntrada = dataEntrada;
+        this.dataSaida = dataSaida;
+        this.eventos = eventos;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatusDescricao() {
+        return statusDescricao;
+    }
+
+    public void setStatusDescricao(String statusDescricao) {
+        this.statusDescricao = statusDescricao;
+    }
+
+    public LocalDateTime getDataEntrada() {
+        return dataEntrada;
+    }
+
+    public void setDataEntrada(LocalDateTime dataEntrada) {
+        this.dataEntrada = dataEntrada;
+    }
+
+    public LocalDateTime getDataSaida() {
+        return dataSaida;
+    }
+
+    public void setDataSaida(LocalDateTime dataSaida) {
+        this.dataSaida = dataSaida;
+    }
+
+    public List<GateEventDTO> getEventos() {
+        return eventos;
+    }
+
+    public void setEventos(List<GateEventDTO> eventos) {
+        this.eventos = eventos;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/JanelaAtendimentoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/JanelaAtendimentoDTO.java
@@ -1,0 +1,85 @@
+package br.com.cloudport.servicogate.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class JanelaAtendimentoDTO {
+
+    private Long id;
+    private LocalDate data;
+    private LocalTime horaInicio;
+    private LocalTime horaFim;
+    private Integer capacidade;
+    private String canalEntrada;
+    private String canalEntradaDescricao;
+
+    public JanelaAtendimentoDTO() {
+    }
+
+    public JanelaAtendimentoDTO(Long id, LocalDate data, LocalTime horaInicio, LocalTime horaFim,
+                                 Integer capacidade, String canalEntrada, String canalEntradaDescricao) {
+        this.id = id;
+        this.data = data;
+        this.horaInicio = horaInicio;
+        this.horaFim = horaFim;
+        this.capacidade = capacidade;
+        this.canalEntrada = canalEntrada;
+        this.canalEntradaDescricao = canalEntradaDescricao;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
+    }
+
+    public LocalTime getHoraInicio() {
+        return horaInicio;
+    }
+
+    public void setHoraInicio(LocalTime horaInicio) {
+        this.horaInicio = horaInicio;
+    }
+
+    public LocalTime getHoraFim() {
+        return horaFim;
+    }
+
+    public void setHoraFim(LocalTime horaFim) {
+        this.horaFim = horaFim;
+    }
+
+    public Integer getCapacidade() {
+        return capacidade;
+    }
+
+    public void setCapacidade(Integer capacidade) {
+        this.capacidade = capacidade;
+    }
+
+    public String getCanalEntrada() {
+        return canalEntrada;
+    }
+
+    public void setCanalEntrada(String canalEntrada) {
+        this.canalEntrada = canalEntrada;
+    }
+
+    public String getCanalEntradaDescricao() {
+        return canalEntradaDescricao;
+    }
+
+    public void setCanalEntradaDescricao(String canalEntradaDescricao) {
+        this.canalEntradaDescricao = canalEntradaDescricao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/MotoristaDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/MotoristaDTO.java
@@ -1,0 +1,72 @@
+package br.com.cloudport.servicogate.dto;
+
+public class MotoristaDTO {
+
+    private Long id;
+    private String nome;
+    private String documento;
+    private String telefone;
+    private Long transportadoraId;
+    private String transportadoraNome;
+
+    public MotoristaDTO() {
+    }
+
+    public MotoristaDTO(Long id, String nome, String documento, String telefone,
+                         Long transportadoraId, String transportadoraNome) {
+        this.id = id;
+        this.nome = nome;
+        this.documento = documento;
+        this.telefone = telefone;
+        this.transportadoraId = transportadoraId;
+        this.transportadoraNome = transportadoraNome;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDocumento() {
+        return documento;
+    }
+
+    public void setDocumento(String documento) {
+        this.documento = documento;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public Long getTransportadoraId() {
+        return transportadoraId;
+    }
+
+    public void setTransportadoraId(Long transportadoraId) {
+        this.transportadoraId = transportadoraId;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+
+    public void setTransportadoraNome(String transportadoraNome) {
+        this.transportadoraNome = transportadoraNome;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/TransportadoraDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/TransportadoraDTO.java
@@ -1,0 +1,51 @@
+package br.com.cloudport.servicogate.dto;
+
+public class TransportadoraDTO {
+
+    private Long id;
+    private String nome;
+    private String documento;
+    private String contato;
+
+    public TransportadoraDTO() {
+    }
+
+    public TransportadoraDTO(Long id, String nome, String documento, String contato) {
+        this.id = id;
+        this.nome = nome;
+        this.documento = documento;
+        this.contato = contato;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDocumento() {
+        return documento;
+    }
+
+    public void setDocumento(String documento) {
+        this.documento = documento;
+    }
+
+    public String getContato() {
+        return contato;
+    }
+
+    public void setContato(String contato) {
+        this.contato = contato;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/VeiculoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/VeiculoDTO.java
@@ -1,0 +1,72 @@
+package br.com.cloudport.servicogate.dto;
+
+public class VeiculoDTO {
+
+    private Long id;
+    private String placa;
+    private String modelo;
+    private String tipo;
+    private Long transportadoraId;
+    private String transportadoraNome;
+
+    public VeiculoDTO() {
+    }
+
+    public VeiculoDTO(Long id, String placa, String modelo, String tipo,
+                       Long transportadoraId, String transportadoraNome) {
+        this.id = id;
+        this.placa = placa;
+        this.modelo = modelo;
+        this.tipo = tipo;
+        this.transportadoraId = transportadoraId;
+        this.transportadoraNome = transportadoraNome;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getPlaca() {
+        return placa;
+    }
+
+    public void setPlaca(String placa) {
+        this.placa = placa;
+    }
+
+    public String getModelo() {
+        return modelo;
+    }
+
+    public void setModelo(String modelo) {
+        this.modelo = modelo;
+    }
+
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    public Long getTransportadoraId() {
+        return transportadoraId;
+    }
+
+    public void setTransportadoraId(Long transportadoraId) {
+        this.transportadoraId = transportadoraId;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+
+    public void setTransportadoraNome(String transportadoraNome) {
+        this.transportadoraNome = transportadoraNome;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/dashboard/OcupacaoPorHoraDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/dashboard/OcupacaoPorHoraDTO.java
@@ -1,0 +1,40 @@
+package br.com.cloudport.servicogate.dto.dashboard;
+
+import java.time.LocalTime;
+
+public class OcupacaoPorHoraDTO {
+
+    private LocalTime horaInicio;
+    private Long totalAgendamentos;
+    private Integer capacidadeSlot;
+
+    public OcupacaoPorHoraDTO(LocalTime horaInicio, Long totalAgendamentos, Integer capacidadeSlot) {
+        this.horaInicio = horaInicio;
+        this.totalAgendamentos = totalAgendamentos;
+        this.capacidadeSlot = capacidadeSlot;
+    }
+
+    public LocalTime getHoraInicio() {
+        return horaInicio;
+    }
+
+    public void setHoraInicio(LocalTime horaInicio) {
+        this.horaInicio = horaInicio;
+    }
+
+    public Long getTotalAgendamentos() {
+        return totalAgendamentos;
+    }
+
+    public void setTotalAgendamentos(Long totalAgendamentos) {
+        this.totalAgendamentos = totalAgendamentos;
+    }
+
+    public Integer getCapacidadeSlot() {
+        return capacidadeSlot;
+    }
+
+    public void setCapacidadeSlot(Integer capacidadeSlot) {
+        this.capacidadeSlot = capacidadeSlot;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/dashboard/TempoMedioPermanenciaDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/dashboard/TempoMedioPermanenciaDTO.java
@@ -1,0 +1,30 @@
+package br.com.cloudport.servicogate.dto.dashboard;
+
+import java.time.LocalDate;
+
+public class TempoMedioPermanenciaDTO {
+
+    private LocalDate dia;
+    private Double tempoMedioMinutos;
+
+    public TempoMedioPermanenciaDTO(LocalDate dia, Double tempoMedioMinutos) {
+        this.dia = dia;
+        this.tempoMedioMinutos = tempoMedioMinutos;
+    }
+
+    public LocalDate getDia() {
+        return dia;
+    }
+
+    public void setDia(LocalDate dia) {
+        this.dia = dia;
+    }
+
+    public Double getTempoMedioMinutos() {
+        return tempoMedioMinutos;
+    }
+
+    public void setTempoMedioMinutos(Double tempoMedioMinutos) {
+        this.tempoMedioMinutos = tempoMedioMinutos;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/mapper/GateMapper.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/mapper/GateMapper.java
@@ -1,0 +1,193 @@
+package br.com.cloudport.servicogate.dto.mapper;
+
+import br.com.cloudport.servicogate.dto.AgendamentoDTO;
+import br.com.cloudport.servicogate.dto.DocumentoAgendamentoDTO;
+import br.com.cloudport.servicogate.dto.GateEventDTO;
+import br.com.cloudport.servicogate.dto.GatePassDTO;
+import br.com.cloudport.servicogate.dto.JanelaAtendimentoDTO;
+import br.com.cloudport.servicogate.dto.MotoristaDTO;
+import br.com.cloudport.servicogate.dto.TransportadoraDTO;
+import br.com.cloudport.servicogate.dto.VeiculoDTO;
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.DocumentoAgendamento;
+import br.com.cloudport.servicogate.model.GateEvent;
+import br.com.cloudport.servicogate.model.GatePass;
+import br.com.cloudport.servicogate.model.JanelaAtendimento;
+import br.com.cloudport.servicogate.model.Motorista;
+import br.com.cloudport.servicogate.model.Transportadora;
+import br.com.cloudport.servicogate.model.Veiculo;
+import br.com.cloudport.servicogate.model.enums.CanalEntrada;
+import br.com.cloudport.servicogate.model.enums.MotivoExcecao;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.model.enums.StatusGate;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class GateMapper {
+
+    private GateMapper() {
+    }
+
+    public static TransportadoraDTO toTransportadoraDTO(Transportadora entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new TransportadoraDTO(entity.getId(), entity.getNome(), entity.getDocumento(), entity.getContato());
+    }
+
+    public static MotoristaDTO toMotoristaDTO(Motorista entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new MotoristaDTO(
+                entity.getId(),
+                entity.getNome(),
+                entity.getDocumento(),
+                entity.getTelefone(),
+                entity.getTransportadora() != null ? entity.getTransportadora().getId() : null,
+                entity.getTransportadora() != null ? entity.getTransportadora().getNome() : null
+        );
+    }
+
+    public static VeiculoDTO toVeiculoDTO(Veiculo entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new VeiculoDTO(
+                entity.getId(),
+                entity.getPlaca(),
+                entity.getModelo(),
+                entity.getTipo(),
+                entity.getTransportadora() != null ? entity.getTransportadora().getId() : null,
+                entity.getTransportadora() != null ? entity.getTransportadora().getNome() : null
+        );
+    }
+
+    public static JanelaAtendimentoDTO toJanelaAtendimentoDTO(JanelaAtendimento entity) {
+        if (entity == null) {
+            return null;
+        }
+        CanalEntrada canal = entity.getCanalEntrada();
+        return new JanelaAtendimentoDTO(
+                entity.getId(),
+                entity.getData(),
+                entity.getHoraInicio(),
+                entity.getHoraFim(),
+                entity.getCapacidade(),
+                canal != null ? canal.name() : null,
+                canal != null ? canal.getDescricao() : null
+        );
+    }
+
+    public static DocumentoAgendamentoDTO toDocumentoAgendamentoDTO(DocumentoAgendamento entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new DocumentoAgendamentoDTO(
+                entity.getId(),
+                entity.getTipoDocumento(),
+                entity.getNumero(),
+                entity.getUrlDocumento()
+        );
+    }
+
+    public static GateEventDTO toGateEventDTO(GateEvent entity) {
+        if (entity == null) {
+            return null;
+        }
+        StatusGate statusGate = entity.getStatus();
+        MotivoExcecao motivo = entity.getMotivoExcecao();
+        return new GateEventDTO(
+                entity.getId(),
+                statusGate != null ? statusGate.name() : null,
+                statusGate != null ? statusGate.getDescricao() : null,
+                motivo != null ? motivo.name() : null,
+                motivo != null ? motivo.getDescricao() : null,
+                entity.getObservacao(),
+                entity.getUsuarioResponsavel(),
+                entity.getRegistradoEm()
+        );
+    }
+
+    public static GatePassDTO toGatePassDTO(GatePass entity) {
+        if (entity == null) {
+            return null;
+        }
+        StatusGate statusGate = entity.getStatus();
+        List<GateEventDTO> eventos = safeList(entity.getEventos()).stream()
+                .map(GateMapper::toGateEventDTO)
+                .collect(Collectors.toList());
+        return new GatePassDTO(
+                entity.getId(),
+                entity.getCodigo(),
+                statusGate != null ? statusGate.name() : null,
+                statusGate != null ? statusGate.getDescricao() : null,
+                entity.getDataEntrada(),
+                entity.getDataSaida(),
+                eventos
+        );
+    }
+
+    public static AgendamentoDTO toAgendamentoDTO(Agendamento entity) {
+        if (entity == null) {
+            return null;
+        }
+        TipoOperacao tipoOperacao = entity.getTipoOperacao();
+        StatusAgendamento statusAgendamento = entity.getStatus();
+        JanelaAtendimento janela = entity.getJanelaAtendimento();
+        return new AgendamentoDTO(
+                entity.getId(),
+                entity.getCodigo(),
+                tipoOperacao != null ? tipoOperacao.name() : null,
+                tipoOperacao != null ? tipoOperacao.getDescricao() : null,
+                statusAgendamento != null ? statusAgendamento.name() : null,
+                statusAgendamento != null ? statusAgendamento.getDescricao() : null,
+                entity.getTransportadora() != null ? entity.getTransportadora().getId() : null,
+                entity.getTransportadora() != null ? entity.getTransportadora().getNome() : null,
+                entity.getMotorista() != null ? entity.getMotorista().getId() : null,
+                entity.getMotorista() != null ? entity.getMotorista().getNome() : null,
+                entity.getVeiculo() != null ? entity.getVeiculo().getId() : null,
+                entity.getVeiculo() != null ? entity.getVeiculo().getPlaca() : null,
+                janela != null ? janela.getId() : null,
+                janela != null ? janela.getData() : null,
+                janela != null ? janela.getHoraInicio() : null,
+                janela != null ? janela.getHoraFim() : null,
+                entity.getHorarioPrevistoChegada(),
+                entity.getHorarioPrevistoSaida(),
+                entity.getHorarioRealChegada(),
+                entity.getHorarioRealSaida(),
+                entity.getObservacoes(),
+                safeList(entity.getDocumentos()).stream()
+                        .map(GateMapper::toDocumentoAgendamentoDTO)
+                        .collect(Collectors.toList()),
+                toGatePassDTO(entity.getGatePass())
+        );
+    }
+
+    private static <T> List<T> safeList(List<T> collection) {
+        return collection == null ? Collections.emptyList() : collection;
+    }
+
+    public static List<TransportadoraDTO> toTransportadoraDTO(List<Transportadora> entities) {
+        return safeStream(entities).map(GateMapper::toTransportadoraDTO).collect(Collectors.toList());
+    }
+
+    public static List<MotoristaDTO> toMotoristaDTO(List<Motorista> entities) {
+        return safeStream(entities).map(GateMapper::toMotoristaDTO).collect(Collectors.toList());
+    }
+
+    public static List<VeiculoDTO> toVeiculoDTO(List<Veiculo> entities) {
+        return safeStream(entities).map(GateMapper::toVeiculoDTO).collect(Collectors.toList());
+    }
+
+    public static List<DocumentoAgendamentoDTO> toDocumentoAgendamentoDTO(List<DocumentoAgendamento> entities) {
+        return safeStream(entities).map(GateMapper::toDocumentoAgendamentoDTO).collect(Collectors.toList());
+    }
+
+    private static <T> java.util.stream.Stream<T> safeStream(List<T> collection) {
+        return Objects.requireNonNullElse(collection, Collections.<T>emptyList()).stream();
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/AbstractAuditableEntity.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/AbstractAuditableEntity.java
@@ -1,0 +1,45 @@
+package br.com.cloudport.servicogate.model;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+
+@MappedSuperclass
+public abstract class AbstractAuditableEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/Agendamento.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/Agendamento.java
@@ -1,0 +1,197 @@
+package br.com.cloudport.servicogate.model;
+
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "agendamento")
+public class Agendamento extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "codigo", nullable = false, unique = true, length = 40)
+    private String codigo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_operacao", nullable = false, length = 40)
+    private TipoOperacao tipoOperacao;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 40)
+    private StatusAgendamento status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "transportadora_id", nullable = false)
+    private Transportadora transportadora;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "motorista_id", nullable = false)
+    private Motorista motorista;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "veiculo_id", nullable = false)
+    private Veiculo veiculo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "janela_atendimento_id", nullable = false)
+    private JanelaAtendimento janelaAtendimento;
+
+    @Column(name = "horario_previsto_chegada")
+    private LocalDateTime horarioPrevistoChegada;
+
+    @Column(name = "horario_previsto_saida")
+    private LocalDateTime horarioPrevistoSaida;
+
+    @Column(name = "horario_real_chegada")
+    private LocalDateTime horarioRealChegada;
+
+    @Column(name = "horario_real_saida")
+    private LocalDateTime horarioRealSaida;
+
+    @Column(name = "observacoes", length = 500)
+    private String observacoes;
+
+    @OneToMany(mappedBy = "agendamento", fetch = FetchType.LAZY)
+    private List<DocumentoAgendamento> documentos = new ArrayList<>();
+
+    @OneToOne(mappedBy = "agendamento", fetch = FetchType.LAZY)
+    private GatePass gatePass;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public TipoOperacao getTipoOperacao() {
+        return tipoOperacao;
+    }
+
+    public void setTipoOperacao(TipoOperacao tipoOperacao) {
+        this.tipoOperacao = tipoOperacao;
+    }
+
+    public StatusAgendamento getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusAgendamento status) {
+        this.status = status;
+    }
+
+    public Transportadora getTransportadora() {
+        return transportadora;
+    }
+
+    public void setTransportadora(Transportadora transportadora) {
+        this.transportadora = transportadora;
+    }
+
+    public Motorista getMotorista() {
+        return motorista;
+    }
+
+    public void setMotorista(Motorista motorista) {
+        this.motorista = motorista;
+    }
+
+    public Veiculo getVeiculo() {
+        return veiculo;
+    }
+
+    public void setVeiculo(Veiculo veiculo) {
+        this.veiculo = veiculo;
+    }
+
+    public JanelaAtendimento getJanelaAtendimento() {
+        return janelaAtendimento;
+    }
+
+    public void setJanelaAtendimento(JanelaAtendimento janelaAtendimento) {
+        this.janelaAtendimento = janelaAtendimento;
+    }
+
+    public LocalDateTime getHorarioPrevistoChegada() {
+        return horarioPrevistoChegada;
+    }
+
+    public void setHorarioPrevistoChegada(LocalDateTime horarioPrevistoChegada) {
+        this.horarioPrevistoChegada = horarioPrevistoChegada;
+    }
+
+    public LocalDateTime getHorarioPrevistoSaida() {
+        return horarioPrevistoSaida;
+    }
+
+    public void setHorarioPrevistoSaida(LocalDateTime horarioPrevistoSaida) {
+        this.horarioPrevistoSaida = horarioPrevistoSaida;
+    }
+
+    public LocalDateTime getHorarioRealChegada() {
+        return horarioRealChegada;
+    }
+
+    public void setHorarioRealChegada(LocalDateTime horarioRealChegada) {
+        this.horarioRealChegada = horarioRealChegada;
+    }
+
+    public LocalDateTime getHorarioRealSaida() {
+        return horarioRealSaida;
+    }
+
+    public void setHorarioRealSaida(LocalDateTime horarioRealSaida) {
+        this.horarioRealSaida = horarioRealSaida;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+
+    public List<DocumentoAgendamento> getDocumentos() {
+        return documentos;
+    }
+
+    public void setDocumentos(List<DocumentoAgendamento> documentos) {
+        this.documentos = documentos;
+    }
+
+    public GatePass getGatePass() {
+        return gatePass;
+    }
+
+    public void setGatePass(GatePass gatePass) {
+        this.gatePass = gatePass;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/DocumentoAgendamento.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/DocumentoAgendamento.java
@@ -1,0 +1,73 @@
+package br.com.cloudport.servicogate.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "documento_agendamento")
+public class DocumentoAgendamento extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tipo_documento", nullable = false, length = 80)
+    private String tipoDocumento;
+
+    @Column(name = "numero", length = 80)
+    private String numero;
+
+    @Column(name = "url_documento", length = 255)
+    private String urlDocumento;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agendamento_id", nullable = false)
+    private Agendamento agendamento;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTipoDocumento() {
+        return tipoDocumento;
+    }
+
+    public void setTipoDocumento(String tipoDocumento) {
+        this.tipoDocumento = tipoDocumento;
+    }
+
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+
+    public String getUrlDocumento() {
+        return urlDocumento;
+    }
+
+    public void setUrlDocumento(String urlDocumento) {
+        this.urlDocumento = urlDocumento;
+    }
+
+    public Agendamento getAgendamento() {
+        return agendamento;
+    }
+
+    public void setAgendamento(Agendamento agendamento) {
+        this.agendamento = agendamento;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/GateEvent.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/GateEvent.java
@@ -1,0 +1,102 @@
+package br.com.cloudport.servicogate.model;
+
+import br.com.cloudport.servicogate.model.enums.MotivoExcecao;
+import br.com.cloudport.servicogate.model.enums.StatusGate;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "gate_event")
+public class GateEvent extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 40)
+    private StatusGate status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "motivo_excecao", length = 40)
+    private MotivoExcecao motivoExcecao;
+
+    @Column(name = "observacao", length = 500)
+    private String observacao;
+
+    @Column(name = "usuario_responsavel", length = 80)
+    private String usuarioResponsavel;
+
+    @Column(name = "registrado_em", nullable = false)
+    private LocalDateTime registradoEm;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gate_pass_id", nullable = false)
+    private GatePass gatePass;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public StatusGate getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusGate status) {
+        this.status = status;
+    }
+
+    public MotivoExcecao getMotivoExcecao() {
+        return motivoExcecao;
+    }
+
+    public void setMotivoExcecao(MotivoExcecao motivoExcecao) {
+        this.motivoExcecao = motivoExcecao;
+    }
+
+    public String getObservacao() {
+        return observacao;
+    }
+
+    public void setObservacao(String observacao) {
+        this.observacao = observacao;
+    }
+
+    public String getUsuarioResponsavel() {
+        return usuarioResponsavel;
+    }
+
+    public void setUsuarioResponsavel(String usuarioResponsavel) {
+        this.usuarioResponsavel = usuarioResponsavel;
+    }
+
+    public LocalDateTime getRegistradoEm() {
+        return registradoEm;
+    }
+
+    public void setRegistradoEm(LocalDateTime registradoEm) {
+        this.registradoEm = registradoEm;
+    }
+
+    public GatePass getGatePass() {
+        return gatePass;
+    }
+
+    public void setGatePass(GatePass gatePass) {
+        this.gatePass = gatePass;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/GatePass.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/GatePass.java
@@ -1,0 +1,103 @@
+package br.com.cloudport.servicogate.model;
+
+import br.com.cloudport.servicogate.model.enums.StatusGate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "gate_pass")
+public class GatePass extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "codigo", nullable = false, unique = true, length = 40)
+    private String codigo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 40)
+    private StatusGate status;
+
+    @Column(name = "data_entrada")
+    private LocalDateTime dataEntrada;
+
+    @Column(name = "data_saida")
+    private LocalDateTime dataSaida;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agendamento_id", nullable = false, unique = true)
+    private Agendamento agendamento;
+
+    @OneToMany(mappedBy = "gatePass", fetch = FetchType.LAZY)
+    private List<GateEvent> eventos = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public StatusGate getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusGate status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getDataEntrada() {
+        return dataEntrada;
+    }
+
+    public void setDataEntrada(LocalDateTime dataEntrada) {
+        this.dataEntrada = dataEntrada;
+    }
+
+    public LocalDateTime getDataSaida() {
+        return dataSaida;
+    }
+
+    public void setDataSaida(LocalDateTime dataSaida) {
+        this.dataSaida = dataSaida;
+    }
+
+    public Agendamento getAgendamento() {
+        return agendamento;
+    }
+
+    public void setAgendamento(Agendamento agendamento) {
+        this.agendamento = agendamento;
+    }
+
+    public List<GateEvent> getEventos() {
+        return eventos;
+    }
+
+    public void setEventos(List<GateEvent> eventos) {
+        this.eventos = eventos;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/JanelaAtendimento.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/JanelaAtendimento.java
@@ -1,0 +1,101 @@
+package br.com.cloudport.servicogate.model;
+
+import br.com.cloudport.servicogate.model.enums.CanalEntrada;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "janela_atendimento")
+public class JanelaAtendimento extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "data", nullable = false)
+    private LocalDate data;
+
+    @Column(name = "hora_inicio", nullable = false)
+    private LocalTime horaInicio;
+
+    @Column(name = "hora_fim", nullable = false)
+    private LocalTime horaFim;
+
+    @Column(name = "capacidade", nullable = false)
+    private Integer capacidade;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "canal_entrada", nullable = false, length = 40)
+    private CanalEntrada canalEntrada;
+
+    @OneToMany(mappedBy = "janelaAtendimento", fetch = FetchType.LAZY)
+    private List<Agendamento> agendamentos = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
+    }
+
+    public LocalTime getHoraInicio() {
+        return horaInicio;
+    }
+
+    public void setHoraInicio(LocalTime horaInicio) {
+        this.horaInicio = horaInicio;
+    }
+
+    public LocalTime getHoraFim() {
+        return horaFim;
+    }
+
+    public void setHoraFim(LocalTime horaFim) {
+        this.horaFim = horaFim;
+    }
+
+    public Integer getCapacidade() {
+        return capacidade;
+    }
+
+    public void setCapacidade(Integer capacidade) {
+        this.capacidade = capacidade;
+    }
+
+    public CanalEntrada getCanalEntrada() {
+        return canalEntrada;
+    }
+
+    public void setCanalEntrada(CanalEntrada canalEntrada) {
+        this.canalEntrada = canalEntrada;
+    }
+
+    public List<Agendamento> getAgendamentos() {
+        return agendamentos;
+    }
+
+    public void setAgendamentos(List<Agendamento> agendamentos) {
+        this.agendamentos = agendamentos;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/Motorista.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/Motorista.java
@@ -1,0 +1,87 @@
+package br.com.cloudport.servicogate.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "motorista")
+public class Motorista extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nome", nullable = false, length = 120)
+    private String nome;
+
+    @Column(name = "documento", nullable = false, length = 20)
+    private String documento;
+
+    @Column(name = "telefone", length = 20)
+    private String telefone;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "transportadora_id", nullable = false)
+    private Transportadora transportadora;
+
+    @OneToMany(mappedBy = "motorista", fetch = FetchType.LAZY)
+    private List<Agendamento> agendamentos = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDocumento() {
+        return documento;
+    }
+
+    public void setDocumento(String documento) {
+        this.documento = documento;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public Transportadora getTransportadora() {
+        return transportadora;
+    }
+
+    public void setTransportadora(Transportadora transportadora) {
+        this.transportadora = transportadora;
+    }
+
+    public List<Agendamento> getAgendamentos() {
+        return agendamentos;
+    }
+
+    public void setAgendamentos(List<Agendamento> agendamentos) {
+        this.agendamentos = agendamentos;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/Transportadora.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/Transportadora.java
@@ -1,0 +1,84 @@
+package br.com.cloudport.servicogate.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "transportadora")
+public class Transportadora extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nome", nullable = false, length = 120)
+    private String nome;
+
+    @Column(name = "documento", nullable = false, unique = true, length = 20)
+    private String documento;
+
+    @Column(name = "contato", length = 120)
+    private String contato;
+
+    @OneToMany(mappedBy = "transportadora", fetch = FetchType.LAZY)
+    private List<Motorista> motoristas = new ArrayList<>();
+
+    @OneToMany(mappedBy = "transportadora", fetch = FetchType.LAZY)
+    private List<Veiculo> veiculos = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDocumento() {
+        return documento;
+    }
+
+    public void setDocumento(String documento) {
+        this.documento = documento;
+    }
+
+    public String getContato() {
+        return contato;
+    }
+
+    public void setContato(String contato) {
+        this.contato = contato;
+    }
+
+    public List<Motorista> getMotoristas() {
+        return motoristas;
+    }
+
+    public void setMotoristas(List<Motorista> motoristas) {
+        this.motoristas = motoristas;
+    }
+
+    public List<Veiculo> getVeiculos() {
+        return veiculos;
+    }
+
+    public void setVeiculos(List<Veiculo> veiculos) {
+        this.veiculos = veiculos;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/Veiculo.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/Veiculo.java
@@ -1,0 +1,87 @@
+package br.com.cloudport.servicogate.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "veiculo")
+public class Veiculo extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "placa", nullable = false, unique = true, length = 10)
+    private String placa;
+
+    @Column(name = "modelo", length = 60)
+    private String modelo;
+
+    @Column(name = "tipo", length = 40)
+    private String tipo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "transportadora_id", nullable = false)
+    private Transportadora transportadora;
+
+    @OneToMany(mappedBy = "veiculo", fetch = FetchType.LAZY)
+    private List<Agendamento> agendamentos = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getPlaca() {
+        return placa;
+    }
+
+    public void setPlaca(String placa) {
+        this.placa = placa;
+    }
+
+    public String getModelo() {
+        return modelo;
+    }
+
+    public void setModelo(String modelo) {
+        this.modelo = modelo;
+    }
+
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    public Transportadora getTransportadora() {
+        return transportadora;
+    }
+
+    public void setTransportadora(Transportadora transportadora) {
+        this.transportadora = transportadora;
+    }
+
+    public List<Agendamento> getAgendamentos() {
+        return agendamentos;
+    }
+
+    public void setAgendamentos(List<Agendamento> agendamentos) {
+        this.agendamentos = agendamentos;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/CanalEntrada.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/CanalEntrada.java
@@ -1,0 +1,19 @@
+package br.com.cloudport.servicogate.model.enums;
+
+public enum CanalEntrada {
+    PORTARIA_PRINCIPAL("Portaria principal"),
+    BALANCA("Balança"),
+    ALCANCE_REMOTO("Agendamento remoto"),
+    APLICATIVO_MOTORISTA("Aplicativo do motorista"),
+    INTEGRACAO_TOS("Integração TOS");
+
+    private final String descricao;
+
+    CanalEntrada(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/MotivoExcecao.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/MotivoExcecao.java
@@ -1,0 +1,19 @@
+package br.com.cloudport.servicogate.model.enums;
+
+public enum MotivoExcecao {
+    DOCUMENTACAO_INCOMPLETA("Documentação incompleta"),
+    DIVERGENCIA_CARGA("Divergência de carga"),
+    ATRASO_PROGRAMADO("Atraso programado"),
+    FALHA_SEGURANCA("Falha de segurança"),
+    OUTROS("Outros");
+
+    private final String descricao;
+
+    MotivoExcecao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/StatusAgendamento.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/StatusAgendamento.java
@@ -1,0 +1,19 @@
+package br.com.cloudport.servicogate.model.enums;
+
+public enum StatusAgendamento {
+    PENDENTE("Pendente"),
+    CONFIRMADO("Confirmado"),
+    EM_ATENDIMENTO("Em atendimento"),
+    CONCLUIDO("Concluído"),
+    CANCELADO("Cancelado");
+
+    private final String descricao;
+
+    StatusAgendamento(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/StatusGate.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/StatusGate.java
@@ -1,0 +1,19 @@
+package br.com.cloudport.servicogate.model.enums;
+
+public enum StatusGate {
+    AGUARDANDO_ENTRADA("Aguardando entrada"),
+    EM_PROCESSAMENTO("Em processamento"),
+    LIBERADO("Liberado"),
+    RETIDO("Retido"),
+    FINALIZADO("Finalizado");
+
+    private final String descricao;
+
+    StatusGate(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/TipoOperacao.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/TipoOperacao.java
@@ -1,0 +1,18 @@
+package br.com.cloudport.servicogate.model.enums;
+
+public enum TipoOperacao {
+    ENTRADA("Entrada"),
+    SAIDA("Saída"),
+    DEVOLUCAO("Devolução"),
+    TRANSFERENCIA("Transferência");
+
+    private final String descricao;
+
+    TipoOperacao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
@@ -1,0 +1,30 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.dto.dashboard.OcupacaoPorHoraDTO;
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> {
+
+    Optional<Agendamento> findByCodigo(String codigo);
+
+    List<Agendamento> findByStatus(StatusAgendamento status);
+
+    List<Agendamento> findByJanelaAtendimentoData(LocalDate data);
+
+    @Query("SELECT new br.com.cloudport.servicogate.dto.dashboard.OcupacaoPorHoraDTO(" +
+            "j.horaInicio, " +
+            "SUM(CASE WHEN a.id IS NOT NULL AND a.status <> br.com.cloudport.servicogate.model.enums.StatusAgendamento.CANCELADO THEN 1 ELSE 0 END), " +
+            "j.capacidade) " +
+            "FROM JanelaAtendimento j LEFT JOIN j.agendamentos a " +
+            "WHERE j.data = :data " +
+            "GROUP BY j.horaInicio, j.capacidade " +
+            "ORDER BY j.horaInicio")
+    List<OcupacaoPorHoraDTO> calcularOcupacaoPorHora(@Param("data") LocalDate data);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/DocumentoAgendamentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/DocumentoAgendamentoRepository.java
@@ -1,0 +1,10 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.model.DocumentoAgendamento;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DocumentoAgendamentoRepository extends JpaRepository<DocumentoAgendamento, Long> {
+
+    List<DocumentoAgendamento> findByAgendamentoId(Long agendamentoId);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GateEventRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GateEventRepository.java
@@ -1,0 +1,10 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.model.GateEvent;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GateEventRepository extends JpaRepository<GateEvent, Long> {
+
+    List<GateEvent> findByGatePassIdOrderByRegistradoEmAsc(Long gatePassId);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GatePassRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GatePassRepository.java
@@ -1,0 +1,25 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.model.GatePass;
+import br.com.cloudport.servicogate.model.enums.StatusGate;
+import br.com.cloudport.servicogate.repository.projection.TempoMedioPermanenciaProjection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface GatePassRepository extends JpaRepository<GatePass, Long> {
+
+    Optional<GatePass> findByCodigo(String codigo);
+
+    List<GatePass> findByStatus(StatusGate status);
+
+    @Query(value = "SELECT DATE(gp.data_entrada) AS dia, " +
+            "AVG(EXTRACT(EPOCH FROM (gp.data_saida - gp.data_entrada))/60) AS tempoMedioMinutos " +
+            "FROM gate_pass gp " +
+            "WHERE gp.data_entrada IS NOT NULL AND gp.data_saida IS NOT NULL " +
+            "GROUP BY DATE(gp.data_entrada) " +
+            "ORDER BY dia",
+            nativeQuery = true)
+    List<TempoMedioPermanenciaProjection> calcularTempoMedioPermanencia();
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/JanelaAtendimentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/JanelaAtendimentoRepository.java
@@ -1,0 +1,11 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.model.JanelaAtendimento;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JanelaAtendimentoRepository extends JpaRepository<JanelaAtendimento, Long> {
+
+    List<JanelaAtendimento> findByDataOrderByHoraInicio(LocalDate data);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/MotoristaRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/MotoristaRepository.java
@@ -1,0 +1,13 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.model.Motorista;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MotoristaRepository extends JpaRepository<Motorista, Long> {
+
+    Optional<Motorista> findByDocumento(String documento);
+
+    List<Motorista> findByTransportadoraIdOrderByNomeAsc(Long transportadoraId);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/TransportadoraRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/TransportadoraRepository.java
@@ -1,0 +1,10 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.model.Transportadora;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransportadoraRepository extends JpaRepository<Transportadora, Long> {
+
+    Optional<Transportadora> findByDocumento(String documento);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/VeiculoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/VeiculoRepository.java
@@ -1,0 +1,13 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.model.Veiculo;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VeiculoRepository extends JpaRepository<Veiculo, Long> {
+
+    Optional<Veiculo> findByPlaca(String placa);
+
+    List<Veiculo> findByTransportadoraIdOrderByPlacaAsc(Long transportadoraId);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/projection/OcupacaoPorHoraProjection.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/projection/OcupacaoPorHoraProjection.java
@@ -1,0 +1,12 @@
+package br.com.cloudport.servicogate.repository.projection;
+
+import java.time.LocalTime;
+
+public interface OcupacaoPorHoraProjection {
+
+    LocalTime getHoraInicio();
+
+    Long getTotalAgendamentos();
+
+    Integer getCapacidadeSlot();
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/projection/TempoMedioPermanenciaProjection.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/projection/TempoMedioPermanenciaProjection.java
@@ -1,0 +1,10 @@
+package br.com.cloudport.servicogate.repository.projection;
+
+import java.time.LocalDate;
+
+public interface TempoMedioPermanenciaProjection {
+
+    LocalDate getDia();
+
+    Double getTempoMedioMinutos();
+}

--- a/backend/servico-gate/src/main/resources/application.properties
+++ b/backend/servico-gate/src/main/resources/application.properties
@@ -9,6 +9,8 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
 
 spring.rabbitmq.host=${GATE_RABBIT_HOST:localhost}
 spring.rabbitmq.port=${GATE_RABBIT_PORT:5672}

--- a/backend/servico-gate/src/main/resources/db/migration/V1__create_gate_tables.sql
+++ b/backend/servico-gate/src/main/resources/db/migration/V1__create_gate_tables.sql
@@ -1,0 +1,110 @@
+CREATE TABLE transportadora (
+    id BIGSERIAL PRIMARY KEY,
+    nome VARCHAR(120) NOT NULL,
+    documento VARCHAR(20) NOT NULL UNIQUE,
+    contato VARCHAR(120),
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_transportadora_nome ON transportadora (nome);
+
+CREATE TABLE motorista (
+    id BIGSERIAL PRIMARY KEY,
+    nome VARCHAR(120) NOT NULL,
+    documento VARCHAR(20) NOT NULL,
+    telefone VARCHAR(20),
+    transportadora_id BIGINT NOT NULL REFERENCES transportadora (id),
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uk_motorista_documento UNIQUE (documento, transportadora_id)
+);
+
+CREATE INDEX idx_motorista_transportadora ON motorista (transportadora_id);
+
+CREATE TABLE veiculo (
+    id BIGSERIAL PRIMARY KEY,
+    placa VARCHAR(10) NOT NULL UNIQUE,
+    modelo VARCHAR(60),
+    tipo VARCHAR(40),
+    transportadora_id BIGINT NOT NULL REFERENCES transportadora (id),
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_veiculo_transportadora ON veiculo (transportadora_id);
+
+CREATE TABLE janela_atendimento (
+    id BIGSERIAL PRIMARY KEY,
+    data DATE NOT NULL,
+    hora_inicio TIME WITHOUT TIME ZONE NOT NULL,
+    hora_fim TIME WITHOUT TIME ZONE NOT NULL,
+    capacidade INTEGER NOT NULL,
+    canal_entrada VARCHAR(40) NOT NULL,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX uk_janela_atendimento_slot ON janela_atendimento (data, hora_inicio, canal_entrada);
+
+CREATE TABLE agendamento (
+    id BIGSERIAL PRIMARY KEY,
+    codigo VARCHAR(40) NOT NULL UNIQUE,
+    tipo_operacao VARCHAR(40) NOT NULL,
+    status VARCHAR(40) NOT NULL,
+    transportadora_id BIGINT NOT NULL REFERENCES transportadora (id),
+    motorista_id BIGINT NOT NULL REFERENCES motorista (id),
+    veiculo_id BIGINT NOT NULL REFERENCES veiculo (id),
+    janela_atendimento_id BIGINT NOT NULL REFERENCES janela_atendimento (id),
+    horario_previsto_chegada TIMESTAMP WITHOUT TIME ZONE,
+    horario_previsto_saida TIMESTAMP WITHOUT TIME ZONE,
+    horario_real_chegada TIMESTAMP WITHOUT TIME ZONE,
+    horario_real_saida TIMESTAMP WITHOUT TIME ZONE,
+    observacoes VARCHAR(500),
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_agendamento_status ON agendamento (status);
+CREATE INDEX idx_agendamento_janela ON agendamento (janela_atendimento_id);
+CREATE INDEX idx_agendamento_transportadora ON agendamento (transportadora_id);
+
+CREATE TABLE documento_agendamento (
+    id BIGSERIAL PRIMARY KEY,
+    tipo_documento VARCHAR(80) NOT NULL,
+    numero VARCHAR(80),
+    url_documento VARCHAR(255),
+    agendamento_id BIGINT NOT NULL REFERENCES agendamento (id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_documento_agendamento_agendamento ON documento_agendamento (agendamento_id);
+
+CREATE TABLE gate_pass (
+    id BIGSERIAL PRIMARY KEY,
+    codigo VARCHAR(40) NOT NULL UNIQUE,
+    status VARCHAR(40) NOT NULL,
+    data_entrada TIMESTAMP WITHOUT TIME ZONE,
+    data_saida TIMESTAMP WITHOUT TIME ZONE,
+    agendamento_id BIGINT NOT NULL UNIQUE REFERENCES agendamento (id),
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_gate_pass_status ON gate_pass (status);
+
+CREATE TABLE gate_event (
+    id BIGSERIAL PRIMARY KEY,
+    status VARCHAR(40) NOT NULL,
+    motivo_excecao VARCHAR(40),
+    observacao VARCHAR(500),
+    usuario_responsavel VARCHAR(80),
+    registrado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    gate_pass_id BIGINT NOT NULL REFERENCES gate_pass (id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_gate_event_gate_pass ON gate_event (gate_pass_id);
+CREATE INDEX idx_gate_event_status ON gate_event (status);


### PR DESCRIPTION
## Sumário
- Adiciona entidades do domínio de gate com enums e relacionamentos auditorados
- Cria DTOs e mapeadores para isolar o modelo persistido dos payloads das APIs
- Implementa repositórios JPA com consultas para dashboards e migração inicial via Flyway

## Testes
- mvn -f backend/servico-gate/pom.xml -DskipTests package *(falha: bloqueio 403 para baixar dependências da base parent do Spring Boot)*

------
https://chatgpt.com/codex/tasks/task_e_68d9135eb5788327b908518414cc72f2