### PR TITLE
chore: bump webpack dev server tooling

### DIFF
--- a/frontend/cloudport/package-lock.json
+++ b/frontend/cloudport/package-lock.json
@@ -13159,9 +13159,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
-      "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
+      "integrity": "sha512-pN5A7xHtHeHT1Fk9f1LbRyFrpDTB0hpkZtaf05QlR3X76vVBsqPHoAUlnNcEMCnsjcnD/woON+7tlGRjuMZSiw==",
       "dev": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
@@ -13192,7 +13192,7 @@
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^5.3.1",
+        "webpack-dev-middleware": "^5.3.4",
         "ws": "^8.13.0"
       },
       "bin": {
@@ -13218,26 +13218,31 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.2.tgz",
+      "integrity": "sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",
-        "memfs": "^3.4.3",
+        "memfs": "^3.4.12",
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
         "schema-utils": "^4.0.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 14.15.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {

--- a/frontend/cloudport/package.json
+++ b/frontend/cloudport/package.json
@@ -50,7 +50,7 @@
     "send": "0.19.0",
     "typescript": "~5.1.3",
     "vite": "~4.5.2",
-    "webpack-dev-server": "^4.15.2",
+    "webpack-dev-server": "4.15.2",
     "express": "4.20.0",
     "http-proxy-middleware": "^2.0.7",
     "cross-spawn": "^7.0.5",


### PR DESCRIPTION
## Summary
- pin webpack-dev-server to 4.15.2 in the Angular frontend to ensure the desired middleware version is pulled
- update the package lock so webpack-dev-middleware resolves to 6.1.2 under webpack-dev-server

## Testing
- npm install *(fails: 403 Forbidden when downloading @ag-grid-enterprise/all-modules due to registry access restrictions)*
- npm run start *(fails: `ng` command not available because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e8d014ece48327b55b6251cd12195c