### PR TITLE
Corrige redirecionamento padrão após login

### DIFF
--- a/frontend/cloudport/src/app/componentes/login/login.component.spec.ts
+++ b/frontend/cloudport/src/app/componentes/login/login.component.spec.ts
@@ -1,6 +1,30 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { ActivatedRoute, RouteReuseStrategy, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
 import { LoginComponent } from './login.component';
+import { AuthenticationService } from '../service/servico-autenticacao/authentication.service';
+import { CustomReuseStrategy } from '../tab-content/customreusestrategy';
+
+class MockAuthenticationService {
+  currentUserValue = null;
+
+  login() {
+    return of({ token: 'fake-token', login: 'user', roles: [] });
+  }
+
+  updateMenuStatus(_status: boolean) {}
+
+  setUserName(_username: string) {}
+}
+
+const activatedRouteStub = {
+  snapshot: {
+    queryParams: {}
+  }
+};
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -8,7 +32,14 @@ describe('LoginComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [LoginComponent]
+      declarations: [LoginComponent],
+      imports: [RouterTestingModule],
+      providers: [
+        FormBuilder,
+        { provide: AuthenticationService, useClass: MockAuthenticationService },
+        { provide: ActivatedRoute, useValue: activatedRouteStub },
+        { provide: RouteReuseStrategy, useClass: CustomReuseStrategy }
+      ]
     });
     fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;
@@ -17,5 +48,19 @@ describe('LoginComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should default returnUrl to /home when query param is missing', () => {
+    expect(component.returnUrl).toBe('/home');
+  });
+
+  it('should redirect to /home when login succeeds without returnUrl', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+
+    component.loginForm.setValue({ username: 'john', password: 'secret' });
+    component.onSubmit();
+
+    expect(navigateSpy).toHaveBeenCalledWith('/home');
   });
 });

--- a/frontend/cloudport/src/app/componentes/login/login.component.ts
+++ b/frontend/cloudport/src/app/componentes/login/login.component.ts
@@ -26,7 +26,7 @@ export class LoginComponent implements OnInit {
     loginForm: FormGroup = this.formBuilder.group({}); // Initialized here
     loading = false;
     submitted = false;
-    returnUrl: string = 'home'; // Initialized here
+    returnUrl: string = '/home'; // Initialized with a sensible default route
     error = '';
 
     constructor(
@@ -39,7 +39,7 @@ export class LoginComponent implements OnInit {
     ) {
         // redirect to home if already logged in
         if (this.authenticationService.currentUserValue) {
-            this.router.navigate([this.returnUrl]);
+            this.router.navigateByUrl(this.returnUrl);
         }
     }
 
@@ -51,7 +51,9 @@ export class LoginComponent implements OnInit {
         });
 
         // get return url from route parameters or default to '/'
-        this.returnUrl = this.route.snapshot.queryParams['returnUrl'] || '';
+        const requestedReturnUrl = this.route.snapshot.queryParams['returnUrl'];
+        const hasCustomReturnUrl = typeof requestedReturnUrl === 'string' && requestedReturnUrl.trim().length > 0;
+        this.returnUrl = hasCustomReturnUrl ? requestedReturnUrl : '/home';
         (this.reuseStrategy as CustomReuseStrategy).markForDestruction('login'.toLowerCase());
     }
 
@@ -74,7 +76,7 @@ export class LoginComponent implements OnInit {
             .subscribe(
                 data => {
 
-                    this.router.navigate([this.returnUrl]);
+                    this.router.navigateByUrl(this.returnUrl);
                     this.authenticationService.setUserName(this.f['username'].value);
                     this.authenticationService.updateMenuStatus(true); // set mostrarMenu to true after successful login
                     (this.reuseStrategy as CustomReuseStrategy).markForDestruction('login'.toLowerCase());


### PR DESCRIPTION
## Summary
- garante que o LoginComponent sempre redirecione para /home quando nenhum returnUrl for informado
- ajusta o teste unitário para cobrir o novo comportamento e incluir dependências simuladas do componente

## Testing
- não executado (npm ci falha devido à dependência privada @ag-grid-enterprise/all-modules)


------
https://chatgpt.com/codex/tasks/task_e_68ea69d0fd2883278a71bbf59d128473