### PR TITLE
chore: alinhar postcss 8.4.31 no lockfile raiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ O projeto depende das seguintes bibliotecas e ferramentas:
 Contribuições são sempre bem-vindas. Se você deseja contribuir, por favor, abra uma issue primeiro para discutir o que você gostaria de mudar.
 
 
+## Lockfiles do ecossistema Node
+
+O repositório mantém dois lockfiles gerados pelo `npm`:
+
+- `frontend/cloudport/package-lock.json`: lockfile principal do front-end Angular.
+- `package-lock.json` na raiz: artefato herdado do bootstrap inicial do front-end que roda utilidades do Angular CLI diretamente da raiz. Ele replica um subconjunto das dependências usadas em `frontend/cloudport/package.json` para permitir que scripts de automação e ambientes legados (por exemplo, pipelines que executam `npm install` na raiz) continuem funcionando.
+
+Ao atualizar dependências JavaScript, execute os comandos de instalação no diretório correspondente e sincronize manualmente o lockfile da raiz apenas quando o `package.json` da raiz sofrer alterações. Isso evita que os dois lockfiles evoluam de forma divergente.
+
+
 ## Serviço de Gestão de Pátio
 
 O microserviço **servico-yard** é um exemplo simples de gestão de contêineres no pátio. Ele expõe duas rotas REST:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8633,8 +8633,8 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
       "dev": true,
       "funding": [


### PR DESCRIPTION
## Resumo
- atualiza a entrada de `node_modules/postcss` do `package-lock.json` raiz para apontar para a versão 8.4.31
- documenta no README a razão da existência de dois lockfiles npm e orienta como mantê-los sincronizados

## Testes
- ⚠️ `npm install postcss@8.4.31` *(falhou devido a 403 do registry restrito no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68e7e7e4983c8327a286bb9f504699ef