### PR TITLE
chore: update ag-grid packages

### DIFF
--- a/frontend/cloudport/package-lock.json
+++ b/frontend/cloudport/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ag-grid-community/core": "^31.3.4",
-        "@ag-grid-enterprise/all-modules": "^27.3.0",
+        "@ag-grid-enterprise/all-modules": "^31.3.4",
         "@ag-grid-enterprise/excel-export": "^30.0.6",
         "@angular/animations": "^16.1.0",
         "@angular/cdk": "^16.1.5",
@@ -5114,22 +5114,20 @@
       "integrity": "sha512-tj9ZeM3Mawk+Q1q7FbwmilGnImfKehXt6RdakD8tD+ll1oUlufS9qr1Ay9Xs9AHEisuk2Q4iJv3EOmu/y5p2lA=="
     },
     "node_modules/ag-grid-angular": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-30.1.0.tgz",
-      "integrity": "sha512-Fslijnu6S5wQ8HsW3WfMG9A52qPL1s1X+59wiEp+8yHk9c0Y1Vh0r3uPIFA7ukicLqBM6y1XJeaLfL8TH1DoMw==",
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-31.3.4.tgz",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": ">= 12.0.0",
-        "@angular/core": ">= 12.0.0",
-        "ag-grid-community": "~30.1.0"
+        "@angular/common": ">= 15.0.0",
+        "@angular/core": ">= 15.0.0",
+        "ag-grid-community": "~31.3.0"
       }
     },
     "node_modules/ag-grid-community": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-30.1.0.tgz",
-      "integrity": "sha512-D69e63CUALxfgLZSu1rXC8Xiyhu6+17zxzTV8cWsyvt5GeSDv2frQ3BKOqGZbUfVoOCLv2SQoHVTTqw8OjxavA=="
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz"
     },
     "node_modules/agent-base": {
       "version": "6.0.2",

--- a/frontend/cloudport/package.json
+++ b/frontend/cloudport/package.json
@@ -11,7 +11,7 @@
   "private": true,
   "dependencies": {
     "@ag-grid-community/core": "^31.3.4",
-    "@ag-grid-enterprise/all-modules": "^27.3.0",
+    "@ag-grid-enterprise/all-modules": "^31.3.4",
     "@ag-grid-enterprise/excel-export": "^31.3.4",
     "@angular/animations": "^16.1.0",
     "@angular/cdk": "^16.1.5",


### PR DESCRIPTION
## Summary
- bump ag-grid dependencies in the Angular frontend to align on version 31.3.4
- update the lockfile to reflect the new ag-grid versions

## Testing
- `npm install` *(fails: npm registry returned 403 Forbidden from the execution environment)*
- `npm run build` *(fails: Angular CLI not available because dependencies could not be installed)*
- `npm test` *(fails: Angular CLI not available because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e701b135808327a21dca019e2baf83