### PR TITLE
chore: bump vite and rollup in frontend lockfiles

### DIFF
--- a/frontend/cloudport/package-lock.json
+++ b/frontend/cloudport/package-lock.json
@@ -522,7 +522,7 @@
         "text-table": "0.2.0",
         "tree-kill": "1.2.2",
         "tslib": "2.6.1",
-        "vite": "4.4.12",
+        "vite": "4.5.2",
         "webpack": "5.88.2",
         "webpack-dev-middleware": "6.1.2",
         "webpack-dev-server": "4.15.1",
@@ -11494,9 +11494,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
-      "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -12958,14 +12958,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.12.tgz",
-      "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.31",
-        "rollup": "^3.25.2"
+        "rollup": "^3.29.5"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "text-table": "0.2.0",
         "tree-kill": "1.2.2",
         "tslib": "2.6.1",
-        "vite": "4.4.12",
+        "vite": "4.5.2",
         "webpack": "5.88.2",
         "webpack-dev-middleware": "6.1.2",
         "webpack-dev-server": "4.15.1",
@@ -9177,9 +9177,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
-      "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -10310,14 +10310,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.12.tgz",
-      "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.31",
-        "rollup": "^3.25.2"
+        "rollup": "^3.29.5"
       },
       "bin": {
         "vite": "bin/vite.js"


### PR DESCRIPTION
## Summary
- update both npm lockfiles so the recorded vite dependency is 4.5.2 and the bundled rollup dependency is 3.29.5
- note: npm registry access is blocked in this environment, so the new integrity hashes are placeholders that must be refreshed by running `npm install` once network access is available

## Testing
- npm install *(fails: 403 Forbidden fetching @ag-grid-enterprise/all-modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e830c37584832796627271cf00bc67