### PR TITLE
feat: add scheduling management endpoints

### DIFF
--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/AgendamentoRulesProperties.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/AgendamentoRulesProperties.java
@@ -1,0 +1,60 @@
+package br.com.cloudport.servicogate.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloudport.gate.agendamento.rules")
+public class AgendamentoRulesProperties {
+
+    /**
+     * Antecedência mínima necessária para criação de agendamentos em relação ao início da janela.
+     */
+    private Duration antecedenciaMinima = Duration.ofHours(2);
+
+    /**
+     * Tempo máximo após o início da janela em que ainda é permitido criar agendamentos.
+     */
+    private Duration atrasoMaximo = Duration.ofHours(1);
+
+    /**
+     * Período anterior ao início da janela em que edições são permitidas.
+     */
+    private Duration edicaoAntecedencia = Duration.ofHours(12);
+
+    /**
+     * Período posterior ao início da janela em que edições são permitidas.
+     */
+    private Duration edicaoAtraso = Duration.ofHours(2);
+
+    public Duration getAntecedenciaMinima() {
+        return antecedenciaMinima;
+    }
+
+    public void setAntecedenciaMinima(Duration antecedenciaMinima) {
+        this.antecedenciaMinima = antecedenciaMinima;
+    }
+
+    public Duration getAtrasoMaximo() {
+        return atrasoMaximo;
+    }
+
+    public void setAtrasoMaximo(Duration atrasoMaximo) {
+        this.atrasoMaximo = atrasoMaximo;
+    }
+
+    public Duration getEdicaoAntecedencia() {
+        return edicaoAntecedencia;
+    }
+
+    public void setEdicaoAntecedencia(Duration edicaoAntecedencia) {
+        this.edicaoAntecedencia = edicaoAntecedencia;
+    }
+
+    public Duration getEdicaoAtraso() {
+        return edicaoAtraso;
+    }
+
+    public void setEdicaoAtraso(Duration edicaoAtraso) {
+        this.edicaoAtraso = edicaoAtraso;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/DocumentoStorageProperties.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/DocumentoStorageProperties.java
@@ -1,0 +1,37 @@
+package br.com.cloudport.servicogate.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloudport.document-storage")
+public class DocumentoStorageProperties {
+
+    private String provider = "local";
+
+    private String basePath = "/var/lib/cloudport/documents";
+
+    private String bucket = "cloudport-documents";
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public void setBasePath(String basePath) {
+        this.basePath = basePath;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/OpenApiConfig.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package br.com.cloudport.servicogate.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@Configuration
+@EnableConfigurationProperties({AgendamentoRulesProperties.class, DocumentoStorageProperties.class})
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI gateOpenApi() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(new Info()
+                        .title("CloudPort - Serviço de Gate")
+                        .description("API para gestão de agendamentos e janelas de atendimento do Gate CloudPort")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("Equipe CloudPort")
+                                .email("suporte@cloudport.com.br"))
+                        .license(new License()
+                                .name("Proprietary")
+                                .url("https://cloudport.com.br")));
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/AgendamentoController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/AgendamentoController.java
@@ -1,0 +1,106 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.dto.AgendamentoDTO;
+import br.com.cloudport.servicogate.dto.AgendamentoRequest;
+import br.com.cloudport.servicogate.dto.DocumentoAgendamentoDTO;
+import br.com.cloudport.servicogate.dto.DocumentoUploadRequest;
+import br.com.cloudport.servicogate.service.AgendamentoService;
+import br.com.cloudport.servicogate.service.DocumentoDownload;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.util.List;
+import javax.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/gate/agendamentos")
+@Validated
+@Tag(name = "Agendamentos", description = "Gestão de agendamentos de gate")
+public class AgendamentoController {
+
+    private final AgendamentoService agendamentoService;
+
+    public AgendamentoController(AgendamentoService agendamentoService) {
+        this.agendamentoService = agendamentoService;
+    }
+
+    @GetMapping
+    @Operation(summary = "Lista agendamentos com filtros de período e paginação")
+    public Page<AgendamentoDTO> listar(@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicio,
+                                       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataFim,
+                                       Pageable pageable) {
+        return agendamentoService.buscar(dataInicio, dataFim, pageable);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Detalha um agendamento específico")
+    public AgendamentoDTO buscarPorId(@PathVariable Long id) {
+        return agendamentoService.buscarPorId(id);
+    }
+
+    @PostMapping
+    @Operation(summary = "Cria um novo agendamento")
+    public ResponseEntity<AgendamentoDTO> criar(@Valid @RequestBody AgendamentoRequest request) {
+        AgendamentoDTO criado = agendamentoService.criar(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Atualiza um agendamento existente")
+    public AgendamentoDTO atualizar(@PathVariable Long id, @Valid @RequestBody AgendamentoRequest request) {
+        return agendamentoService.atualizar(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Cancela um agendamento")
+    public ResponseEntity<Void> cancelar(@PathVariable Long id) {
+        agendamentoService.cancelar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping(value = "/{id}/documentos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "Realiza upload de documento para o agendamento")
+    public ResponseEntity<DocumentoAgendamentoDTO> uploadDocumento(@PathVariable Long id,
+                                                                   @Valid @RequestPart("metadata") DocumentoUploadRequest metadata,
+                                                                   @RequestPart("file") MultipartFile arquivo) {
+        DocumentoAgendamentoDTO documento = agendamentoService.adicionarDocumento(id, metadata, arquivo);
+        return ResponseEntity.status(HttpStatus.CREATED).body(documento);
+    }
+
+    @GetMapping("/{id}/documentos")
+    @Operation(summary = "Lista documentos de um agendamento")
+    public List<DocumentoAgendamentoDTO> listarDocumentos(@PathVariable Long id) {
+        return agendamentoService.listarDocumentos(id);
+    }
+
+    @GetMapping("/{agendamentoId}/documentos/{documentoId}")
+    @Operation(summary = "Download de documento do agendamento")
+    public ResponseEntity<org.springframework.core.io.Resource> downloadDocumento(@PathVariable Long agendamentoId,
+                                                                                  @PathVariable Long documentoId) {
+        DocumentoDownload download = agendamentoService.baixarDocumento(agendamentoId, documentoId);
+        ContentDisposition disposition = ContentDisposition.attachment().filename(download.getFilename()).build();
+        return ResponseEntity.ok()
+                .header("Content-Disposition", disposition.toString())
+                .contentType(MediaType.parseMediaType(download.getContentType()))
+                .body(download.getResource());
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/ConfigController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/ConfigController.java
@@ -1,0 +1,33 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.dto.EnumResponseDTO;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/gate/config")
+@Tag(name = "Configurações", description = "Endpoints de configuração para combobox dinâmicas")
+public class ConfigController {
+
+    @GetMapping("/tipos-operacao")
+    @Operation(summary = "Lista os tipos de operação disponíveis")
+    public ResponseEntity<List<EnumResponseDTO>> listarTiposOperacao() {
+        List<EnumResponseDTO> body = Arrays.stream(TipoOperacao.values())
+                .map(tipo -> new EnumResponseDTO(tipo.name(), tipo.getDescricao()))
+                .collect(Collectors.toList());
+        CacheControl cacheControl = CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
+        return ResponseEntity.ok()
+                .cacheControl(cacheControl)
+                .body(body);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/JanelaAtendimentoController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/JanelaAtendimentoController.java
@@ -1,0 +1,71 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.dto.JanelaAtendimentoDTO;
+import br.com.cloudport.servicogate.dto.JanelaAtendimentoRequest;
+import br.com.cloudport.servicogate.service.JanelaAtendimentoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import javax.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/gate/janelas")
+@Validated
+@Tag(name = "Janelas de Atendimento", description = "Gerenciamento de janelas de atendimento")
+public class JanelaAtendimentoController {
+
+    private final JanelaAtendimentoService janelaAtendimentoService;
+
+    public JanelaAtendimentoController(JanelaAtendimentoService janelaAtendimentoService) {
+        this.janelaAtendimentoService = janelaAtendimentoService;
+    }
+
+    @GetMapping
+    @Operation(summary = "Lista janelas de atendimento com filtros de período")
+    public Page<JanelaAtendimentoDTO> listar(@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicio,
+                                             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataFim,
+                                             Pageable pageable) {
+        return janelaAtendimentoService.buscar(dataInicio, dataFim, pageable);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Obtém detalhes de uma janela de atendimento")
+    public JanelaAtendimentoDTO buscarPorId(@PathVariable Long id) {
+        return janelaAtendimentoService.buscarPorId(id);
+    }
+
+    @PostMapping
+    @Operation(summary = "Cria uma nova janela de atendimento")
+    public ResponseEntity<JanelaAtendimentoDTO> criar(@Valid @RequestBody JanelaAtendimentoRequest request) {
+        JanelaAtendimentoDTO criado = janelaAtendimentoService.criar(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Atualiza uma janela de atendimento")
+    public JanelaAtendimentoDTO atualizar(@PathVariable Long id, @Valid @RequestBody JanelaAtendimentoRequest request) {
+        return janelaAtendimentoService.atualizar(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Remove uma janela de atendimento")
+    public ResponseEntity<Void> remover(@PathVariable Long id) {
+        janelaAtendimentoService.remover(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/AgendamentoRequest.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/AgendamentoRequest.java
@@ -1,0 +1,123 @@
+package br.com.cloudport.servicogate.dto;
+
+import java.time.LocalDateTime;
+import javax.validation.constraints.Future;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class AgendamentoRequest {
+
+    @NotBlank
+    @Size(max = 40)
+    private String codigo;
+
+    @NotBlank
+    private String tipoOperacao;
+
+    @NotBlank
+    private String status;
+
+    @NotNull
+    private Long transportadoraId;
+
+    @NotNull
+    private Long motoristaId;
+
+    @NotNull
+    private Long veiculoId;
+
+    @NotNull
+    private Long janelaAtendimentoId;
+
+    @NotNull
+    @Future(message = "Horário previsto de chegada deve estar no futuro")
+    private LocalDateTime horarioPrevistoChegada;
+
+    @NotNull
+    @Future(message = "Horário previsto de saída deve estar no futuro")
+    private LocalDateTime horarioPrevistoSaida;
+
+    @Size(max = 500)
+    private String observacoes;
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public String getTipoOperacao() {
+        return tipoOperacao;
+    }
+
+    public void setTipoOperacao(String tipoOperacao) {
+        this.tipoOperacao = tipoOperacao;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Long getTransportadoraId() {
+        return transportadoraId;
+    }
+
+    public void setTransportadoraId(Long transportadoraId) {
+        this.transportadoraId = transportadoraId;
+    }
+
+    public Long getMotoristaId() {
+        return motoristaId;
+    }
+
+    public void setMotoristaId(Long motoristaId) {
+        this.motoristaId = motoristaId;
+    }
+
+    public Long getVeiculoId() {
+        return veiculoId;
+    }
+
+    public void setVeiculoId(Long veiculoId) {
+        this.veiculoId = veiculoId;
+    }
+
+    public Long getJanelaAtendimentoId() {
+        return janelaAtendimentoId;
+    }
+
+    public void setJanelaAtendimentoId(Long janelaAtendimentoId) {
+        this.janelaAtendimentoId = janelaAtendimentoId;
+    }
+
+    public LocalDateTime getHorarioPrevistoChegada() {
+        return horarioPrevistoChegada;
+    }
+
+    public void setHorarioPrevistoChegada(LocalDateTime horarioPrevistoChegada) {
+        this.horarioPrevistoChegada = horarioPrevistoChegada;
+    }
+
+    public LocalDateTime getHorarioPrevistoSaida() {
+        return horarioPrevistoSaida;
+    }
+
+    public void setHorarioPrevistoSaida(LocalDateTime horarioPrevistoSaida) {
+        this.horarioPrevistoSaida = horarioPrevistoSaida;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/DocumentoAgendamentoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/DocumentoAgendamentoDTO.java
@@ -6,15 +6,22 @@ public class DocumentoAgendamentoDTO {
     private String tipoDocumento;
     private String numero;
     private String urlDocumento;
+    private String nomeArquivo;
+    private String contentType;
+    private Long tamanhoBytes;
 
     public DocumentoAgendamentoDTO() {
     }
 
-    public DocumentoAgendamentoDTO(Long id, String tipoDocumento, String numero, String urlDocumento) {
+    public DocumentoAgendamentoDTO(Long id, String tipoDocumento, String numero, String urlDocumento,
+                                   String nomeArquivo, String contentType, Long tamanhoBytes) {
         this.id = id;
         this.tipoDocumento = tipoDocumento;
         this.numero = numero;
         this.urlDocumento = urlDocumento;
+        this.nomeArquivo = nomeArquivo;
+        this.contentType = contentType;
+        this.tamanhoBytes = tamanhoBytes;
     }
 
     public Long getId() {
@@ -47,5 +54,29 @@ public class DocumentoAgendamentoDTO {
 
     public void setUrlDocumento(String urlDocumento) {
         this.urlDocumento = urlDocumento;
+    }
+
+    public String getNomeArquivo() {
+        return nomeArquivo;
+    }
+
+    public void setNomeArquivo(String nomeArquivo) {
+        this.nomeArquivo = nomeArquivo;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public Long getTamanhoBytes() {
+        return tamanhoBytes;
+    }
+
+    public void setTamanhoBytes(Long tamanhoBytes) {
+        this.tamanhoBytes = tamanhoBytes;
     }
 }

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/DocumentoUploadRequest.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/DocumentoUploadRequest.java
@@ -1,0 +1,30 @@
+package br.com.cloudport.servicogate.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public class DocumentoUploadRequest {
+
+    @NotBlank
+    @Size(max = 80)
+    private String tipoDocumento;
+
+    @Size(max = 80)
+    private String numero;
+
+    public String getTipoDocumento() {
+        return tipoDocumento;
+    }
+
+    public void setTipoDocumento(String tipoDocumento) {
+        this.tipoDocumento = tipoDocumento;
+    }
+
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/JanelaAtendimentoRequest.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/JanelaAtendimentoRequest.java
@@ -1,0 +1,66 @@
+package br.com.cloudport.servicogate.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public class JanelaAtendimentoRequest {
+
+    @NotNull
+    private LocalDate data;
+
+    @NotNull
+    private LocalTime horaInicio;
+
+    @NotNull
+    private LocalTime horaFim;
+
+    @NotNull
+    @Min(1)
+    private Integer capacidade;
+
+    @NotBlank
+    private String canalEntrada;
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
+    }
+
+    public LocalTime getHoraInicio() {
+        return horaInicio;
+    }
+
+    public void setHoraInicio(LocalTime horaInicio) {
+        this.horaInicio = horaInicio;
+    }
+
+    public LocalTime getHoraFim() {
+        return horaFim;
+    }
+
+    public void setHoraFim(LocalTime horaFim) {
+        this.horaFim = horaFim;
+    }
+
+    public Integer getCapacidade() {
+        return capacidade;
+    }
+
+    public void setCapacidade(Integer capacidade) {
+        this.capacidade = capacidade;
+    }
+
+    public String getCanalEntrada() {
+        return canalEntrada;
+    }
+
+    public void setCanalEntrada(String canalEntrada) {
+        this.canalEntrada = canalEntrada;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/mapper/GateMapper.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/mapper/GateMapper.java
@@ -90,7 +90,10 @@ public final class GateMapper {
                 entity.getId(),
                 entity.getTipoDocumento(),
                 entity.getNumero(),
-                entity.getUrlDocumento()
+                entity.getUrlDocumento(),
+                entity.getNomeArquivo(),
+                entity.getContentType(),
+                entity.getTamanhoBytes()
         );
     }
 

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/exception/ApiError.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/exception/ApiError.java
@@ -1,0 +1,35 @@
+package br.com.cloudport.servicogate.exception;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class ApiError {
+
+    private final OffsetDateTime timestamp;
+    private final int status;
+    private final String message;
+    private final List<String> errors;
+
+    public ApiError(int status, String message, List<String> errors) {
+        this.timestamp = OffsetDateTime.now();
+        this.status = status;
+        this.message = message;
+        this.errors = errors;
+    }
+
+    public OffsetDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/exception/BusinessException.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/exception/BusinessException.java
@@ -1,0 +1,12 @@
+package br.com.cloudport.servicogate.exception;
+
+public class BusinessException extends RuntimeException {
+
+    public BusinessException(String message) {
+        super(message);
+    }
+
+    public BusinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/exception/GlobalExceptionHandler.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/exception/GlobalExceptionHandler.java
@@ -1,0 +1,58 @@
+package br.com.cloudport.servicogate.exception;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ApiError> handleNotFound(NotFoundException ex) {
+        ApiError apiError = new ApiError(HttpStatus.NOT_FOUND.value(), ex.getMessage(), Collections.emptyList());
+        return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiError> handleBusiness(BusinessException ex) {
+        ApiError apiError = new ApiError(HttpStatus.UNPROCESSABLE_ENTITY.value(), ex.getMessage(), Collections.emptyList());
+        return new ResponseEntity<>(apiError, HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiError> handleConstraintViolation(ConstraintViolationException ex) {
+        List<String> errors = ex.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.toList());
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST.value(), "Erro de validação", errors);
+        return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatus status,
+                                                                  WebRequest request) {
+        BindingResult bindingResult = ex.getBindingResult();
+        List<String> errors = bindingResult.getFieldErrors().stream()
+                .map(this::formatFieldError)
+                .collect(Collectors.toList());
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST.value(), "Erro de validação", errors);
+        return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
+    }
+
+    private String formatFieldError(FieldError error) {
+        return error.getField() + ": " + error.getDefaultMessage();
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/exception/NotFoundException.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package br.com.cloudport.servicogate.exception;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/DocumentoAgendamento.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/DocumentoAgendamento.java
@@ -27,6 +27,15 @@ public class DocumentoAgendamento extends AbstractAuditableEntity {
     @Column(name = "url_documento", length = 255)
     private String urlDocumento;
 
+    @Column(name = "nome_arquivo", length = 255)
+    private String nomeArquivo;
+
+    @Column(name = "content_type", length = 120)
+    private String contentType;
+
+    @Column(name = "tamanho_bytes")
+    private Long tamanhoBytes;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "agendamento_id", nullable = false)
     private Agendamento agendamento;
@@ -61,6 +70,30 @@ public class DocumentoAgendamento extends AbstractAuditableEntity {
 
     public void setUrlDocumento(String urlDocumento) {
         this.urlDocumento = urlDocumento;
+    }
+
+    public String getNomeArquivo() {
+        return nomeArquivo;
+    }
+
+    public void setNomeArquivo(String nomeArquivo) {
+        this.nomeArquivo = nomeArquivo;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public Long getTamanhoBytes() {
+        return tamanhoBytes;
+    }
+
+    public void setTamanhoBytes(Long tamanhoBytes) {
+        this.tamanhoBytes = tamanhoBytes;
     }
 
     public Agendamento getAgendamento() {

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
@@ -6,6 +6,8 @@ import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,6 +19,19 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
     List<Agendamento> findByStatus(StatusAgendamento status);
 
     List<Agendamento> findByJanelaAtendimentoData(LocalDate data);
+
+    Page<Agendamento> findByJanelaAtendimentoData(LocalDate data, Pageable pageable);
+
+    Page<Agendamento> findByJanelaAtendimentoDataBetween(LocalDate inicio, LocalDate fim, Pageable pageable);
+
+    Page<Agendamento> findByJanelaAtendimentoDataGreaterThanEqual(LocalDate inicio, Pageable pageable);
+
+    Page<Agendamento> findByJanelaAtendimentoDataLessThanEqual(LocalDate fim, Pageable pageable);
+
+    long countByJanelaAtendimentoIdAndStatusNot(Long janelaAtendimentoId, StatusAgendamento status);
+
+    long countByJanelaAtendimentoIdAndStatusNotAndIdNot(Long janelaAtendimentoId, StatusAgendamento status,
+                                                        Long id);
 
     @Query("SELECT new br.com.cloudport.servicogate.dto.dashboard.OcupacaoPorHoraDTO(" +
             "j.horaInicio, " +

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/JanelaAtendimentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/JanelaAtendimentoRepository.java
@@ -3,9 +3,19 @@ package br.com.cloudport.servicogate.repository;
 import br.com.cloudport.servicogate.model.JanelaAtendimento;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JanelaAtendimentoRepository extends JpaRepository<JanelaAtendimento, Long> {
 
     List<JanelaAtendimento> findByDataOrderByHoraInicio(LocalDate data);
+
+    Page<JanelaAtendimento> findByData(LocalDate data, Pageable pageable);
+
+    Page<JanelaAtendimento> findByDataBetween(LocalDate inicio, LocalDate fim, Pageable pageable);
+
+    Page<JanelaAtendimento> findByDataGreaterThanEqual(LocalDate inicio, Pageable pageable);
+
+    Page<JanelaAtendimento> findByDataLessThanEqual(LocalDate fim, Pageable pageable);
 }

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/AgendamentoService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/AgendamentoService.java
@@ -1,0 +1,318 @@
+package br.com.cloudport.servicogate.service;
+
+import br.com.cloudport.servicogate.config.AgendamentoRulesProperties;
+import br.com.cloudport.servicogate.dto.AgendamentoDTO;
+import br.com.cloudport.servicogate.dto.AgendamentoRequest;
+import br.com.cloudport.servicogate.dto.DocumentoAgendamentoDTO;
+import br.com.cloudport.servicogate.dto.DocumentoUploadRequest;
+import br.com.cloudport.servicogate.dto.mapper.GateMapper;
+import br.com.cloudport.servicogate.exception.BusinessException;
+import br.com.cloudport.servicogate.exception.NotFoundException;
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.DocumentoAgendamento;
+import br.com.cloudport.servicogate.model.JanelaAtendimento;
+import br.com.cloudport.servicogate.model.Motorista;
+import br.com.cloudport.servicogate.model.Transportadora;
+import br.com.cloudport.servicogate.model.Veiculo;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import br.com.cloudport.servicogate.repository.AgendamentoRepository;
+import br.com.cloudport.servicogate.repository.DocumentoAgendamentoRepository;
+import br.com.cloudport.servicogate.repository.JanelaAtendimentoRepository;
+import br.com.cloudport.servicogate.repository.MotoristaRepository;
+import br.com.cloudport.servicogate.repository.TransportadoraRepository;
+import br.com.cloudport.servicogate.repository.VeiculoRepository;
+import br.com.cloudport.servicogate.storage.DocumentoStorageService;
+import br.com.cloudport.servicogate.storage.StoredDocumento;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Transactional
+public class AgendamentoService {
+
+    private final AgendamentoRepository agendamentoRepository;
+    private final JanelaAtendimentoRepository janelaAtendimentoRepository;
+    private final TransportadoraRepository transportadoraRepository;
+    private final MotoristaRepository motoristaRepository;
+    private final VeiculoRepository veiculoRepository;
+    private final DocumentoAgendamentoRepository documentoAgendamentoRepository;
+    private final DocumentoStorageService documentoStorageService;
+    private final AgendamentoRulesProperties rulesProperties;
+
+    public AgendamentoService(AgendamentoRepository agendamentoRepository,
+                              JanelaAtendimentoRepository janelaAtendimentoRepository,
+                              TransportadoraRepository transportadoraRepository,
+                              MotoristaRepository motoristaRepository,
+                              VeiculoRepository veiculoRepository,
+                              DocumentoAgendamentoRepository documentoAgendamentoRepository,
+                              DocumentoStorageService documentoStorageService,
+                              AgendamentoRulesProperties rulesProperties) {
+        this.agendamentoRepository = agendamentoRepository;
+        this.janelaAtendimentoRepository = janelaAtendimentoRepository;
+        this.transportadoraRepository = transportadoraRepository;
+        this.motoristaRepository = motoristaRepository;
+        this.veiculoRepository = veiculoRepository;
+        this.documentoAgendamentoRepository = documentoAgendamentoRepository;
+        this.documentoStorageService = documentoStorageService;
+        this.rulesProperties = rulesProperties;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AgendamentoDTO> buscar(LocalDate dataInicio, LocalDate dataFim, Pageable pageable) {
+        Page<Agendamento> page;
+        if (dataInicio != null && dataFim != null) {
+            page = agendamentoRepository.findByJanelaAtendimentoDataBetween(dataInicio, dataFim, pageable);
+        } else if (dataInicio != null) {
+            page = agendamentoRepository.findByJanelaAtendimentoDataGreaterThanEqual(dataInicio, pageable);
+        } else if (dataFim != null) {
+            page = agendamentoRepository.findByJanelaAtendimentoDataLessThanEqual(dataFim, pageable);
+        } else {
+            page = agendamentoRepository.findAll(pageable);
+        }
+        return page.map(GateMapper::toAgendamentoDTO);
+    }
+
+    @Transactional(readOnly = true)
+    public AgendamentoDTO buscarPorId(Long id) {
+        Agendamento agendamento = obterAgendamento(id);
+        return GateMapper.toAgendamentoDTO(agendamento);
+    }
+
+    public AgendamentoDTO criar(AgendamentoRequest request) {
+        validarCodigoUnico(null, request.getCodigo());
+        JanelaAtendimento janela = buscarJanela(request.getJanelaAtendimentoId());
+        validarCapacidade(janela, null);
+        validarRegrasDeHorario(janela, request.getHorarioPrevistoChegada());
+        validarIntervaloPrevisto(request.getHorarioPrevistoChegada(), request.getHorarioPrevistoSaida());
+        if (!horarioDentroDaJanela(janela, request.getHorarioPrevistoChegada())) {
+            throw new BusinessException("Horário previsto de chegada deve estar dentro da janela de atendimento");
+        }
+        if (!horarioDentroDaJanela(janela, request.getHorarioPrevistoSaida())) {
+            throw new BusinessException("Horário previsto de saída deve estar dentro da janela de atendimento");
+        }
+
+        Agendamento agendamento = new Agendamento();
+        aplicarDados(agendamento, request, janela);
+        Agendamento salvo = agendamentoRepository.save(agendamento);
+        return GateMapper.toAgendamentoDTO(salvo);
+    }
+
+    public AgendamentoDTO atualizar(Long id, AgendamentoRequest request) {
+        Agendamento existente = obterAgendamento(id);
+        validarEdicaoPermitida(existente);
+        validarCodigoUnico(id, request.getCodigo());
+
+        JanelaAtendimento janela = buscarJanela(request.getJanelaAtendimentoId());
+        if (!Objects.equals(janela.getId(), existente.getJanelaAtendimento().getId())) {
+            validarCapacidade(janela, id);
+            validarRegrasDeHorario(janela, request.getHorarioPrevistoChegada());
+        } else {
+            validarCapacidade(janela, id);
+        }
+        validarIntervaloPrevisto(request.getHorarioPrevistoChegada(), request.getHorarioPrevistoSaida());
+        if (!horarioDentroDaJanela(janela, request.getHorarioPrevistoChegada())) {
+            throw new BusinessException("Horário previsto de chegada deve estar dentro da janela de atendimento");
+        }
+        if (!horarioDentroDaJanela(janela, request.getHorarioPrevistoSaida())) {
+            throw new BusinessException("Horário previsto de saída deve estar dentro da janela de atendimento");
+        }
+
+        aplicarDados(existente, request, janela);
+        Agendamento salvo = agendamentoRepository.save(existente);
+        return GateMapper.toAgendamentoDTO(salvo);
+    }
+
+    public void cancelar(Long id) {
+        Agendamento agendamento = obterAgendamento(id);
+        validarEdicaoPermitida(agendamento);
+        agendamento.setStatus(StatusAgendamento.CANCELADO);
+        agendamentoRepository.save(agendamento);
+    }
+
+    public DocumentoAgendamentoDTO adicionarDocumento(Long agendamentoId, DocumentoUploadRequest request, MultipartFile arquivo) {
+        Agendamento agendamento = obterAgendamento(agendamentoId);
+        validarEdicaoPermitida(agendamento);
+        StoredDocumento storedDocumento = documentoStorageService.armazenar(agendamentoId, arquivo);
+
+        DocumentoAgendamento documento = new DocumentoAgendamento();
+        documento.setAgendamento(agendamento);
+        documento.setTipoDocumento(request.getTipoDocumento());
+        documento.setNumero(request.getNumero());
+        documento.setUrlDocumento(storedDocumento.getStorageKey());
+        documento.setNomeArquivo(storedDocumento.getNomeOriginal());
+        documento.setContentType(storedDocumento.getContentType());
+        documento.setTamanhoBytes(storedDocumento.getTamanho());
+
+        DocumentoAgendamento salvo = documentoAgendamentoRepository.save(documento);
+        return GateMapper.toDocumentoAgendamentoDTO(salvo);
+    }
+
+    @Transactional(readOnly = true)
+    public DocumentoDownload baixarDocumento(Long agendamentoId, Long documentoId) {
+        Agendamento agendamento = obterAgendamento(agendamentoId);
+        DocumentoAgendamento documento = documentoAgendamentoRepository.findById(documentoId)
+                .orElseThrow(() -> new NotFoundException("Documento não encontrado"));
+        if (!Objects.equals(documento.getAgendamento().getId(), agendamento.getId())) {
+            throw new NotFoundException("Documento não pertence ao agendamento informado");
+        }
+        org.springframework.core.io.Resource resource = documentoStorageService.carregarComoResource(documento.getUrlDocumento());
+        if (!resource.exists()) {
+            throw new NotFoundException("Arquivo do documento não encontrado");
+        }
+        String contentType = documento.getContentType() != null ? documento.getContentType() : determinarContentType(resource);
+        String filename = documento.getNomeArquivo() != null ? documento.getNomeArquivo() : documento.getTipoDocumento();
+        return new DocumentoDownload(resource, filename, contentType);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DocumentoAgendamentoDTO> listarDocumentos(Long agendamentoId) {
+        Agendamento agendamento = obterAgendamento(agendamentoId);
+        return documentoAgendamentoRepository.findByAgendamentoId(agendamento.getId()).stream()
+                .map(GateMapper::toDocumentoAgendamentoDTO)
+                .collect(Collectors.toList());
+    }
+
+    private String determinarContentType(org.springframework.core.io.Resource resource) {
+        try {
+            if (resource.isFile()) {
+                Path path = resource.getFile().toPath();
+                return Files.probeContentType(path);
+            }
+        } catch (Exception ignored) {
+        }
+        return "application/octet-stream";
+    }
+
+    private void aplicarDados(Agendamento agendamento, AgendamentoRequest request, JanelaAtendimento janela) {
+        agendamento.setCodigo(request.getCodigo());
+        agendamento.setTipoOperacao(parseTipoOperacao(request.getTipoOperacao()));
+        agendamento.setStatus(parseStatus(request.getStatus()));
+        agendamento.setTransportadora(buscarTransportadora(request.getTransportadoraId()));
+        agendamento.setMotorista(buscarMotorista(request.getMotoristaId()));
+        agendamento.setVeiculo(buscarVeiculo(request.getVeiculoId()));
+        agendamento.setJanelaAtendimento(janela);
+        agendamento.setHorarioPrevistoChegada(request.getHorarioPrevistoChegada());
+        agendamento.setHorarioPrevistoSaida(request.getHorarioPrevistoSaida());
+        agendamento.setObservacoes(request.getObservacoes());
+    }
+
+    private void validarCodigoUnico(Long id, String codigo) {
+        agendamentoRepository.findByCodigo(codigo).ifPresent(existing -> {
+            if (id == null || !existing.getId().equals(id)) {
+                throw new BusinessException("Código de agendamento já utilizado");
+            }
+        });
+    }
+
+    private void validarCapacidade(JanelaAtendimento janela, Long agendamentoId) {
+        long ocupacao;
+        if (agendamentoId == null) {
+            ocupacao = agendamentoRepository.countByJanelaAtendimentoIdAndStatusNot(janela.getId(), StatusAgendamento.CANCELADO);
+        } else {
+            ocupacao = agendamentoRepository.countByJanelaAtendimentoIdAndStatusNotAndIdNot(janela.getId(), StatusAgendamento.CANCELADO, agendamentoId);
+        }
+        if (ocupacao >= janela.getCapacidade()) {
+            throw new BusinessException("Capacidade da janela atingida");
+        }
+    }
+
+    private void validarRegrasDeHorario(JanelaAtendimento janela, LocalDateTime horarioPrevistoChegada) {
+        LocalDateTime inicioJanela = LocalDateTime.of(janela.getData(), janela.getHoraInicio());
+        LocalDateTime limiteCriacao = inicioJanela.minus(rulesProperties.getAntecedenciaMinima());
+        LocalDateTime limiteAtraso = inicioJanela.plus(rulesProperties.getAtrasoMaximo());
+        LocalDateTime agora = LocalDateTime.now();
+        if (agora.isAfter(limiteCriacao)) {
+            throw new BusinessException("Agendamento deve ser criado com antecedência mínima de "
+                    + rulesProperties.getAntecedenciaMinima().toHours() + " horas");
+        }
+        if (agora.isAfter(limiteAtraso)) {
+            throw new BusinessException("Prazo para criação do agendamento expirou");
+        }
+        if (!horarioDentroDaJanela(janela, horarioPrevistoChegada)) {
+            throw new BusinessException("Horário previsto de chegada deve estar dentro da janela de atendimento");
+        }
+    }
+
+    private void validarIntervaloPrevisto(LocalDateTime chegada, LocalDateTime saida) {
+        if (saida.isBefore(chegada) || saida.equals(chegada)) {
+            throw new BusinessException("Horário previsto de saída deve ser posterior ao horário de chegada");
+        }
+    }
+
+    private boolean horarioDentroDaJanela(JanelaAtendimento janela, LocalDateTime horario) {
+        LocalDateTime inicio = LocalDateTime.of(janela.getData(), janela.getHoraInicio());
+        LocalDateTime fim = LocalDateTime.of(janela.getData(), janela.getHoraFim());
+        return (horario.isAfter(inicio) || horario.isEqual(inicio))
+                && (horario.isBefore(fim) || horario.isEqual(fim));
+    }
+
+    private void validarEdicaoPermitida(Agendamento agendamento) {
+        JanelaAtendimento janela = agendamento.getJanelaAtendimento();
+        LocalDateTime inicio = LocalDateTime.of(janela.getData(), janela.getHoraInicio());
+        LocalDateTime limiteAnterior = inicio.minus(rulesProperties.getEdicaoAntecedencia());
+        LocalDateTime limitePosterior = inicio.plus(rulesProperties.getEdicaoAtraso());
+        LocalDateTime agora = LocalDateTime.now();
+        if (agora.isBefore(limiteAnterior) || agora.isAfter(limitePosterior)) {
+            throw new BusinessException("Edição bloqueada para esta janela de atendimento");
+        }
+    }
+
+    private Agendamento obterAgendamento(Long id) {
+        return agendamentoRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Agendamento não encontrado"));
+    }
+
+    private JanelaAtendimento buscarJanela(Long id) {
+        return janelaAtendimentoRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Janela de atendimento não encontrada"));
+    }
+
+    private Transportadora buscarTransportadora(Long id) {
+        return transportadoraRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Transportadora não encontrada"));
+    }
+
+    private Motorista buscarMotorista(Long id) {
+        return motoristaRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Motorista não encontrado"));
+    }
+
+    private Veiculo buscarVeiculo(Long id) {
+        return veiculoRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Veículo não encontrado"));
+    }
+
+    private TipoOperacao parseTipoOperacao(String tipoOperacao) {
+        try {
+            String normalized = tipoOperacao.trim().toUpperCase(Locale.ROOT)
+                    .replace('-', '_')
+                    .replace(' ', '_');
+            return TipoOperacao.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException("Tipo de operação inválido: " + tipoOperacao);
+        }
+    }
+
+    private StatusAgendamento parseStatus(String status) {
+        try {
+            String normalized = status.trim().toUpperCase(Locale.ROOT)
+                    .replace('-', '_')
+                    .replace(' ', '_');
+            return StatusAgendamento.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException("Status de agendamento inválido: " + status);
+        }
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/DocumentoDownload.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/DocumentoDownload.java
@@ -1,0 +1,28 @@
+package br.com.cloudport.servicogate.service;
+
+import org.springframework.core.io.Resource;
+
+public class DocumentoDownload {
+
+    private final Resource resource;
+    private final String filename;
+    private final String contentType;
+
+    public DocumentoDownload(Resource resource, String filename, String contentType) {
+        this.resource = resource;
+        this.filename = filename;
+        this.contentType = contentType != null ? contentType : "application/octet-stream";
+    }
+
+    public Resource getResource() {
+        return resource;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/JanelaAtendimentoService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/JanelaAtendimentoService.java
@@ -1,0 +1,97 @@
+package br.com.cloudport.servicogate.service;
+
+import br.com.cloudport.servicogate.dto.JanelaAtendimentoDTO;
+import br.com.cloudport.servicogate.dto.JanelaAtendimentoRequest;
+import br.com.cloudport.servicogate.dto.mapper.GateMapper;
+import br.com.cloudport.servicogate.exception.BusinessException;
+import br.com.cloudport.servicogate.exception.NotFoundException;
+import br.com.cloudport.servicogate.model.JanelaAtendimento;
+import br.com.cloudport.servicogate.model.enums.CanalEntrada;
+import br.com.cloudport.servicogate.repository.JanelaAtendimentoRepository;
+import java.time.LocalDate;
+import java.util.Locale;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class JanelaAtendimentoService {
+
+    private final JanelaAtendimentoRepository janelaAtendimentoRepository;
+
+    public JanelaAtendimentoService(JanelaAtendimentoRepository janelaAtendimentoRepository) {
+        this.janelaAtendimentoRepository = janelaAtendimentoRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<JanelaAtendimentoDTO> buscar(LocalDate dataInicio, LocalDate dataFim, Pageable pageable) {
+        Page<JanelaAtendimento> page;
+        if (dataInicio != null && dataFim != null) {
+            page = janelaAtendimentoRepository.findByDataBetween(dataInicio, dataFim, pageable);
+        } else if (dataInicio != null) {
+            page = janelaAtendimentoRepository.findByDataGreaterThanEqual(dataInicio, pageable);
+        } else if (dataFim != null) {
+            page = janelaAtendimentoRepository.findByDataLessThanEqual(dataFim, pageable);
+        } else {
+            page = janelaAtendimentoRepository.findAll(pageable);
+        }
+        return page.map(GateMapper::toJanelaAtendimentoDTO);
+    }
+
+    @Transactional(readOnly = true)
+    public JanelaAtendimentoDTO buscarPorId(Long id) {
+        JanelaAtendimento janela = janelaAtendimentoRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Janela de atendimento não encontrada"));
+        return GateMapper.toJanelaAtendimentoDTO(janela);
+    }
+
+    public JanelaAtendimentoDTO criar(JanelaAtendimentoRequest request) {
+        validarIntervaloHorarios(request);
+        JanelaAtendimento janela = new JanelaAtendimento();
+        aplicarDados(janela, request);
+        JanelaAtendimento salvo = janelaAtendimentoRepository.save(janela);
+        return GateMapper.toJanelaAtendimentoDTO(salvo);
+    }
+
+    public JanelaAtendimentoDTO atualizar(Long id, JanelaAtendimentoRequest request) {
+        validarIntervaloHorarios(request);
+        JanelaAtendimento existente = janelaAtendimentoRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Janela de atendimento não encontrada"));
+        aplicarDados(existente, request);
+        JanelaAtendimento salvo = janelaAtendimentoRepository.save(existente);
+        return GateMapper.toJanelaAtendimentoDTO(salvo);
+    }
+
+    public void remover(Long id) {
+        JanelaAtendimento existente = janelaAtendimentoRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Janela de atendimento não encontrada"));
+        janelaAtendimentoRepository.delete(existente);
+    }
+
+    private void validarIntervaloHorarios(JanelaAtendimentoRequest request) {
+        if (request.getHoraFim().isBefore(request.getHoraInicio()) || request.getHoraFim().equals(request.getHoraInicio())) {
+            throw new BusinessException("Hora fim deve ser posterior à hora início");
+        }
+    }
+
+    private void aplicarDados(JanelaAtendimento janela, JanelaAtendimentoRequest request) {
+        janela.setData(request.getData());
+        janela.setHoraInicio(request.getHoraInicio());
+        janela.setHoraFim(request.getHoraFim());
+        janela.setCapacidade(request.getCapacidade());
+        janela.setCanalEntrada(parseCanalEntrada(request.getCanalEntrada()));
+    }
+
+    private CanalEntrada parseCanalEntrada(String canal) {
+        try {
+            String normalized = canal.trim().toUpperCase(Locale.ROOT)
+                    .replace('-', '_')
+                    .replace(' ', '_');
+            return CanalEntrada.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException("Canal de entrada inválido: " + canal);
+        }
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/storage/DocumentoStorageService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/storage/DocumentoStorageService.java
@@ -1,0 +1,11 @@
+package br.com.cloudport.servicogate.storage;
+
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface DocumentoStorageService {
+
+    StoredDocumento armazenar(Long agendamentoId, MultipartFile arquivo);
+
+    Resource carregarComoResource(String storageKey);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/storage/LocalDocumentoStorageService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/storage/LocalDocumentoStorageService.java
@@ -1,0 +1,79 @@
+package br.com.cloudport.servicogate.storage;
+
+import br.com.cloudport.servicogate.config.DocumentoStorageProperties;
+import br.com.cloudport.servicogate.exception.BusinessException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Locale;
+import java.util.UUID;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class LocalDocumentoStorageService implements DocumentoStorageService {
+
+    private final DocumentoStorageProperties properties;
+
+    public LocalDocumentoStorageService(DocumentoStorageProperties properties) {
+        this.properties = properties;
+        if (!"local".equalsIgnoreCase(properties.getProvider())) {
+            throw new BusinessException("Provedor de armazenamento não suportado: " + properties.getProvider());
+        }
+    }
+
+    @Override
+    public StoredDocumento armazenar(Long agendamentoId, MultipartFile arquivo) {
+        try {
+            Path baseDirectory = Paths.get(properties.getBasePath()).toAbsolutePath().normalize();
+            Files.createDirectories(baseDirectory);
+            Path agendamentoDirectory = baseDirectory.resolve(String.valueOf(agendamentoId));
+            Files.createDirectories(agendamentoDirectory);
+
+            String originalFilename = arquivo.getOriginalFilename();
+            String sanitizedExtension = extrairExtensao(originalFilename);
+            String generatedName = UUID.randomUUID() + (sanitizedExtension.isEmpty() ? "" : "." + sanitizedExtension);
+            Path destino = agendamentoDirectory.resolve(generatedName);
+
+            try {
+                Files.copy(arquivo.getInputStream(), destino, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException ioException) {
+                throw new UncheckedIOException(ioException);
+            }
+
+            String storageKey = agendamentoId + "/" + generatedName;
+            String nomeOriginal = StringUtils.hasText(originalFilename) ? originalFilename : generatedName;
+            return new StoredDocumento(storageKey, nomeOriginal, arquivo.getContentType(), arquivo.getSize());
+        } catch (IOException e) {
+            throw new BusinessException("Erro ao armazenar documento de agendamento", e);
+        }
+    }
+
+    @Override
+    public Resource carregarComoResource(String storageKey) {
+        Path baseDirectory = Paths.get(properties.getBasePath()).toAbsolutePath().normalize();
+        Path arquivo = baseDirectory.resolve(storageKey).normalize();
+        if (!arquivo.startsWith(baseDirectory)) {
+            throw new BusinessException("Caminho de documento inválido");
+        }
+        return new FileSystemResource(arquivo);
+    }
+
+    private String extrairExtensao(String originalFilename) {
+        if (!StringUtils.hasText(originalFilename)) {
+            return "";
+        }
+        String sanitized = originalFilename.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9.]+", "-");
+        int lastDot = sanitized.lastIndexOf('.');
+        if (lastDot < 0) {
+            return "";
+        }
+        return sanitized.substring(lastDot + 1);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/storage/StoredDocumento.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/storage/StoredDocumento.java
@@ -1,0 +1,32 @@
+package br.com.cloudport.servicogate.storage;
+
+public class StoredDocumento {
+
+    private final String storageKey;
+    private final String nomeOriginal;
+    private final String contentType;
+    private final long tamanho;
+
+    public StoredDocumento(String storageKey, String nomeOriginal, String contentType, long tamanho) {
+        this.storageKey = storageKey;
+        this.nomeOriginal = nomeOriginal;
+        this.contentType = contentType;
+        this.tamanho = tamanho;
+    }
+
+    public String getStorageKey() {
+        return storageKey;
+    }
+
+    public String getNomeOriginal() {
+        return nomeOriginal;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public long getTamanho() {
+        return tamanho;
+    }
+}

--- a/backend/servico-gate/src/main/resources/application.properties
+++ b/backend/servico-gate/src/main/resources/application.properties
@@ -31,6 +31,11 @@ cloudport.document-storage.provider=${DOCUMENT_STORAGE_PROVIDER:local}
 cloudport.document-storage.base-path=${DOCUMENT_STORAGE_BASE_PATH:/var/lib/cloudport/documents}
 cloudport.document-storage.bucket=${DOCUMENT_STORAGE_BUCKET:cloudport-documents}
 
+cloudport.gate.agendamento.rules.antecedencia-minima=${AGENDAMENTO_ANTECEDENCIA_MINIMA:PT2H}
+cloudport.gate.agendamento.rules.atraso-maximo=${AGENDAMENTO_ATRASO_MAXIMO:PT1H}
+cloudport.gate.agendamento.rules.edicao-antecedencia=${AGENDAMENTO_EDICAO_ANTECEDENCIA:PT12H}
+cloudport.gate.agendamento.rules.edicao-atraso=${AGENDAMENTO_EDICAO_ATRASO:PT2H}
+
 # Resilience4j
 resilience4j.circuitbreaker.instances.tosApi.register-health-indicator=true
 resilience4j.circuitbreaker.instances.tosApi.sliding-window-size=${RESILIENCE4J_TOS_WINDOW_SIZE:10}


### PR DESCRIPTION
## Summary
- implement new agendamento and janela controllers with CRUD, filtering and validation using dedicated request DTOs
- add service layer rules covering capacity, time windows and document handling backed by local storage metadata
- expose configuration enums, OpenAPI metadata and a global error handler while wiring new scheduling rule properties

## Testing
- mvn -q test *(fails: unable to download Spring Boot parent due to 403 from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e91668c4f08327ade1de86bbdbcf4b