### PR TITLE
Ajusta resposta 404 para operações de role inexistente

### DIFF
--- a/backend/servico-autenticacao/pom.xml
+++ b/backend/servico-autenticacao/pom.xml
@@ -61,6 +61,11 @@
                         <scope>test</scope>
                 </dependency>
                 <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
                         <groupId>com.h2database</groupId>
                         <artifactId>h2</artifactId>
                         <scope>test</scope>

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/GlobalExceptionHandler.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/GlobalExceptionHandler.java
@@ -24,9 +24,9 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
     }
 
-    @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<Object> handleResourceNotFoundException(ResourceNotFoundException ex) {
-        logger.warn("ResourceNotFoundException encontrada no GlobalExceptionHandler: ", ex);
+    @ExceptionHandler(RoleNotFoundException.class)
+    public ResponseEntity<Object> handleRoleNotFoundException(RoleNotFoundException ex) {
+        logger.warn("RoleNotFoundException encontrada no GlobalExceptionHandler: ", ex);
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
     }
 

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/ResourceNotFoundException.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/ResourceNotFoundException.java
@@ -1,8 +1,0 @@
-package br.com.cloudport.servicoautenticacao.exception;
-
-public class ResourceNotFoundException extends RuntimeException {
-
-    public ResourceNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/RoleNotFoundException.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/RoleNotFoundException.java
@@ -1,0 +1,8 @@
+package br.com.cloudport.servicoautenticacao.exception;
+
+public class RoleNotFoundException extends RuntimeException {
+
+    public RoleNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/services/RoleService.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/services/RoleService.java
@@ -1,7 +1,7 @@
 package br.com.cloudport.servicoautenticacao.services;
 
 import br.com.cloudport.servicoautenticacao.dto.RoleDTO;
-import br.com.cloudport.servicoautenticacao.exception.ResourceNotFoundException;
+import br.com.cloudport.servicoautenticacao.exception.RoleNotFoundException;
 import br.com.cloudport.servicoautenticacao.model.Role;
 import br.com.cloudport.servicoautenticacao.repositories.RoleRepository;
 import br.com.cloudport.servicoautenticacao.repositories.UserRoleRepository;
@@ -45,7 +45,7 @@ public class RoleService {
     @Transactional
     public RoleDTO findByName(String name) {
         Role role = roleRepository.findByName(name)
-                .orElseThrow(() -> new ResourceNotFoundException("Role " + name + " not found"));
+                .orElseThrow(() -> new RoleNotFoundException("Role " + name + " not found"));
         return new RoleDTO(role.getId(), role.getName()); // Adicione o id aqui
     }
 
@@ -61,7 +61,7 @@ public class RoleService {
     @Transactional
     public RoleDTO updateRole(Long id, RoleDTO roleDTO) {
         Role role = roleRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Role with id " + id + " not found"));
+                .orElseThrow(() -> new RoleNotFoundException("Role with id " + id + " not found"));
         role.setName(roleDTO.getName()); // Atualiza o nome da função
         Role updatedRole = roleRepository.save(role);
         return new RoleDTO(updatedRole.getId(), updatedRole.getName()); // Retorna a função atualizada
@@ -75,7 +75,7 @@ public class RoleService {
         }
 
         if (!roleRepository.existsById(id)) {
-            throw new ResourceNotFoundException("Role com id " + id + " não encontrado.");
+            throw new RoleNotFoundException("Role com id " + id + " não encontrado.");
         }
 
         roleRepository.deleteById(id);

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/RoleControllerNotFoundIT.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/RoleControllerNotFoundIT.java
@@ -1,0 +1,49 @@
+package br.com.cloudport.servicoautenticacao.controllers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RoleControllerNotFoundIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("GET /api/roles/{name} deve retornar 404 quando o role não existir")
+    void shouldReturn404WhenRoleIsNotFoundByName() throws Exception {
+        mockMvc.perform(get("/api/roles/{name}", "role-inexistente"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("PUT /api/roles/{id} deve retornar 404 quando o role não existir")
+    void shouldReturn404WhenRoleIsNotFoundOnUpdate() throws Exception {
+        mockMvc.perform(put("/api/roles/{id}", 999L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Novo Nome\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("DELETE /api/roles/{id} deve retornar 404 quando o role não existir")
+    void shouldReturn404WhenRoleIsNotFoundOnDelete() throws Exception {
+        mockMvc.perform(delete("/api/roles/{id}", 999L))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- adiciona a exceção `RoleNotFoundException` e atualiza o `RoleService` para retornar 404 em buscas, atualização e remoção de roles inexistentes
- ajusta o `GlobalExceptionHandler` para mapear a nova exceção para `HttpStatus.NOT_FOUND`
- cria testes de integração com MockMvc que garantem as respostas 404 e adiciona a dependência de teste necessária

## Testing
- ⚠️ `mvn -q test` *(falha: bloqueio de acesso ao repositório Maven impede o download do parent Spring Boot)*

------
https://chatgpt.com/codex/tasks/task_e_68e8f1aa57288327b6ed510585ecfb27