### PR TITLE
chore: add dev overrides for express send cookie

### DIFF
--- a/frontend/cloudport/package-lock.json
+++ b/frontend/cloudport/package-lock.json
@@ -37,6 +37,7 @@
         "@angular/compiler-cli": "^16.1.0",
         "@types/jasmine": "~4.3.0",
         "@types/node": "^20.5.0",
+        "cookie": "0.7.0",
         "jasmine-core": "~4.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -44,6 +45,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "rollup": "~3.29.5",
+        "send": "0.19.0",
         "typescript": "~5.1.3",
         "vite": "~4.5.2"
       }

--- a/frontend/cloudport/package.json
+++ b/frontend/cloudport/package.json
@@ -39,6 +39,7 @@
     "@angular/compiler-cli": "^16.1.0",
     "@types/jasmine": "~4.3.0",
     "@types/node": "^20.5.0",
+    "cookie": "0.7.0",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
@@ -46,8 +47,10 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "rollup": "~3.29.5",
+    "send": "0.19.0",
     "typescript": "~5.1.3",
     "vite": "~4.5.2",
-    "webpack-dev-server": "^4.15.2"
+    "webpack-dev-server": "^4.15.2",
+    "express": "4.20.0"
   }
 }


### PR DESCRIPTION
## Summary
- add express@4.20.0, send@0.19.0, and cookie@0.7.0 as devDependencies in the Angular frontend so the desired versions are pinned
- synchronize the top-level dev dependency declarations in the lockfile with the newly added packages

## Testing
- `npm install --no-progress` *(fails: download of @ag-grid-enterprise/all-modules is forbidden in this environment, preventing lockfile regeneration)*
- `npm run test` *(fails: Angular CLI is unavailable because dependencies cannot be installed without access to the private @ag-grid-enterprise packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e7baa49bf483278c6a935576a91fd6