### PR TITLE
fix: alinhar payloads de autenticação entre backend e frontend

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationController.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationController.java
@@ -50,14 +50,23 @@ public class AuthenticationController {
         var usernamePassword = new UsernamePasswordAuthenticationToken(data.getLogin(), data.getPassword());
         var auth = this.authenticationManager.authenticate(usernamePassword);
 
-        var token = tokenService.generateToken((User) auth.getPrincipal());
-        
         User user = (User) auth.getPrincipal();
+        var token = tokenService.generateToken(user);
+
         Set<String> roles = user.getRoles().stream()
                                  .map(userRole -> userRole.getRole().getName())
                                  .collect(Collectors.toSet());
 
-        return ResponseEntity.ok(new LoginResponseDTO(token, roles));
+        String perfil = roles.stream().findFirst().orElse("");
+
+        return ResponseEntity.ok(new LoginResponseDTO(
+                user.getId(),
+                user.getLogin(),
+                user.getLogin(),
+                perfil,
+                token,
+                roles
+        ));
     }
 
     @PostMapping("/register")

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/LoginResponseDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/LoginResponseDTO.java
@@ -2,14 +2,39 @@ package br.com.cloudport.servicoautenticacao.dto;
 
 
 import java.util.Set;
+import java.util.UUID;
 
 public class LoginResponseDTO {
+    private final UUID id;
+    private final String login;
+    private final String nome;
+    private final String perfil;
     private final String token;
     private final Set<String> roles;
 
-    public LoginResponseDTO(String token, Set<String> roles) {
+    public LoginResponseDTO(UUID id, String login, String nome, String perfil, String token, Set<String> roles) {
+        this.id = id;
+        this.login = login;
+        this.nome = nome;
+        this.perfil = perfil;
         this.token = token;
         this.roles = roles;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public String getPerfil() {
+        return perfil;
     }
 
     public String getToken() {

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
@@ -75,6 +75,10 @@ class AuthenticationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(user.getId().toString()))
+                .andExpect(jsonPath("$.login").value("test"))
+                .andExpect(jsonPath("$.nome").value("test"))
+                .andExpect(jsonPath("$.perfil").value("ADMIN"))
                 .andExpect(jsonPath("$.token").value("token"))
                 .andExpect(jsonPath("$.roles[0]").value("ADMIN"));
     }

--- a/frontend/cloudport/src/app/componentes/model/user.model.spec.ts
+++ b/frontend/cloudport/src/app/componentes/model/user.model.spec.ts
@@ -2,7 +2,7 @@ import { User } from './user.model';
 
 describe('User model', () => {
   it('deve preencher as propriedades fornecidas no construtor', () => {
-    const user = new User('1', 'João', 'token-123', 'joao@example.com', 'senha', 'ADMIN');
+    const user = new User('1', 'João', 'token-123', 'joao@example.com', 'senha', 'ADMIN', ['ADMIN']);
 
     expect(user.id).toBe('1');
     expect(user.nome).toBe('João');
@@ -10,6 +10,7 @@ describe('User model', () => {
     expect(user.email).toBe('joao@example.com');
     expect(user.senha).toBe('senha');
     expect(user.perfil).toBe('ADMIN');
+    expect(user.roles).toEqual(['ADMIN']);
   });
 
   it('deve permitir instanciar com valores padrão', () => {
@@ -21,5 +22,6 @@ describe('User model', () => {
     expect(user.email).toBe('');
     expect(user.senha).toBe('');
     expect(user.perfil).toBe('');
+    expect(user.roles).toEqual([]);
   });
 });

--- a/frontend/cloudport/src/app/componentes/model/user.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/user.model.ts
@@ -5,7 +5,8 @@ export class User {
       token: string = '',
       email: string = '',
       senha: string = '',
-      perfil: string = ''
+      perfil: string = '',
+      roles: string[] = []
     ) {
       this.id = id;
       this.nome = nome;
@@ -13,13 +14,15 @@ export class User {
       this.email = email;
       this.senha = senha;
       this.perfil = perfil;
+      this.roles = roles;
     }
-  
+
     public id: string;
     public nome: string;
     public token: string;
     public email: string;
     public senha: string;
     public perfil: string;
+    public roles: string[];
   }
-  
+

--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
@@ -71,14 +71,21 @@ export class AuthenticationService {
         }
 
         const source = data.data ?? data;
+        const roles = Array.isArray(source.roles)
+            ? source.roles
+            : (source.roles ? [source.roles] : []);
+        const perfil = source.perfil ?? data.perfil ?? (roles.length > 0 ? roles[0] : '');
+        const nome = source.nome ?? source.name ?? source.login ?? data.nome ?? data.login ?? '';
+        const id = source.id ?? data.id ?? source.userId ?? data.userId ?? '';
 
         return new User(
-            source.id ?? data.id ?? '',
-            source.nome ?? source.name ?? data.nome ?? '',
+            id,
+            nome,
             source.token ?? data.token ?? '',
             source.email ?? data.email ?? '',
             source.senha ?? data.senha ?? '',
-            source.perfil ?? data.perfil ?? ''
+            perfil,
+            roles
         );
     }
 }


### PR DESCRIPTION
## Summary
- enrich the login response with user metadata expected by the Angular client
- update the frontend user model and authentication service to persist roles and profile from the backend
- extend backend and frontend unit tests to cover the new contract

## Testing
- mvn -q test *(fails: Maven central blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e84289f25083278c0cb5f19b2f21e3