### PR TITLE
Documentar execução do serviço Gate e ajustar configuração de testes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,39 @@ Para executá-lo, navegue até `backend/servico-yard` e rode `mvn spring-boot:ru
 
 ## Serviço de Gate
 
-O serviço **servico-gate** pode ser iniciado após configurar as variáveis adicionadas em `env.example`. Certifique-se de que PostgreSQL e RabbitMQ estão em execução e que o TOS e o storage de documentos referenciados estão acessíveis.
+O serviço **servico-gate** centraliza integrações de gate, realizando chamadas ao TOS, comunicação via RabbitMQ e persistência em PostgreSQL. Para executá-lo, configure as variáveis `GATE_*`, `TOS_API_*` e `DOCUMENT_STORAGE_*` descritas em `env.example`. Certifique-se também de que PostgreSQL e RabbitMQ estejam operacionais.
 
-Para subir o serviço manualmente:
+### Subindo o serviço manualmente
 
 ```bash
 cd backend/servico-gate
 mvn spring-boot:run
 ```
 
-O serviço expõe a porta definida em `GATE_SERVER_PORT` (padrão `8082`).
+Por padrão o serviço expõe a porta `GATE_SERVER_PORT` (valor padrão `8082`). Ajuste-a conforme necessário quando executar múltiplos serviços localmente.
 
-Para desenvolvimento local com Docker, inclua instâncias de PostgreSQL e RabbitMQ compatíveis com as credenciais configuradas.
+### Dependências externas sugeridas via Docker Compose
+
+Um arquivo `docker-compose` não está incluído, mas recomenda-se preparar containers semelhantes aos exemplos abaixo para desenvolvimento local:
+
+```yaml
+services:
+  gate-postgres:
+    image: postgres:13
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_DB: servico_gate
+      POSTGRES_USER: ${GATE_DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${GATE_DB_PASSWORD:-postgres}
+  gate-rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${GATE_RABBIT_USERNAME:-guest}
+      RABBITMQ_DEFAULT_PASS: ${GATE_RABBIT_PASSWORD:-guest}
+```
+
+Atualize as portas caso já existam instâncias locais em execução.

--- a/backend/servico-gate/src/test/resources/application-test.properties
+++ b/backend/servico-gate/src/test/resources/application-test.properties
@@ -9,6 +9,8 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
 
 spring.rabbitmq.host=${GATE_RABBIT_HOST:localhost}
 spring.rabbitmq.port=${GATE_RABBIT_PORT:5672}

--- a/gitpod.txt
+++ b/gitpod.txt
@@ -3,7 +3,7 @@ rm -rf node_modules package-lock.json
 nvm install node
 nvm use node
 npm install -g @angular/cli
-npm install -g npm 
+npm install -g npm
 npm install @angular/core
 npm install --save ag-grid-community
 npm install --save ag-grid-angular
@@ -22,3 +22,10 @@ createdb servico_autenticacao
 cd backend/servico-autenticacao/
 mvn spring-boot:run
 
+# ------------------------------------------------------------------------------
+# Serviço Gate
+# Em um novo terminal, configure o banco e execute o serviço de gate.
+createdb servico_gate
+
+cd backend/servico-gate/
+mvn spring-boot:run


### PR DESCRIPTION
## Resumo
- documentei o processo de execução local do servico-gate e sugeri compose com PostgreSQL e RabbitMQ
- alinhei application-test.properties com as configurações do ambiente principal, incluindo suporte ao Flyway
- atualizei o roteiro do Gitpod para subir o banco e a aplicação do servico-gate

## Testes
- `mvn -f backend/servico-gate/pom.xml -q test` *(falhou: bloqueio de acesso ao Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9763f8e7c8327a399a7d1b84757cb