### PR TITLE
chore: update webpack dev server dependency

### DIFF
--- a/frontend/cloudport/package.json
+++ b/frontend/cloudport/package.json
@@ -47,6 +47,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "rollup": "~3.29.5",
     "typescript": "~5.1.3",
-    "vite": "~4.5.2"
+    "vite": "~4.5.2",
+    "webpack-dev-server": "^4.15.2"
   }
 }


### PR DESCRIPTION
## Summary
- atualiza a devDependency `webpack-dev-server` para `^4.15.2` no projeto Angular do frontend, visando trazer `webpack-dev-middleware@5.3.4`

## Testing
- npm install *(falha: 403 Forbidden ao baixar @ag-grid-enterprise/all-modules da registry npm)*
- npm run start *(não executado: instalação de dependências não concluída por erro 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e7a7c9b554832791fe76902f51a361