### PR TITLE
chore: align ag-grid excel-export lock version

### DIFF
--- a/frontend/cloudport/package-lock.json
+++ b/frontend/cloudport/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ag-grid-community/core": "^31.3.4",
         "@ag-grid-enterprise/all-modules": "^31.3.4",
-        "@ag-grid-enterprise/excel-export": "^30.0.6",
+        "@ag-grid-enterprise/excel-export": "^31.3.4",
         "@angular/animations": "^16.1.0",
         "@angular/cdk": "^16.1.5",
         "@angular/common": "^16.1.0",


### PR DESCRIPTION
## Summary
- update the package-lock to require @ag-grid-enterprise/excel-export ^31.3.4 alongside the other ag-grid packages

## Testing
- npm install *(fails: 403 Forbidden while downloading @ag-grid-enterprise/all-modules)*
- npm run build *(fails: ng not found because the Angular CLI dependencies were not installed)*
- npm test *(fails: ng not found because the Angular CLI dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e7a0738a0883278d73fd651b80a229