### PR TITLE
Implementa fluxo de gate com integrações de hardware

### DIFF
--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/GateFlowProperties.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/GateFlowProperties.java
@@ -1,0 +1,56 @@
+package br.com.cloudport.servicogate.config;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloudport.gate.flow")
+public class GateFlowProperties {
+
+    private Duration toleranciaEntradaAntecipada = Duration.ofMinutes(30);
+    private Duration toleranciaEntradaAtraso = Duration.ofMinutes(30);
+    private Duration toleranciaSaidaAntecipada = Duration.ofMinutes(30);
+    private Duration toleranciaSaidaAtraso = Duration.ofMinutes(30);
+    private List<String> rolesLiberacaoManual = new ArrayList<>();
+
+    public Duration getToleranciaEntradaAntecipada() {
+        return toleranciaEntradaAntecipada;
+    }
+
+    public void setToleranciaEntradaAntecipada(Duration toleranciaEntradaAntecipada) {
+        this.toleranciaEntradaAntecipada = toleranciaEntradaAntecipada;
+    }
+
+    public Duration getToleranciaEntradaAtraso() {
+        return toleranciaEntradaAtraso;
+    }
+
+    public void setToleranciaEntradaAtraso(Duration toleranciaEntradaAtraso) {
+        this.toleranciaEntradaAtraso = toleranciaEntradaAtraso;
+    }
+
+    public Duration getToleranciaSaidaAntecipada() {
+        return toleranciaSaidaAntecipada;
+    }
+
+    public void setToleranciaSaidaAntecipada(Duration toleranciaSaidaAntecipada) {
+        this.toleranciaSaidaAntecipada = toleranciaSaidaAntecipada;
+    }
+
+    public Duration getToleranciaSaidaAtraso() {
+        return toleranciaSaidaAtraso;
+    }
+
+    public void setToleranciaSaidaAtraso(Duration toleranciaSaidaAtraso) {
+        this.toleranciaSaidaAtraso = toleranciaSaidaAtraso;
+    }
+
+    public List<String> getRolesLiberacaoManual() {
+        return rolesLiberacaoManual;
+    }
+
+    public void setRolesLiberacaoManual(List<String> rolesLiberacaoManual) {
+        this.rolesLiberacaoManual = rolesLiberacaoManual;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/HardwareIntegrationProperties.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/HardwareIntegrationProperties.java
@@ -1,0 +1,53 @@
+package br.com.cloudport.servicogate.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloudport.gate.hardware")
+public class HardwareIntegrationProperties {
+
+    private String entradaQueue = "gate.hardware.entrada";
+    private String saidaQueue = "gate.hardware.saida";
+    private String decisaoExchange = "gate.hardware.decisao";
+    private String decisaoRoutingEntrada = "gate.hardware.decisao.entrada";
+    private String decisaoRoutingSaida = "gate.hardware.decisao.saida";
+
+    public String getEntradaQueue() {
+        return entradaQueue;
+    }
+
+    public void setEntradaQueue(String entradaQueue) {
+        this.entradaQueue = entradaQueue;
+    }
+
+    public String getSaidaQueue() {
+        return saidaQueue;
+    }
+
+    public void setSaidaQueue(String saidaQueue) {
+        this.saidaQueue = saidaQueue;
+    }
+
+    public String getDecisaoExchange() {
+        return decisaoExchange;
+    }
+
+    public void setDecisaoExchange(String decisaoExchange) {
+        this.decisaoExchange = decisaoExchange;
+    }
+
+    public String getDecisaoRoutingEntrada() {
+        return decisaoRoutingEntrada;
+    }
+
+    public void setDecisaoRoutingEntrada(String decisaoRoutingEntrada) {
+        this.decisaoRoutingEntrada = decisaoRoutingEntrada;
+    }
+
+    public String getDecisaoRoutingSaida() {
+        return decisaoRoutingSaida;
+    }
+
+    public void setDecisaoRoutingSaida(String decisaoRoutingSaida) {
+        this.decisaoRoutingSaida = decisaoRoutingSaida;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/OpenApiConfig.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/OpenApiConfig.java
@@ -10,7 +10,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @Configuration
-@EnableConfigurationProperties({AgendamentoRulesProperties.class, DocumentoStorageProperties.class})
+@EnableConfigurationProperties({
+        AgendamentoRulesProperties.class,
+        DocumentoStorageProperties.class,
+        GateFlowProperties.class,
+        HardwareIntegrationProperties.class
+})
 public class OpenApiConfig {
 
     @Bean

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/GateFlowController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/GateFlowController.java
@@ -1,0 +1,50 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.dto.GateDecisionDTO;
+import br.com.cloudport.servicogate.dto.GateEventDTO;
+import br.com.cloudport.servicogate.dto.GateFlowRequest;
+import br.com.cloudport.servicogate.dto.ManualReleaseRequest;
+import br.com.cloudport.servicogate.service.GateFlowService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/gate")
+@Tag(name = "Fluxo de Gate", description = "Processamento de eventos de entrada e saída do gate")
+public class GateFlowController {
+
+    private final GateFlowService gateFlowService;
+
+    public GateFlowController(GateFlowService gateFlowService) {
+        this.gateFlowService = gateFlowService;
+    }
+
+    @PostMapping("/entrada")
+    @Operation(summary = "Processa um evento de entrada identificado por placa ou QR code")
+    public ResponseEntity<GateDecisionDTO> registrarEntrada(@Valid @RequestBody GateFlowRequest request) {
+        GateDecisionDTO decision = gateFlowService.registrarEntrada(request);
+        return ResponseEntity.ok(decision);
+    }
+
+    @PostMapping("/saida")
+    @Operation(summary = "Processa um evento de saída identificado por placa ou QR code")
+    public ResponseEntity<GateDecisionDTO> registrarSaida(@Valid @RequestBody GateFlowRequest request) {
+        GateDecisionDTO decision = gateFlowService.registrarSaida(request);
+        return ResponseEntity.ok(decision);
+    }
+
+    @PostMapping("/agendamentos/{id}/liberacao-manual")
+    @Operation(summary = "Registra liberação ou bloqueio manual para um agendamento")
+    public ResponseEntity<GateEventDTO> liberarManual(@PathVariable("id") Long agendamentoId,
+                                                      @Valid @RequestBody ManualReleaseRequest request) {
+        GateEventDTO evento = gateFlowService.liberarManual(agendamentoId, request);
+        return ResponseEntity.ok(evento);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/GateDecisionDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/GateDecisionDTO.java
@@ -1,0 +1,116 @@
+package br.com.cloudport.servicogate.dto;
+
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.GatePass;
+import br.com.cloudport.servicogate.model.enums.StatusGate;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GateDecisionDTO {
+
+    private boolean autorizado;
+    private String statusGate;
+    private String statusDescricao;
+    private Long agendamentoId;
+    private String codigoAgendamento;
+    private Long gatePassId;
+    private String codigoGatePass;
+    private String mensagem;
+
+    public static GateDecisionDTO autorizado(StatusGate status, Agendamento agendamento, GatePass gatePass,
+                                             String mensagem) {
+        GateDecisionDTO dto = new GateDecisionDTO();
+        dto.setAutorizado(true);
+        dto.preencherContexto(status, agendamento, gatePass);
+        dto.setMensagem(mensagem);
+        return dto;
+    }
+
+    public static GateDecisionDTO negado(StatusGate status, Agendamento agendamento, GatePass gatePass,
+                                         String mensagem) {
+        GateDecisionDTO dto = new GateDecisionDTO();
+        dto.setAutorizado(false);
+        dto.preencherContexto(status, agendamento, gatePass);
+        dto.setMensagem(mensagem);
+        return dto;
+    }
+
+    private void preencherContexto(StatusGate status, Agendamento agendamento, GatePass gatePass) {
+        if (status != null) {
+            this.statusGate = status.name();
+            this.statusDescricao = status.getDescricao();
+        }
+        if (agendamento != null) {
+            this.agendamentoId = agendamento.getId();
+            this.codigoAgendamento = agendamento.getCodigo();
+        }
+        if (gatePass != null) {
+            this.gatePassId = gatePass.getId();
+            this.codigoGatePass = gatePass.getCodigo();
+        }
+    }
+
+    public boolean isAutorizado() {
+        return autorizado;
+    }
+
+    public void setAutorizado(boolean autorizado) {
+        this.autorizado = autorizado;
+    }
+
+    public String getStatusGate() {
+        return statusGate;
+    }
+
+    public void setStatusGate(String statusGate) {
+        this.statusGate = statusGate;
+    }
+
+    public String getStatusDescricao() {
+        return statusDescricao;
+    }
+
+    public void setStatusDescricao(String statusDescricao) {
+        this.statusDescricao = statusDescricao;
+    }
+
+    public Long getAgendamentoId() {
+        return agendamentoId;
+    }
+
+    public void setAgendamentoId(Long agendamentoId) {
+        this.agendamentoId = agendamentoId;
+    }
+
+    public String getCodigoAgendamento() {
+        return codigoAgendamento;
+    }
+
+    public void setCodigoAgendamento(String codigoAgendamento) {
+        this.codigoAgendamento = codigoAgendamento;
+    }
+
+    public Long getGatePassId() {
+        return gatePassId;
+    }
+
+    public void setGatePassId(Long gatePassId) {
+        this.gatePassId = gatePassId;
+    }
+
+    public String getCodigoGatePass() {
+        return codigoGatePass;
+    }
+
+    public void setCodigoGatePass(String codigoGatePass) {
+        this.codigoGatePass = codigoGatePass;
+    }
+
+    public String getMensagem() {
+        return mensagem;
+    }
+
+    public void setMensagem(String mensagem) {
+        this.mensagem = mensagem;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/GateFlowRequest.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/GateFlowRequest.java
@@ -1,0 +1,52 @@
+package br.com.cloudport.servicogate.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import javax.validation.constraints.Size;
+
+public class GateFlowRequest {
+
+    @Size(max = 10)
+    private String placa;
+
+    @Size(max = 120)
+    private String qrCode;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime timestamp;
+
+    @Size(max = 80)
+    private String operador;
+
+    public String getPlaca() {
+        return placa;
+    }
+
+    public void setPlaca(String placa) {
+        this.placa = placa;
+    }
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public void setQrCode(String qrCode) {
+        this.qrCode = qrCode;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getOperador() {
+        return operador;
+    }
+
+    public void setOperador(String operador) {
+        this.operador = operador;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/ManualReleaseAction.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/ManualReleaseAction.java
@@ -1,0 +1,6 @@
+package br.com.cloudport.servicogate.dto;
+
+public enum ManualReleaseAction {
+    LIBERAR,
+    BLOQUEAR
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/ManualReleaseRequest.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/ManualReleaseRequest.java
@@ -1,0 +1,51 @@
+package br.com.cloudport.servicogate.dto;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class ManualReleaseRequest {
+
+    @NotNull
+    private ManualReleaseAction acao;
+
+    @Size(max = 40)
+    private String motivo;
+
+    @Size(max = 500)
+    private String observacao;
+
+    @Size(max = 80)
+    private String operador;
+
+    public ManualReleaseAction getAcao() {
+        return acao;
+    }
+
+    public void setAcao(ManualReleaseAction acao) {
+        this.acao = acao;
+    }
+
+    public String getMotivo() {
+        return motivo;
+    }
+
+    public void setMotivo(String motivo) {
+        this.motivo = motivo;
+    }
+
+    public String getObservacao() {
+        return observacao;
+    }
+
+    public void setObservacao(String observacao) {
+        this.observacao = observacao;
+    }
+
+    public String getOperador() {
+        return operador;
+    }
+
+    public void setOperador(String operador) {
+        this.operador = operador;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/hardware/GateHardwareListener.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/hardware/GateHardwareListener.java
@@ -1,0 +1,77 @@
+package br.com.cloudport.servicogate.integration.hardware;
+
+import br.com.cloudport.servicogate.dto.GateDecisionDTO;
+import br.com.cloudport.servicogate.dto.GateFlowRequest;
+import br.com.cloudport.servicogate.exception.BusinessException;
+import br.com.cloudport.servicogate.exception.NotFoundException;
+import br.com.cloudport.servicogate.model.enums.StatusGate;
+import br.com.cloudport.servicogate.service.GateFlowService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class GateHardwareListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GateHardwareListener.class);
+
+    private final GateFlowService gateFlowService;
+    private final GateHardwarePublisher publisher;
+    private final ObjectMapper objectMapper;
+
+    public GateHardwareListener(GateFlowService gateFlowService,
+                                GateHardwarePublisher publisher,
+                                ObjectMapper objectMapper) {
+        this.gateFlowService = gateFlowService;
+        this.publisher = publisher;
+        this.objectMapper = objectMapper;
+    }
+
+    @RabbitListener(queues = "${cloudport.gate.hardware.entrada-queue}")
+    public void consumirEntrada(@Payload String payload) {
+        processarMensagem(payload, true);
+    }
+
+    @RabbitListener(queues = "${cloudport.gate.hardware.saida-queue}")
+    public void consumirSaida(@Payload String payload) {
+        processarMensagem(payload, false);
+    }
+
+    private void processarMensagem(String payload, boolean entrada) {
+        if (!StringUtils.hasText(payload)) {
+            return;
+        }
+        try {
+            HardwareEventMessage event = objectMapper.readValue(payload, HardwareEventMessage.class);
+            GateFlowRequest request = event.toRequest();
+            GateDecisionDTO decision = entrada
+                    ? gateFlowService.registrarEntrada(request)
+                    : gateFlowService.registrarSaida(request);
+            publicarDecisao(decision, event, entrada);
+        } catch (BusinessException | NotFoundException ex) {
+            LOGGER.warn("Falha ao processar evento de hardware: {}", ex.getMessage());
+            publicarDecisao(GateDecisionDTO.negado(StatusGate.RETIDO, null, null, ex.getMessage()),
+                    criarFallbackEvento(payload), entrada);
+        } catch (Exception ex) {
+            LOGGER.error("Erro inesperado ao processar evento do hardware", ex);
+        }
+    }
+
+    private void publicarDecisao(GateDecisionDTO decision, HardwareEventMessage event, boolean entrada) {
+        if (entrada) {
+            publisher.publicarDecisaoEntrada(decision, event);
+        } else {
+            publisher.publicarDecisaoSaida(decision, event);
+        }
+    }
+
+    private HardwareEventMessage criarFallbackEvento(String payload) {
+        HardwareEventMessage event = new HardwareEventMessage();
+        event.setQrCode(payload);
+        return event;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/hardware/GateHardwarePublisher.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/hardware/GateHardwarePublisher.java
@@ -1,0 +1,46 @@
+package br.com.cloudport.servicogate.integration.hardware;
+
+import br.com.cloudport.servicogate.config.HardwareIntegrationProperties;
+import br.com.cloudport.servicogate.dto.GateDecisionDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GateHardwarePublisher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GateHardwarePublisher.class);
+
+    private final RabbitTemplate rabbitTemplate;
+    private final HardwareIntegrationProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public GateHardwarePublisher(RabbitTemplate rabbitTemplate,
+                                 HardwareIntegrationProperties properties,
+                                 ObjectMapper objectMapper) {
+        this.rabbitTemplate = rabbitTemplate;
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    public void publicarDecisaoEntrada(GateDecisionDTO decision, HardwareEventMessage event) {
+        publicar(decision, event, properties.getDecisaoRoutingEntrada());
+    }
+
+    public void publicarDecisaoSaida(GateDecisionDTO decision, HardwareEventMessage event) {
+        publicar(decision, event, properties.getDecisaoRoutingSaida());
+    }
+
+    private void publicar(GateDecisionDTO decision, HardwareEventMessage event, String routingKey) {
+        HardwareDecisionMessage message = HardwareDecisionMessage.from(decision, event);
+        try {
+            String payload = objectMapper.writeValueAsString(message);
+            rabbitTemplate.convertAndSend(properties.getDecisaoExchange(), routingKey, payload);
+        } catch (JsonProcessingException ex) {
+            LOGGER.error("Falha ao serializar decisão de gate para publicação", ex);
+        }
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/hardware/HardwareDecisionMessage.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/hardware/HardwareDecisionMessage.java
@@ -1,0 +1,152 @@
+package br.com.cloudport.servicogate.integration.hardware;
+
+import br.com.cloudport.servicogate.dto.GateDecisionDTO;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HardwareDecisionMessage implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private boolean autorizado;
+    private String statusGate;
+    private String statusDescricao;
+    private Long agendamentoId;
+    private String codigoAgendamento;
+    private Long gatePassId;
+    private String codigoGatePass;
+    private String mensagem;
+    private String placa;
+    private String qrCode;
+    private LocalDateTime timestamp;
+    private String origem;
+    private String dispositivo;
+
+    public static HardwareDecisionMessage from(GateDecisionDTO decision, HardwareEventMessage event) {
+        HardwareDecisionMessage message = new HardwareDecisionMessage();
+        if (decision != null) {
+            message.setAutorizado(decision.isAutorizado());
+            message.setStatusGate(decision.getStatusGate());
+            message.setStatusDescricao(decision.getStatusDescricao());
+            message.setAgendamentoId(decision.getAgendamentoId());
+            message.setCodigoAgendamento(decision.getCodigoAgendamento());
+            message.setGatePassId(decision.getGatePassId());
+            message.setCodigoGatePass(decision.getCodigoGatePass());
+            message.setMensagem(decision.getMensagem());
+        }
+        if (event != null) {
+            message.setPlaca(event.getPlaca());
+            message.setQrCode(event.getQrCode());
+            message.setTimestamp(event.getTimestamp());
+            message.setOrigem(event.getOrigem());
+            message.setDispositivo(event.getDispositivo());
+        }
+        return message;
+    }
+
+    public boolean isAutorizado() {
+        return autorizado;
+    }
+
+    public void setAutorizado(boolean autorizado) {
+        this.autorizado = autorizado;
+    }
+
+    public String getStatusGate() {
+        return statusGate;
+    }
+
+    public void setStatusGate(String statusGate) {
+        this.statusGate = statusGate;
+    }
+
+    public String getStatusDescricao() {
+        return statusDescricao;
+    }
+
+    public void setStatusDescricao(String statusDescricao) {
+        this.statusDescricao = statusDescricao;
+    }
+
+    public Long getAgendamentoId() {
+        return agendamentoId;
+    }
+
+    public void setAgendamentoId(Long agendamentoId) {
+        this.agendamentoId = agendamentoId;
+    }
+
+    public String getCodigoAgendamento() {
+        return codigoAgendamento;
+    }
+
+    public void setCodigoAgendamento(String codigoAgendamento) {
+        this.codigoAgendamento = codigoAgendamento;
+    }
+
+    public Long getGatePassId() {
+        return gatePassId;
+    }
+
+    public void setGatePassId(Long gatePassId) {
+        this.gatePassId = gatePassId;
+    }
+
+    public String getCodigoGatePass() {
+        return codigoGatePass;
+    }
+
+    public void setCodigoGatePass(String codigoGatePass) {
+        this.codigoGatePass = codigoGatePass;
+    }
+
+    public String getMensagem() {
+        return mensagem;
+    }
+
+    public void setMensagem(String mensagem) {
+        this.mensagem = mensagem;
+    }
+
+    public String getPlaca() {
+        return placa;
+    }
+
+    public void setPlaca(String placa) {
+        this.placa = placa;
+    }
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public void setQrCode(String qrCode) {
+        this.qrCode = qrCode;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getOrigem() {
+        return origem;
+    }
+
+    public void setOrigem(String origem) {
+        this.origem = origem;
+    }
+
+    public String getDispositivo() {
+        return dispositivo;
+    }
+
+    public void setDispositivo(String dispositivo) {
+        this.dispositivo = dispositivo;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/hardware/HardwareEventMessage.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/hardware/HardwareEventMessage.java
@@ -1,0 +1,78 @@
+package br.com.cloudport.servicogate.integration.hardware;
+
+import br.com.cloudport.servicogate.dto.GateFlowRequest;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HardwareEventMessage {
+
+    private String placa;
+    private String qrCode;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime timestamp;
+
+    private String operador;
+    private String origem;
+    private String dispositivo;
+
+    public GateFlowRequest toRequest() {
+        GateFlowRequest request = new GateFlowRequest();
+        request.setPlaca(Optional.ofNullable(placa).map(String::trim).orElse(null));
+        request.setQrCode(Optional.ofNullable(qrCode).map(String::trim).orElse(null));
+        request.setTimestamp(timestamp);
+        request.setOperador(operador);
+        return request;
+    }
+
+    public String getPlaca() {
+        return placa;
+    }
+
+    public void setPlaca(String placa) {
+        this.placa = placa;
+    }
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public void setQrCode(String qrCode) {
+        this.qrCode = qrCode;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getOperador() {
+        return operador;
+    }
+
+    public void setOperador(String operador) {
+        this.operador = operador;
+    }
+
+    public String getOrigem() {
+        return origem;
+    }
+
+    public void setOrigem(String origem) {
+        this.origem = origem;
+    }
+
+    public String getDispositivo() {
+        return dispositivo;
+    }
+
+    public void setDispositivo(String dispositivo) {
+        this.dispositivo = dispositivo;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/StatusAgendamento.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/StatusAgendamento.java
@@ -4,7 +4,10 @@ public enum StatusAgendamento {
     PENDENTE("Pendente"),
     CONFIRMADO("Confirmado"),
     EM_ATENDIMENTO("Em atendimento"),
+    EM_EXECUCAO("Em execução"),
     CONCLUIDO("Concluído"),
+    COMPLETO("Completo"),
+    NO_SHOW("No show"),
     CANCELADO("Cancelado");
 
     private final String descricao;

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
@@ -16,6 +16,10 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
 
     Optional<Agendamento> findByCodigo(String codigo);
 
+    Optional<Agendamento> findFirstByVeiculoPlacaIgnoreCaseAndStatusInOrderByHorarioPrevistoChegadaAsc(
+            String placa,
+            List<StatusAgendamento> status);
+
     List<Agendamento> findByStatus(StatusAgendamento status);
 
     List<Agendamento> findByJanelaAtendimentoData(LocalDate data);

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GatePassRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GatePassRepository.java
@@ -14,6 +14,8 @@ public interface GatePassRepository extends JpaRepository<GatePass, Long> {
 
     List<GatePass> findByStatus(StatusGate status);
 
+    Optional<GatePass> findByAgendamentoId(Long agendamentoId);
+
     @Query(value = "SELECT DATE(gp.data_entrada) AS dia, " +
             "AVG(EXTRACT(EPOCH FROM (gp.data_saida - gp.data_entrada))/60) AS tempoMedioMinutos " +
             "FROM gate_pass gp " +

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateFlowService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateFlowService.java
@@ -1,0 +1,325 @@
+package br.com.cloudport.servicogate.service;
+
+import br.com.cloudport.servicogate.config.GateFlowProperties;
+import br.com.cloudport.servicogate.dto.GateDecisionDTO;
+import br.com.cloudport.servicogate.dto.GateFlowRequest;
+import br.com.cloudport.servicogate.dto.ManualReleaseAction;
+import br.com.cloudport.servicogate.dto.ManualReleaseRequest;
+import br.com.cloudport.servicogate.dto.mapper.GateMapper;
+import br.com.cloudport.servicogate.exception.BusinessException;
+import br.com.cloudport.servicogate.exception.NotFoundException;
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.DocumentoAgendamento;
+import br.com.cloudport.servicogate.model.GateEvent;
+import br.com.cloudport.servicogate.model.GatePass;
+import br.com.cloudport.servicogate.model.enums.MotivoExcecao;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.model.enums.StatusGate;
+import br.com.cloudport.servicogate.repository.AgendamentoRepository;
+import br.com.cloudport.servicogate.repository.GateEventRepository;
+import br.com.cloudport.servicogate.repository.GatePassRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+@Service
+@Transactional
+public class GateFlowService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GateFlowService.class);
+
+    private static final EnumSet<StatusAgendamento> STATUS_VALIDOS_ENTRADA = EnumSet.of(
+            StatusAgendamento.CONFIRMADO,
+            StatusAgendamento.EM_ATENDIMENTO,
+            StatusAgendamento.EM_EXECUCAO
+    );
+
+    private static final EnumSet<StatusAgendamento> STATUS_VALIDOS_SAIDA = EnumSet.of(
+            StatusAgendamento.EM_EXECUCAO,
+            StatusAgendamento.EM_ATENDIMENTO
+    );
+
+    private final AgendamentoRepository agendamentoRepository;
+    private final GatePassRepository gatePassRepository;
+    private final GateEventRepository gateEventRepository;
+    private final GateFlowProperties flowProperties;
+
+    public GateFlowService(AgendamentoRepository agendamentoRepository,
+                           GatePassRepository gatePassRepository,
+                           GateEventRepository gateEventRepository,
+                           GateFlowProperties flowProperties) {
+        this.agendamentoRepository = agendamentoRepository;
+        this.gatePassRepository = gatePassRepository;
+        this.gateEventRepository = gateEventRepository;
+        this.flowProperties = flowProperties;
+    }
+
+    public GateDecisionDTO registrarEntrada(GateFlowRequest request) {
+        LocalDateTime timestamp = resolverTimestamp(request.getTimestamp());
+        Agendamento agendamento = localizarAgendamento(request);
+        GatePass gatePass = obterOuCriarGatePass(agendamento);
+        try {
+            validarStatusParaEntrada(agendamento);
+            validarDocumentos(agendamento);
+            validarJanela(agendamento.getHorarioPrevistoChegada(), timestamp,
+                    flowProperties.getToleranciaEntradaAntecipada(),
+                    flowProperties.getToleranciaEntradaAtraso(),
+                    "Horário de chegada fora da tolerância permitida");
+
+            agendamento.setHorarioRealChegada(timestamp);
+            agendamento.setStatus(StatusAgendamento.EM_EXECUCAO);
+            gatePass.setDataEntrada(timestamp);
+            gatePass.setStatus(StatusGate.EM_PROCESSAMENTO);
+
+            gatePassRepository.save(gatePass);
+            agendamentoRepository.save(agendamento);
+
+            GateEvent evento = registrarEvento(gatePass, StatusGate.LIBERADO, null,
+                    "Entrada autorizada", resolverOperador(request.getOperador()), timestamp);
+            LOGGER.info("Entrada autorizada para agendamento {}", agendamento.getCodigo());
+
+            return GateDecisionDTO.autorizado(evento.getStatus(), agendamento, gatePass,
+                    "Entrada liberada com sucesso");
+        } catch (RuntimeException ex) {
+            registrarEvento(gatePass, StatusGate.RETIDO, null, ex.getMessage(),
+                    resolverOperador(request.getOperador()), timestamp);
+            throw ex;
+        }
+    }
+
+    public GateDecisionDTO registrarSaida(GateFlowRequest request) {
+        LocalDateTime timestamp = resolverTimestamp(request.getTimestamp());
+        Agendamento agendamento = localizarAgendamento(request);
+        GatePass gatePass = obterOuCriarGatePass(agendamento);
+        try {
+            validarStatusParaSaida(agendamento, gatePass);
+            validarJanela(agendamento.getHorarioPrevistoSaida(), timestamp,
+                    flowProperties.getToleranciaSaidaAntecipada(),
+                    flowProperties.getToleranciaSaidaAtraso(),
+                    "Horário de saída fora da tolerância permitida");
+
+            agendamento.setHorarioRealSaida(timestamp);
+            gatePass.setDataSaida(timestamp);
+            gatePass.setStatus(StatusGate.FINALIZADO);
+
+            if (agendamento.getHorarioRealChegada() == null) {
+                agendamento.setStatus(StatusAgendamento.NO_SHOW);
+            } else {
+                agendamento.setStatus(StatusAgendamento.COMPLETO);
+            }
+
+            gatePassRepository.save(gatePass);
+            agendamentoRepository.save(agendamento);
+
+            GateEvent evento = registrarEvento(gatePass, StatusGate.FINALIZADO, null,
+                    "Saída registrada", resolverOperador(request.getOperador()), timestamp);
+            LOGGER.info("Saída registrada para agendamento {}", agendamento.getCodigo());
+
+            return GateDecisionDTO.autorizado(evento.getStatus(), agendamento, gatePass,
+                    "Saída registrada e gate finalizado");
+        } catch (RuntimeException ex) {
+            registrarEvento(gatePass, StatusGate.RETIDO, null, ex.getMessage(),
+                    resolverOperador(request.getOperador()), timestamp);
+            throw ex;
+        }
+    }
+
+    public GateEvent registrarBloqueioManual(Long agendamentoId, ManualReleaseRequest request) {
+        validarPermissaoManual(request.getOperador());
+        Agendamento agendamento = obterAgendamento(agendamentoId);
+        GatePass gatePass = obterOuCriarGatePass(agendamento);
+        gatePass.setStatus(StatusGate.RETIDO);
+        gatePassRepository.save(gatePass);
+        return registrarEvento(gatePass, StatusGate.RETIDO, parseMotivo(request.getMotivo()),
+                request.getObservacao(), resolverOperador(request.getOperador()), LocalDateTime.now());
+    }
+
+    public GateEvent registrarLiberacaoManual(Long agendamentoId, ManualReleaseRequest request) {
+        validarPermissaoManual(request.getOperador());
+        Agendamento agendamento = obterAgendamento(agendamentoId);
+        GatePass gatePass = obterOuCriarGatePass(agendamento);
+        gatePass.setStatus(StatusGate.LIBERADO);
+        gatePassRepository.save(gatePass);
+        return registrarEvento(gatePass, StatusGate.LIBERADO, parseMotivo(request.getMotivo()),
+                request.getObservacao(), resolverOperador(request.getOperador()), LocalDateTime.now());
+    }
+
+    public br.com.cloudport.servicogate.dto.GateEventDTO liberarManual(Long agendamentoId, ManualReleaseRequest request) {
+        GateEvent evento;
+        if (request.getAcao() == ManualReleaseAction.LIBERAR) {
+            evento = registrarLiberacaoManual(agendamentoId, request);
+        } else {
+            evento = registrarBloqueioManual(agendamentoId, request);
+        }
+        return GateMapper.toGateEventDTO(evento);
+    }
+
+    private Agendamento localizarAgendamento(GateFlowRequest request) {
+        if (StringUtils.hasText(request.getQrCode())) {
+            return agendamentoRepository.findByCodigo(request.getQrCode().trim())
+                    .orElseThrow(() -> new NotFoundException("Agendamento não encontrado para o QR code informado"));
+        }
+        if (StringUtils.hasText(request.getPlaca())) {
+            List<StatusAgendamento> status = new ArrayList<>(STATUS_VALIDOS_ENTRADA);
+            return agendamentoRepository.findFirstByVeiculoPlacaIgnoreCaseAndStatusInOrderByHorarioPrevistoChegadaAsc(
+                            request.getPlaca().trim(), status)
+                    .orElseThrow(() -> new NotFoundException("Agendamento não encontrado para a placa informada"));
+        }
+        throw new BusinessException("Informe a placa ou o QR code para processar o evento");
+    }
+
+    private GatePass obterOuCriarGatePass(Agendamento agendamento) {
+        GatePass gatePass = gatePassRepository.findByAgendamentoId(agendamento.getId()).orElse(null);
+        if (gatePass == null) {
+            gatePass = new GatePass();
+            gatePass.setAgendamento(agendamento);
+            gatePass.setCodigo(gerarCodigoGatePass(agendamento));
+            gatePass.setStatus(StatusGate.AGUARDANDO_ENTRADA);
+            gatePass = gatePassRepository.save(gatePass);
+            agendamento.setGatePass(gatePass);
+        } else if (agendamento.getGatePass() == null) {
+            agendamento.setGatePass(gatePass);
+        }
+        return gatePass;
+    }
+
+    private String gerarCodigoGatePass(Agendamento agendamento) {
+        return "GP-" + agendamento.getCodigo() + "-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase(Locale.ROOT);
+    }
+
+    private void validarStatusParaEntrada(Agendamento agendamento) {
+        if (!STATUS_VALIDOS_ENTRADA.contains(agendamento.getStatus())) {
+            throw new BusinessException("Agendamento não está elegível para entrada");
+        }
+        if (agendamento.getStatus() == StatusAgendamento.CANCELADO) {
+            throw new BusinessException("Agendamento cancelado não pode ingressar no site");
+        }
+    }
+
+    private void validarStatusParaSaida(Agendamento agendamento, GatePass gatePass) {
+        if (!STATUS_VALIDOS_SAIDA.contains(agendamento.getStatus())) {
+            throw new BusinessException("Agendamento não está em execução para registrar a saída");
+        }
+        if (gatePass.getDataEntrada() == null) {
+            throw new BusinessException("Não é possível registrar saída sem entrada registrada");
+        }
+    }
+
+    private void validarDocumentos(Agendamento agendamento) {
+        List<DocumentoAgendamento> documentos = agendamento.getDocumentos();
+        if (CollectionUtils.isEmpty(documentos)) {
+            throw new BusinessException("Agendamento sem documentação obrigatória");
+        }
+        boolean documentoInvalido = documentos.stream()
+                .anyMatch(doc -> !StringUtils.hasText(doc.getUrlDocumento()));
+        if (documentoInvalido) {
+            throw new BusinessException("Documentação pendente de validação");
+        }
+    }
+
+    private void validarJanela(LocalDateTime horarioPrevisto,
+                               LocalDateTime timestamp,
+                               Duration toleranciaAntecipada,
+                               Duration toleranciaAtraso,
+                               String mensagemErro) {
+        if (horarioPrevisto == null) {
+            return;
+        }
+        LocalDateTime inicio = horarioPrevisto.minus(toleranciaAntecipada != null ? toleranciaAntecipada : Duration.ZERO);
+        LocalDateTime fim = horarioPrevisto.plus(toleranciaAtraso != null ? toleranciaAtraso : Duration.ZERO);
+        if (timestamp.isBefore(inicio) || timestamp.isAfter(fim)) {
+            throw new BusinessException(mensagemErro);
+        }
+    }
+
+    private GateEvent registrarEvento(GatePass gatePass,
+                                      StatusGate status,
+                                      MotivoExcecao motivo,
+                                      String observacao,
+                                      String operador,
+                                      LocalDateTime timestamp) {
+        GateEvent event = new GateEvent();
+        event.setGatePass(gatePass);
+        event.setStatus(status);
+        event.setMotivoExcecao(motivo);
+        event.setObservacao(observacao);
+        event.setUsuarioResponsavel(operador);
+        event.setRegistradoEm(timestamp != null ? timestamp : LocalDateTime.now());
+        GateEvent salvo = gateEventRepository.save(event);
+        gatePass.getEventos().add(salvo);
+        return salvo;
+    }
+
+    private MotivoExcecao parseMotivo(String motivo) {
+        if (!StringUtils.hasText(motivo)) {
+            return null;
+        }
+        try {
+            String normalized = motivo.trim().toUpperCase(Locale.ROOT)
+                    .replace('-', '_')
+                    .replace(' ', '_');
+            return MotivoExcecao.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException("Motivo de exceção inválido: " + motivo);
+        }
+    }
+
+    private Agendamento obterAgendamento(Long agendamentoId) {
+        return agendamentoRepository.findById(agendamentoId)
+                .orElseThrow(() -> new NotFoundException("Agendamento não encontrado"));
+    }
+
+    private void validarPermissaoManual(String operador) {
+        List<String> roles = flowProperties.getRolesLiberacaoManual();
+        if (CollectionUtils.isEmpty(roles)) {
+            return;
+        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new BusinessException("Usuário não autorizado para liberação manual");
+        }
+        List<String> authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+        boolean permitido = authorities.stream()
+                .map(authority -> authority != null ? authority.toUpperCase(Locale.ROOT) : null)
+                .filter(Objects::nonNull)
+                .anyMatch(auth -> roles.stream()
+                        .map(role -> role != null ? role.toUpperCase(Locale.ROOT) : null)
+                        .filter(Objects::nonNull)
+                        .anyMatch(auth::equals));
+        if (!permitido) {
+            throw new BusinessException("Usuário não possui permissão para liberação manual");
+        }
+    }
+
+    private LocalDateTime resolverTimestamp(LocalDateTime timestamp) {
+        return timestamp != null ? timestamp : LocalDateTime.now();
+    }
+
+    private String resolverOperador(String operadorInformado) {
+        if (StringUtils.hasText(operadorInformado)) {
+            return operadorInformado.trim();
+        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && StringUtils.hasText(authentication.getName())) {
+            return authentication.getName();
+        }
+        return "sistema";
+    }
+}

--- a/backend/servico-gate/src/main/resources/application.properties
+++ b/backend/servico-gate/src/main/resources/application.properties
@@ -26,6 +26,19 @@ springdoc.swagger-ui.path=/swagger-ui.html
 cloudport.tos.api.base-url=${TOS_API_BASE_URL:http://localhost:8080}
 cloudport.tos.api.timeout=${TOS_API_TIMEOUT_MS:5000}
 
+# Fluxo de gate e integrações de hardware
+cloudport.gate.flow.tolerancia-entrada-antecipada=${GATE_TOL_ENTRADA_ANTEC:PT30M}
+cloudport.gate.flow.tolerancia-entrada-atraso=${GATE_TOL_ENTRADA_ATRASO:PT30M}
+cloudport.gate.flow.tolerancia-saida-antecipada=${GATE_TOL_SAIDA_ANTEC:PT30M}
+cloudport.gate.flow.tolerancia-saida-atraso=${GATE_TOL_SAIDA_ATRASO:PT30M}
+cloudport.gate.flow.roles-liberacao-manual=${GATE_ROLES_LIBERACAO_MANUAL:ROLE_SUPERVISOR,ROLE_COORDENADOR,ROLE_ADMIN}
+
+cloudport.gate.hardware.entrada-queue=${GATE_HARDWARE_ENTRADA_QUEUE:gate.hardware.entrada}
+cloudport.gate.hardware.saida-queue=${GATE_HARDWARE_SAIDA_QUEUE:gate.hardware.saida}
+cloudport.gate.hardware.decisao-exchange=${GATE_HARDWARE_DECISAO_EXCHANGE:gate.hardware.decisao}
+cloudport.gate.hardware.decisao-routing-entrada=${GATE_HARDWARE_DECISAO_ROUTING_ENTRADA:gate.hardware.decisao.entrada}
+cloudport.gate.hardware.decisao-routing-saida=${GATE_HARDWARE_DECISAO_ROUTING_SAIDA:gate.hardware.decisao.saida}
+
 # Configurações de armazenamento de documentos
 cloudport.document-storage.provider=${DOCUMENT_STORAGE_PROVIDER:local}
 cloudport.document-storage.base-path=${DOCUMENT_STORAGE_BASE_PATH:/var/lib/cloudport/documents}


### PR DESCRIPTION
## Resumo
- adiciona GateFlowService e GateFlowController para processar eventos de entrada e saída, aplicar validações e registrar liberações manuais
- integra o serviço com filas AMQP via listeners e publicadores dedicados, além de DTOs para decisões do gate
- expande configurações com novas propriedades de fluxo, ajustes de status e métodos de repositório para localizar agendamentos e gate pass vinculados

## Testes
- `mvn -f backend/servico-gate/pom.xml test` *(falha: 403 ao baixar org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68ea36603f9c8327bd383a929bf00e50