### PR TITLE
docs: detalha filtros e paginação nas rotas de gate

### DIFF
--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/AgendamentoController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/AgendamentoController.java
@@ -7,10 +7,12 @@ import br.com.cloudport.servicogate.dto.DocumentoUploadRequest;
 import br.com.cloudport.servicogate.service.AgendamentoService;
 import br.com.cloudport.servicogate.service.DocumentoDownload;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
 import javax.validation.Valid;
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -45,9 +47,11 @@ public class AgendamentoController {
 
     @GetMapping
     @Operation(summary = "Lista agendamentos com filtros de período e paginação")
-    public Page<AgendamentoDTO> listar(@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicio,
+    public Page<AgendamentoDTO> listar(@Parameter(description = "Data inicial do período (inclusive)")
+                                       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicio,
+                                       @Parameter(description = "Data final do período (inclusive)")
                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataFim,
-                                       Pageable pageable) {
+                                       @ParameterObject Pageable pageable) {
         return agendamentoService.buscar(dataInicio, dataFim, pageable);
     }
 

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/JanelaAtendimentoController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/JanelaAtendimentoController.java
@@ -4,9 +4,11 @@ import br.com.cloudport.servicogate.dto.JanelaAtendimentoDTO;
 import br.com.cloudport.servicogate.dto.JanelaAtendimentoRequest;
 import br.com.cloudport.servicogate.service.JanelaAtendimentoService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import javax.validation.Valid;
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -37,9 +39,11 @@ public class JanelaAtendimentoController {
 
     @GetMapping
     @Operation(summary = "Lista janelas de atendimento com filtros de período")
-    public Page<JanelaAtendimentoDTO> listar(@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicio,
+    public Page<JanelaAtendimentoDTO> listar(@Parameter(description = "Data inicial do período (inclusive)")
+                                             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicio,
+                                             @Parameter(description = "Data final do período (inclusive)")
                                              @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataFim,
-                                             Pageable pageable) {
+                                             @ParameterObject Pageable pageable) {
         return janelaAtendimentoService.buscar(dataInicio, dataFim, pageable);
     }
 


### PR DESCRIPTION
## Sumário
- Documenta os filtros de período e a paginação nas listagens de agendamentos e janelas de atendimento.
- Adiciona suporte do SpringDoc para parametrização de Pageable nas rotas de consulta.

## Testes
- ⚠️ `./mvnw -q -DskipTests=false test` (wrapper sem dependências locais)
- ⚠️ `mvn -q -DskipTests=false test` (falha por bloqueio de acesso ao Maven Central)


------
https://chatgpt.com/codex/tasks/task_e_68e9a6e3e50c83278345d8e1f0f617e9