### PR TITLE
Add GitHub Actions workflow for backend and frontend builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Build Backend and Frontend
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  backend:
+    name: Build backend services
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - servico-autenticacao
+          - servico-gate
+          - servico-yard
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Build ${{ matrix.service }}
+        run: mvn -B -f backend/${{ matrix.service }}/pom.xml clean verify
+
+  frontend:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/cloudport/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend/cloudport
+        run: npm ci
+
+      - name: Build project
+        working-directory: frontend/cloudport
+        run: npm run build --if-present


### PR DESCRIPTION
## Summary
- create a GitHub Actions workflow that builds the three backend Maven services
- add a frontend job that installs dependencies and runs the Angular build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea50e012c4832795adfdf2b01e2fe4