### PR TITLE
Ajusta tratamento de not found em RoleService

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/GlobalExceptionHandler.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/GlobalExceptionHandler.java
@@ -24,6 +24,12 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Object> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        logger.warn("ResourceNotFoundException encontrada no GlobalExceptionHandler: ", ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
         logger.warn("IllegalArgumentException encontrada no GlobalExceptionHandler: ", ex);

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/ResourceNotFoundException.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package br.com.cloudport.servicoautenticacao.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/services/RoleService.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/services/RoleService.java
@@ -1,7 +1,8 @@
 package br.com.cloudport.servicoautenticacao.services;
 
-import br.com.cloudport.servicoautenticacao.model.Role;
 import br.com.cloudport.servicoautenticacao.dto.RoleDTO;
+import br.com.cloudport.servicoautenticacao.exception.ResourceNotFoundException;
+import br.com.cloudport.servicoautenticacao.model.Role;
 import br.com.cloudport.servicoautenticacao.repositories.RoleRepository;
 import br.com.cloudport.servicoautenticacao.repositories.UserRoleRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +45,7 @@ public class RoleService {
     @Transactional
     public RoleDTO findByName(String name) {
         Role role = roleRepository.findByName(name)
-                .orElseThrow(() -> new IllegalArgumentException("Role " + name + " not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Role " + name + " not found"));
         return new RoleDTO(role.getId(), role.getName()); // Adicione o id aqui
     }
 
@@ -60,7 +61,7 @@ public class RoleService {
     @Transactional
     public RoleDTO updateRole(Long id, RoleDTO roleDTO) {
         Role role = roleRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Role with id " + id + " not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Role with id " + id + " not found"));
         role.setName(roleDTO.getName()); // Atualiza o nome da função
         Role updatedRole = roleRepository.save(role);
         return new RoleDTO(updatedRole.getId(), updatedRole.getName()); // Retorna a função atualizada
@@ -74,7 +75,7 @@ public class RoleService {
         }
 
         if (!roleRepository.existsById(id)) {
-            throw new IllegalStateException("Role com id " + id + " não encontrado.");
+            throw new ResourceNotFoundException("Role com id " + id + " não encontrado.");
         }
 
         roleRepository.deleteById(id);


### PR DESCRIPTION
## Summary
- cria a exceção `ResourceNotFoundException` para representar cenários de recurso ausente
- atualiza o `RoleService` para lançar a nova exceção nos fluxos de busca, atualização e remoção
- configura o `GlobalExceptionHandler` para responder com `404 NOT_FOUND` quando a exceção ocorrer

## Testing
- ./mvnw spring-boot:run *(falhou: Maven Wrapper não conseguiu baixar dependências devido a falta de acesso à rede)*

------
https://chatgpt.com/codex/tasks/task_e_68e85479e0f083279fb83d3960cd42cb