### PR TITLE
feat: adicionar dashboard e relatorios do gate

### DIFF
--- a/backend/servico-gate/pom.xml
+++ b/backend/servico-gate/pom.xml
@@ -77,6 +77,26 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>5.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>5.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/DashboardController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/DashboardController.java
@@ -1,0 +1,55 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.dto.dashboard.DashboardFiltroDTO;
+import br.com.cloudport.servicogate.dto.dashboard.DashboardResumoDTO;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import br.com.cloudport.servicogate.service.DashboardService;
+import java.time.LocalDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/gate/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping
+    public DashboardResumoDTO consultar(
+            @RequestParam(value = "inicio", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime inicio,
+            @RequestParam(value = "fim", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fim,
+            @RequestParam(value = "transportadoraId", required = false) Long transportadoraId,
+            @RequestParam(value = "tipoOperacao", required = false) String tipoOperacao
+    ) {
+        DashboardFiltroDTO filtro = construirFiltro(inicio, fim, transportadoraId, tipoOperacao);
+        return dashboardService.obterResumo(filtro);
+    }
+
+    @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamDashboard() {
+        return dashboardService.registrarAssinante();
+    }
+
+    private DashboardFiltroDTO construirFiltro(LocalDateTime inicio, LocalDateTime fim,
+                                               Long transportadoraId, String tipoOperacao) {
+        DashboardFiltroDTO filtro = new DashboardFiltroDTO();
+        filtro.setInicio(inicio);
+        filtro.setFim(fim);
+        filtro.setTransportadoraId(transportadoraId);
+        if (tipoOperacao != null && !tipoOperacao.isBlank()) {
+            filtro.setTipoOperacao(TipoOperacao.valueOf(tipoOperacao.toUpperCase()));
+        }
+        return filtro;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/RelatorioController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/RelatorioController.java
@@ -1,0 +1,81 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.dto.dashboard.DashboardFiltroDTO;
+import br.com.cloudport.servicogate.dto.relatorio.FormatoExportacao;
+import br.com.cloudport.servicogate.dto.relatorio.RelatorioAgendamentoDTO;
+import br.com.cloudport.servicogate.dto.relatorio.RelatorioResponseDTO;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import br.com.cloudport.servicogate.service.DashboardService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/gate/relatorios")
+public class RelatorioController {
+
+    private final DashboardService dashboardService;
+
+    public RelatorioController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping
+    public RelatorioResponseDTO consultar(
+            @RequestParam(value = "inicio", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime inicio,
+            @RequestParam(value = "fim", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fim,
+            @RequestParam(value = "transportadoraId", required = false) Long transportadoraId,
+            @RequestParam(value = "tipoOperacao", required = false) String tipoOperacao
+    ) {
+        DashboardFiltroDTO filtro = construirFiltro(inicio, fim, transportadoraId, tipoOperacao);
+        List<RelatorioAgendamentoDTO> agendamentos = dashboardService.buscarRelatorio(filtro);
+        return new RelatorioResponseDTO(dashboardService.obterResumo(filtro), agendamentos);
+    }
+
+    @GetMapping("/export")
+    public ResponseEntity<byte[]> exportar(
+            @RequestParam(value = "inicio", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime inicio,
+            @RequestParam(value = "fim", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fim,
+            @RequestParam(value = "transportadoraId", required = false) Long transportadoraId,
+            @RequestParam(value = "tipoOperacao", required = false) String tipoOperacao,
+            @RequestParam(value = "formato", required = false) String formato
+    ) {
+        DashboardFiltroDTO filtro = construirFiltro(inicio, fim, transportadoraId, tipoOperacao);
+        FormatoExportacao formatoExportacao = FormatoExportacao.from(formato);
+        byte[] arquivo = dashboardService.exportarRelatorio(filtro, formatoExportacao);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(formatoExportacao.getMediaType());
+        headers.setContentDisposition(ContentDisposition.attachment()
+                .filename("relatorio-gate." + formatoExportacao.getExtensao())
+                .build());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(arquivo);
+    }
+
+    private DashboardFiltroDTO construirFiltro(LocalDateTime inicio, LocalDateTime fim,
+                                               Long transportadoraId, String tipoOperacao) {
+        DashboardFiltroDTO filtro = new DashboardFiltroDTO();
+        filtro.setInicio(inicio);
+        filtro.setFim(fim);
+        filtro.setTransportadoraId(transportadoraId);
+        if (tipoOperacao != null && !tipoOperacao.isBlank()) {
+            filtro.setTipoOperacao(TipoOperacao.valueOf(tipoOperacao.toUpperCase()));
+        }
+        return filtro;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/dashboard/DashboardFiltroDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/dashboard/DashboardFiltroDTO.java
@@ -1,0 +1,44 @@
+package br.com.cloudport.servicogate.dto.dashboard;
+
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import java.time.LocalDateTime;
+
+public class DashboardFiltroDTO {
+
+    private LocalDateTime inicio;
+    private LocalDateTime fim;
+    private Long transportadoraId;
+    private TipoOperacao tipoOperacao;
+
+    public LocalDateTime getInicio() {
+        return inicio;
+    }
+
+    public void setInicio(LocalDateTime inicio) {
+        this.inicio = inicio;
+    }
+
+    public LocalDateTime getFim() {
+        return fim;
+    }
+
+    public void setFim(LocalDateTime fim) {
+        this.fim = fim;
+    }
+
+    public Long getTransportadoraId() {
+        return transportadoraId;
+    }
+
+    public void setTransportadoraId(Long transportadoraId) {
+        this.transportadoraId = transportadoraId;
+    }
+
+    public TipoOperacao getTipoOperacao() {
+        return tipoOperacao;
+    }
+
+    public void setTipoOperacao(TipoOperacao tipoOperacao) {
+        this.tipoOperacao = tipoOperacao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/dashboard/DashboardResumoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/dashboard/DashboardResumoDTO.java
@@ -1,0 +1,70 @@
+package br.com.cloudport.servicogate.dto.dashboard;
+
+import java.util.List;
+
+public class DashboardResumoDTO {
+
+    private long totalAgendamentos;
+    private double percentualPontualidade;
+    private double percentualNoShow;
+    private double percentualOcupacaoSlots;
+    private double tempoMedioTurnaroundMinutos;
+    private List<OcupacaoPorHoraDTO> ocupacaoPorHora;
+    private List<TempoMedioPermanenciaDTO> turnaroundPorDia;
+
+    public long getTotalAgendamentos() {
+        return totalAgendamentos;
+    }
+
+    public void setTotalAgendamentos(long totalAgendamentos) {
+        this.totalAgendamentos = totalAgendamentos;
+    }
+
+    public double getPercentualPontualidade() {
+        return percentualPontualidade;
+    }
+
+    public void setPercentualPontualidade(double percentualPontualidade) {
+        this.percentualPontualidade = percentualPontualidade;
+    }
+
+    public double getPercentualNoShow() {
+        return percentualNoShow;
+    }
+
+    public void setPercentualNoShow(double percentualNoShow) {
+        this.percentualNoShow = percentualNoShow;
+    }
+
+    public double getPercentualOcupacaoSlots() {
+        return percentualOcupacaoSlots;
+    }
+
+    public void setPercentualOcupacaoSlots(double percentualOcupacaoSlots) {
+        this.percentualOcupacaoSlots = percentualOcupacaoSlots;
+    }
+
+    public double getTempoMedioTurnaroundMinutos() {
+        return tempoMedioTurnaroundMinutos;
+    }
+
+    public void setTempoMedioTurnaroundMinutos(double tempoMedioTurnaroundMinutos) {
+        this.tempoMedioTurnaroundMinutos = tempoMedioTurnaroundMinutos;
+    }
+
+    public List<OcupacaoPorHoraDTO> getOcupacaoPorHora() {
+        return ocupacaoPorHora;
+    }
+
+    public void setOcupacaoPorHora(List<OcupacaoPorHoraDTO> ocupacaoPorHora) {
+        this.ocupacaoPorHora = ocupacaoPorHora;
+    }
+
+    public List<TempoMedioPermanenciaDTO> getTurnaroundPorDia() {
+        return turnaroundPorDia;
+    }
+
+    public void setTurnaroundPorDia(List<TempoMedioPermanenciaDTO> turnaroundPorDia) {
+        this.turnaroundPorDia = turnaroundPorDia;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/relatorio/FormatoExportacao.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/relatorio/FormatoExportacao.java
@@ -1,0 +1,31 @@
+package br.com.cloudport.servicogate.dto.relatorio;
+
+import org.springframework.http.MediaType;
+
+public enum FormatoExportacao {
+    CSV("text/csv", "csv"),
+    EXCEL("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx");
+
+    private final String mediaType;
+    private final String extensao;
+
+    FormatoExportacao(String mediaType, String extensao) {
+        this.mediaType = mediaType;
+        this.extensao = extensao;
+    }
+
+    public MediaType getMediaType() {
+        return MediaType.parseMediaType(mediaType);
+    }
+
+    public String getExtensao() {
+        return extensao;
+    }
+
+    public static FormatoExportacao from(String value) {
+        if (value == null) {
+            return CSV;
+        }
+        return FormatoExportacao.valueOf(value.trim().toUpperCase());
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/relatorio/RelatorioAgendamentoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/relatorio/RelatorioAgendamentoDTO.java
@@ -1,0 +1,95 @@
+package br.com.cloudport.servicogate.dto.relatorio;
+
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import java.time.LocalDateTime;
+
+public class RelatorioAgendamentoDTO {
+
+    private String codigo;
+    private TipoOperacao tipoOperacao;
+    private StatusAgendamento status;
+    private String transportadora;
+    private LocalDateTime horarioPrevistoChegada;
+    private LocalDateTime horarioRealChegada;
+    private LocalDateTime horarioPrevistoSaida;
+    private LocalDateTime horarioRealSaida;
+
+    public static RelatorioAgendamentoDTO fromEntity(Agendamento agendamento) {
+        RelatorioAgendamentoDTO dto = new RelatorioAgendamentoDTO();
+        dto.setCodigo(agendamento.getCodigo());
+        dto.setTipoOperacao(agendamento.getTipoOperacao());
+        dto.setStatus(agendamento.getStatus());
+        dto.setTransportadora(agendamento.getTransportadora() != null ? agendamento.getTransportadora().getNome() : null);
+        dto.setHorarioPrevistoChegada(agendamento.getHorarioPrevistoChegada());
+        dto.setHorarioRealChegada(agendamento.getHorarioRealChegada());
+        dto.setHorarioPrevistoSaida(agendamento.getHorarioPrevistoSaida());
+        dto.setHorarioRealSaida(agendamento.getHorarioRealSaida());
+        return dto;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public TipoOperacao getTipoOperacao() {
+        return tipoOperacao;
+    }
+
+    public void setTipoOperacao(TipoOperacao tipoOperacao) {
+        this.tipoOperacao = tipoOperacao;
+    }
+
+    public StatusAgendamento getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusAgendamento status) {
+        this.status = status;
+    }
+
+    public String getTransportadora() {
+        return transportadora;
+    }
+
+    public void setTransportadora(String transportadora) {
+        this.transportadora = transportadora;
+    }
+
+    public LocalDateTime getHorarioPrevistoChegada() {
+        return horarioPrevistoChegada;
+    }
+
+    public void setHorarioPrevistoChegada(LocalDateTime horarioPrevistoChegada) {
+        this.horarioPrevistoChegada = horarioPrevistoChegada;
+    }
+
+    public LocalDateTime getHorarioRealChegada() {
+        return horarioRealChegada;
+    }
+
+    public void setHorarioRealChegada(LocalDateTime horarioRealChegada) {
+        this.horarioRealChegada = horarioRealChegada;
+    }
+
+    public LocalDateTime getHorarioPrevistoSaida() {
+        return horarioPrevistoSaida;
+    }
+
+    public void setHorarioPrevistoSaida(LocalDateTime horarioPrevistoSaida) {
+        this.horarioPrevistoSaida = horarioPrevistoSaida;
+    }
+
+    public LocalDateTime getHorarioRealSaida() {
+        return horarioRealSaida;
+    }
+
+    public void setHorarioRealSaida(LocalDateTime horarioRealSaida) {
+        this.horarioRealSaida = horarioRealSaida;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/relatorio/RelatorioResponseDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/relatorio/RelatorioResponseDTO.java
@@ -1,0 +1,34 @@
+package br.com.cloudport.servicogate.dto.relatorio;
+
+import br.com.cloudport.servicogate.dto.dashboard.DashboardResumoDTO;
+import java.util.List;
+
+public class RelatorioResponseDTO {
+
+    private DashboardResumoDTO resumo;
+    private List<RelatorioAgendamentoDTO> agendamentos;
+
+    public RelatorioResponseDTO() {
+    }
+
+    public RelatorioResponseDTO(DashboardResumoDTO resumo, List<RelatorioAgendamentoDTO> agendamentos) {
+        this.resumo = resumo;
+        this.agendamentos = agendamentos;
+    }
+
+    public DashboardResumoDTO getResumo() {
+        return resumo;
+    }
+
+    public void setResumo(DashboardResumoDTO resumo) {
+        this.resumo = resumo;
+    }
+
+    public List<RelatorioAgendamentoDTO> getAgendamentos() {
+        return agendamentos;
+    }
+
+    public void setAgendamentos(List<RelatorioAgendamentoDTO> agendamentos) {
+        this.agendamentos = agendamentos;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
@@ -3,6 +3,8 @@ package br.com.cloudport.servicogate.repository;
 import br.com.cloudport.servicogate.dto.dashboard.OcupacaoPorHoraDTO;
 import br.com.cloudport.servicogate.model.Agendamento;
 import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import br.com.cloudport.servicogate.repository.projection.DashboardMetricsProjection;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -46,4 +48,45 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
             "GROUP BY j.horaInicio, j.capacidade " +
             "ORDER BY j.horaInicio")
     List<OcupacaoPorHoraDTO> calcularOcupacaoPorHora(@Param("data") LocalDate data);
+
+    @Query(value = "SELECT " +
+            "COUNT(*) FILTER (WHERE a.status <> 'CANCELADO') AS total_agendamentos, " +
+            "SUM(CASE WHEN a.status <> 'CANCELADO' AND a.horario_real_chegada IS NOT NULL AND a.horario_previsto_chegada IS NOT NULL " +
+            "AND ABS(EXTRACT(EPOCH FROM (a.horario_real_chegada - a.horario_previsto_chegada))) <= (:toleranciaPontualidade * 60) THEN 1 ELSE 0 END) AS pontuais, " +
+            "SUM(CASE WHEN a.status = 'NO_SHOW' THEN 1 ELSE 0 END) AS no_show, " +
+            "AVG(EXTRACT(EPOCH FROM (a.horario_real_saida - a.horario_real_chegada)) / 60) FILTER (WHERE a.horario_real_chegada IS NOT NULL AND a.horario_real_saida IS NOT NULL) AS turnaround_medio, " +
+            "COALESCE(COUNT(*) FILTER (WHERE a.status <> 'CANCELADO')::decimal / NULLIF(( " +
+            "SELECT SUM(j.capacidade) FROM janela_atendimento j WHERE EXISTS ( " +
+            "SELECT 1 FROM agendamento a2 WHERE a2.janela_atendimento_id = j.id " +
+            "AND a2.status <> 'CANCELADO' " +
+            "AND (:inicio IS NULL OR a2.horario_previsto_chegada >= :inicio) " +
+            "AND (:fim IS NULL OR a2.horario_previsto_saida <= :fim) " +
+            "AND (:transportadoraId IS NULL OR a2.transportadora_id = :transportadoraId) " +
+            "AND (:tipoOperacao IS NULL OR a2.tipo_operacao = :tipoOperacao))), 0), 0) AS ocupacao_slots " +
+            "FROM agendamento a " +
+            "WHERE (:inicio IS NULL OR a.horario_previsto_chegada >= :inicio) " +
+            "AND (:fim IS NULL OR a.horario_previsto_saida <= :fim) " +
+            "AND (:transportadoraId IS NULL OR a.transportadora_id = :transportadoraId) " +
+            "AND (:tipoOperacao IS NULL OR a.tipo_operacao = :tipoOperacao)",
+            nativeQuery = true)
+    DashboardMetricsProjection calcularMetricasDashboard(@Param("inicio") java.time.LocalDateTime inicio,
+                                                         @Param("fim") java.time.LocalDateTime fim,
+                                                         @Param("transportadoraId") Long transportadoraId,
+                                                         @Param("tipoOperacao") String tipoOperacao,
+                                                         @Param("toleranciaPontualidade") int toleranciaPontualidade);
+
+    @Query("SELECT a FROM Agendamento a " +
+            "JOIN FETCH a.transportadora t " +
+            "JOIN FETCH a.janelaAtendimento j " +
+            "LEFT JOIN FETCH a.gatePass gp " +
+            "WHERE (:inicio IS NULL OR a.horarioPrevistoChegada >= :inicio) " +
+            "AND (:fim IS NULL OR a.horarioPrevistoSaida <= :fim) " +
+            "AND (:transportadoraId IS NULL OR t.id = :transportadoraId) " +
+            "AND (:tipoOperacao IS NULL OR a.tipoOperacao = :tipoOperacao) " +
+            "AND a.status <> br.com.cloudport.servicogate.model.enums.StatusAgendamento.CANCELADO " +
+            "ORDER BY a.horarioPrevistoChegada ASC")
+    List<Agendamento> buscarRelatorio(@Param("inicio") java.time.LocalDateTime inicio,
+                                      @Param("fim") java.time.LocalDateTime fim,
+                                      @Param("transportadoraId") Long transportadoraId,
+                                      @Param("tipoOperacao") TipoOperacao tipoOperacao);
 }

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/projection/DashboardMetricsProjection.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/projection/DashboardMetricsProjection.java
@@ -1,0 +1,14 @@
+package br.com.cloudport.servicogate.repository.projection;
+
+public interface DashboardMetricsProjection {
+
+    Long getTotalAgendamentos();
+
+    Long getPontuais();
+
+    Long getNoShow();
+
+    Double getTurnaroundMedio();
+
+    Double getOcupacaoSlots();
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/DashboardService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/DashboardService.java
@@ -1,0 +1,256 @@
+package br.com.cloudport.servicogate.service;
+
+import br.com.cloudport.servicogate.dto.dashboard.DashboardFiltroDTO;
+import br.com.cloudport.servicogate.dto.dashboard.DashboardResumoDTO;
+import br.com.cloudport.servicogate.dto.dashboard.OcupacaoPorHoraDTO;
+import br.com.cloudport.servicogate.dto.dashboard.TempoMedioPermanenciaDTO;
+import br.com.cloudport.servicogate.dto.relatorio.FormatoExportacao;
+import br.com.cloudport.servicogate.dto.relatorio.RelatorioAgendamentoDTO;
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import br.com.cloudport.servicogate.repository.AgendamentoRepository;
+import br.com.cloudport.servicogate.repository.projection.DashboardMetricsProjection;
+import com.opencsv.CSVWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@Transactional(readOnly = true)
+public class DashboardService {
+
+    private static final int TOLERANCIA_PONTUALIDADE_MINUTOS = 15;
+    private static final long SSE_TIMEOUT_MILLIS = Duration.ofMinutes(30).toMillis();
+
+    private final AgendamentoRepository agendamentoRepository;
+    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    public DashboardService(AgendamentoRepository agendamentoRepository) {
+        this.agendamentoRepository = agendamentoRepository;
+    }
+
+    public DashboardResumoDTO obterResumo(DashboardFiltroDTO filtro) {
+        DashboardMetricsProjection projection = agendamentoRepository.calcularMetricasDashboard(
+                filtro.getInicio(),
+                filtro.getFim(),
+                filtro.getTransportadoraId(),
+                filtro.getTipoOperacao() != null ? filtro.getTipoOperacao().name() : null,
+                TOLERANCIA_PONTUALIDADE_MINUTOS
+        );
+
+        long total = Optional.ofNullable(projection.getTotalAgendamentos()).orElse(0L);
+        long pontuais = Optional.ofNullable(projection.getPontuais()).orElse(0L);
+        long noShow = Optional.ofNullable(projection.getNoShow()).orElse(0L);
+        double turnaround = Optional.ofNullable(projection.getTurnaroundMedio()).orElse(0D);
+        double ocupacao = Optional.ofNullable(projection.getOcupacaoSlots()).orElse(0D);
+
+        List<Agendamento> agendamentosFiltrados = buscarAgendamentos(filtro);
+
+        DashboardResumoDTO resumo = new DashboardResumoDTO();
+        resumo.setTotalAgendamentos(total);
+        resumo.setPercentualPontualidade(total > 0 ? (pontuais * 100.0) / total : 0D);
+        resumo.setPercentualNoShow(total > 0 ? (noShow * 100.0) / total : 0D);
+        resumo.setPercentualOcupacaoSlots(ocupacao * 100.0);
+        resumo.setTempoMedioTurnaroundMinutos(turnaround);
+        resumo.setOcupacaoPorHora(calcularOcupacaoPorHora(agendamentosFiltrados));
+        resumo.setTurnaroundPorDia(calcularTurnaroundPorDia(agendamentosFiltrados));
+
+        publicarAtualizacao(resumo);
+        return resumo;
+    }
+
+    public List<RelatorioAgendamentoDTO> buscarRelatorio(DashboardFiltroDTO filtro) {
+        List<Agendamento> agendamentos = buscarAgendamentos(filtro);
+        if (CollectionUtils.isEmpty(agendamentos)) {
+            return Collections.emptyList();
+        }
+        return agendamentos.stream()
+                .map(RelatorioAgendamentoDTO::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public byte[] exportarRelatorio(DashboardFiltroDTO filtro, FormatoExportacao formato) {
+        List<RelatorioAgendamentoDTO> linhas = buscarRelatorio(filtro);
+        if (formato == FormatoExportacao.EXCEL) {
+            return gerarPlanilhaExcel(linhas);
+        }
+        return gerarCsv(linhas);
+    }
+
+    public SseEmitter registrarAssinante() {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
+        emitters.add(emitter);
+        emitter.onCompletion(() -> emitters.remove(emitter));
+        emitter.onTimeout(() -> emitters.remove(emitter));
+        emitter.onError(throwable -> emitters.remove(emitter));
+        return emitter;
+    }
+
+    private void publicarAtualizacao(DashboardResumoDTO resumo) {
+        if (emitters.isEmpty()) {
+            return;
+        }
+        emitters.forEach(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("dashboard-atualizado")
+                        .data(resumo));
+            } catch (IOException ex) {
+                emitter.completeWithError(ex);
+                emitters.remove(emitter);
+            }
+        });
+    }
+
+    private List<Agendamento> buscarAgendamentos(DashboardFiltroDTO filtro) {
+        return agendamentoRepository.buscarRelatorio(
+                filtro.getInicio(),
+                filtro.getFim(),
+                filtro.getTransportadoraId(),
+                filtro.getTipoOperacao()
+        );
+    }
+
+    private List<OcupacaoPorHoraDTO> calcularOcupacaoPorHora(List<Agendamento> agendamentos) {
+        if (CollectionUtils.isEmpty(agendamentos)) {
+            return Collections.emptyList();
+        }
+        return agendamentos.stream()
+                .collect(Collectors.groupingBy(agendamento -> agendamento.getJanelaAtendimento().getHoraInicio()))
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    long total = entry.getValue().stream()
+                            .filter(agendamento -> agendamento.getStatus() != null
+                                    && agendamento.getStatus() != br.com.cloudport.servicogate.model.enums.StatusAgendamento.CANCELADO)
+                            .count();
+                    Integer capacidade = Optional.ofNullable(entry.getValue().get(0).getJanelaAtendimento().getCapacidade())
+                            .orElse(0);
+                    return new OcupacaoPorHoraDTO(entry.getKey(), total, capacidade);
+                })
+                .sorted((a, b) -> a.getHoraInicio().compareTo(b.getHoraInicio()))
+                .collect(Collectors.toList());
+    }
+
+    private List<TempoMedioPermanenciaDTO> calcularTurnaroundPorDia(List<Agendamento> agendamentos) {
+        if (CollectionUtils.isEmpty(agendamentos)) {
+            return Collections.emptyList();
+        }
+        return agendamentos.stream()
+                .filter(agendamento -> Objects.nonNull(agendamento.getHorarioRealChegada())
+                        && Objects.nonNull(agendamento.getHorarioRealSaida()))
+                .collect(Collectors.groupingBy(agendamento -> agendamento.getHorarioRealSaida().toLocalDate()))
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    double media = entry.getValue().stream()
+                            .mapToDouble(agendamento -> Duration.between(
+                                    agendamento.getHorarioRealChegada(),
+                                    agendamento.getHorarioRealSaida()
+                            ).toMinutes())
+                            .average()
+                            .orElse(0D);
+                    return new TempoMedioPermanenciaDTO(entry.getKey(), media);
+                })
+                .sorted((a, b) -> a.getDia().compareTo(b.getDia()))
+                .collect(Collectors.toList());
+    }
+
+    private byte[] gerarCsv(List<RelatorioAgendamentoDTO> linhas) {
+        try (StringWriter out = new StringWriter(); CSVWriter writer = new CSVWriter(out)) {
+            writer.writeNext(new String[]{
+                    "Código",
+                    "Tipo de Operação",
+                    "Status",
+                    "Transportadora",
+                    "Previsto Chegada",
+                    "Real Chegada",
+                    "Previsto Saída",
+                    "Real Saída"
+            });
+
+            for (RelatorioAgendamentoDTO dto : linhas) {
+                writer.writeNext(new String[]{
+                        dto.getCodigo(),
+                        Optional.ofNullable(dto.getTipoOperacao()).map(TipoOperacao::name).orElse(""),
+                        Optional.ofNullable(dto.getStatus()).map(Enum::name).orElse(""),
+                        Optional.ofNullable(dto.getTransportadora()).orElse(""),
+                        formatarData(dto.getHorarioPrevistoChegada()),
+                        formatarData(dto.getHorarioRealChegada()),
+                        formatarData(dto.getHorarioPrevistoSaida()),
+                        formatarData(dto.getHorarioRealSaida())
+                });
+            }
+            writer.flush();
+            return out.toString().getBytes();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Erro ao gerar CSV de relatórios", ex);
+        }
+    }
+
+    private byte[] gerarPlanilhaExcel(List<RelatorioAgendamentoDTO> linhas) {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("Relatório Gate");
+            int rowIndex = 0;
+            Row header = sheet.createRow(rowIndex++);
+            String[] cabecalho = {
+                    "Código",
+                    "Tipo de Operação",
+                    "Status",
+                    "Transportadora",
+                    "Previsto Chegada",
+                    "Real Chegada",
+                    "Previsto Saída",
+                    "Real Saída"
+            };
+            for (int i = 0; i < cabecalho.length; i++) {
+                Cell cell = header.createCell(i);
+                cell.setCellValue(cabecalho[i]);
+            }
+
+            for (RelatorioAgendamentoDTO dto : linhas) {
+                Row row = sheet.createRow(rowIndex++);
+                int col = 0;
+                row.createCell(col++).setCellValue(dto.getCodigo());
+                row.createCell(col++).setCellValue(Optional.ofNullable(dto.getTipoOperacao()).map(TipoOperacao::name).orElse(""));
+                row.createCell(col++).setCellValue(Optional.ofNullable(dto.getStatus()).map(Enum::name).orElse(""));
+                row.createCell(col++).setCellValue(Optional.ofNullable(dto.getTransportadora()).orElse(""));
+                row.createCell(col++).setCellValue(formatarData(dto.getHorarioPrevistoChegada()));
+                row.createCell(col++).setCellValue(formatarData(dto.getHorarioRealChegada()));
+                row.createCell(col++).setCellValue(formatarData(dto.getHorarioPrevistoSaida()));
+                row.createCell(col++).setCellValue(formatarData(dto.getHorarioRealSaida()));
+            }
+
+            for (int i = 0; i < cabecalho.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            try (java.io.ByteArrayOutputStream outputStream = new java.io.ByteArrayOutputStream()) {
+                workbook.write(outputStream);
+                return outputStream.toByteArray();
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Erro ao gerar planilha Excel do relatório", ex);
+        }
+    }
+
+    private String formatarData(LocalDateTime data) {
+        return data != null ? data.toString() : "";
+    }
+}

--- a/backend/servico-gate/src/test/java/br/com/cloudport/servicogate/repository/AgendamentoRepositoryTest.java
+++ b/backend/servico-gate/src/test/java/br/com/cloudport/servicogate/repository/AgendamentoRepositoryTest.java
@@ -1,0 +1,186 @@
+package br.com.cloudport.servicogate.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.JanelaAtendimento;
+import br.com.cloudport.servicogate.model.Motorista;
+import br.com.cloudport.servicogate.model.Transportadora;
+import br.com.cloudport.servicogate.model.Veiculo;
+import br.com.cloudport.servicogate.model.enums.CanalEntrada;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.model.enums.TipoOperacao;
+import br.com.cloudport.servicogate.repository.projection.DashboardMetricsProjection;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false"
+})
+class AgendamentoRepositoryTest {
+
+    @Autowired
+    private AgendamentoRepository agendamentoRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Transportadora transportadoraA;
+    private Transportadora transportadoraB;
+
+    @BeforeEach
+    void setUp() {
+        transportadoraA = criarTransportadora("TransA", "001");
+        transportadoraB = criarTransportadora("TransB", "002");
+
+        Motorista motoristaA = criarMotorista("João", "123", transportadoraA);
+        Motorista motoristaB = criarMotorista("Maria", "456", transportadoraB);
+
+        Veiculo veiculoA = criarVeiculo("AAA1234", transportadoraA);
+        Veiculo veiculoB = criarVeiculo("BBB5678", transportadoraB);
+
+        JanelaAtendimento janela1 = criarJanela(LocalDate.of(2024, 1, 10), LocalTime.of(8, 0), LocalTime.of(9, 0), 2);
+        JanelaAtendimento janela2 = criarJanela(LocalDate.of(2024, 1, 10), LocalTime.of(10, 0), LocalTime.of(11, 0), 1);
+        JanelaAtendimento janela3 = criarJanela(LocalDate.of(2024, 1, 10), LocalTime.of(12, 0), LocalTime.of(13, 0), 1);
+        JanelaAtendimento janela4 = criarJanela(LocalDate.of(2024, 1, 10), LocalTime.of(14, 0), LocalTime.of(15, 0), 1);
+        JanelaAtendimento janela5 = criarJanela(LocalDate.of(2024, 1, 11), LocalTime.of(9, 0), LocalTime.of(10, 0), 1);
+
+        criarAgendamento("AG001", transportadoraA, motoristaA, veiculoA, janela1,
+                TipoOperacao.ENTRADA, StatusAgendamento.COMPLETO,
+                LocalDateTime.of(2024, 1, 10, 8, 0), LocalDateTime.of(2024, 1, 10, 9, 0),
+                LocalDateTime.of(2024, 1, 10, 8, 5), LocalDateTime.of(2024, 1, 10, 8, 55));
+
+        criarAgendamento("AG002", transportadoraA, motoristaA, veiculoA, janela2,
+                TipoOperacao.ENTRADA, StatusAgendamento.COMPLETO,
+                LocalDateTime.of(2024, 1, 10, 10, 0), LocalDateTime.of(2024, 1, 10, 11, 30),
+                LocalDateTime.of(2024, 1, 10, 10, 30), LocalDateTime.of(2024, 1, 10, 11, 45));
+
+        criarAgendamento("AG003", transportadoraA, motoristaA, veiculoA, janela3,
+                TipoOperacao.ENTRADA, StatusAgendamento.NO_SHOW,
+                LocalDateTime.of(2024, 1, 10, 12, 0), LocalDateTime.of(2024, 1, 10, 13, 0),
+                null, null);
+
+        criarAgendamento("AG004", transportadoraA, motoristaA, veiculoA, janela4,
+                TipoOperacao.ENTRADA, StatusAgendamento.CANCELADO,
+                LocalDateTime.of(2024, 1, 10, 14, 0), LocalDateTime.of(2024, 1, 10, 15, 0),
+                null, null);
+
+        criarAgendamento("AG005", transportadoraB, motoristaB, veiculoB, janela5,
+                TipoOperacao.SAIDA, StatusAgendamento.COMPLETO,
+                LocalDateTime.of(2024, 1, 11, 9, 0), LocalDateTime.of(2024, 1, 11, 10, 0),
+                LocalDateTime.of(2024, 1, 11, 9, 5), LocalDateTime.of(2024, 1, 11, 9, 50));
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    void deveCalcularMetricasDashboard() {
+        LocalDateTime inicio = LocalDateTime.of(2024, 1, 10, 0, 0);
+        LocalDateTime fim = LocalDateTime.of(2024, 1, 10, 23, 59);
+
+        DashboardMetricsProjection projection = agendamentoRepository.calcularMetricasDashboard(
+                inicio,
+                fim,
+                transportadoraA.getId(),
+                TipoOperacao.ENTRADA.name(),
+                15
+        );
+
+        assertThat(projection.getTotalAgendamentos()).isEqualTo(3);
+        assertThat(projection.getPontuais()).isEqualTo(1);
+        assertThat(projection.getNoShow()).isEqualTo(1);
+        assertThat(projection.getTurnaroundMedio()).isCloseTo(62.5, within(0.1));
+        assertThat(projection.getOcupacaoSlots()).isCloseTo(0.75, within(0.0001));
+    }
+
+    @Test
+    void deveBuscarAgendamentosParaRelatorioComFiltros() {
+        LocalDateTime inicio = LocalDateTime.of(2024, 1, 10, 0, 0);
+        LocalDateTime fim = LocalDateTime.of(2024, 1, 10, 23, 59);
+
+        List<Agendamento> resultados = agendamentoRepository.buscarRelatorio(
+                inicio,
+                fim,
+                transportadoraA.getId(),
+                TipoOperacao.ENTRADA
+        );
+
+        assertThat(resultados)
+                .extracting(Agendamento::getCodigo)
+                .containsExactly("AG001", "AG002", "AG003");
+        assertThat(resultados)
+                .allMatch(agendamento -> agendamento.getTransportadora().getId().equals(transportadoraA.getId()));
+        assertThat(resultados)
+                .allMatch(agendamento -> agendamento.getTipoOperacao() == TipoOperacao.ENTRADA);
+    }
+
+    private Transportadora criarTransportadora(String nome, String documento) {
+        Transportadora transportadora = new Transportadora();
+        transportadora.setNome(nome);
+        transportadora.setDocumento(documento);
+        return entityManager.persist(transportadora);
+    }
+
+    private Motorista criarMotorista(String nome, String documento, Transportadora transportadora) {
+        Motorista motorista = new Motorista();
+        motorista.setNome(nome);
+        motorista.setDocumento(documento);
+        motorista.setTransportadora(transportadora);
+        return entityManager.persist(motorista);
+    }
+
+    private Veiculo criarVeiculo(String placa, Transportadora transportadora) {
+        Veiculo veiculo = new Veiculo();
+        veiculo.setPlaca(placa);
+        veiculo.setTransportadora(transportadora);
+        return entityManager.persist(veiculo);
+    }
+
+    private JanelaAtendimento criarJanela(LocalDate data, LocalTime inicio, LocalTime fim, int capacidade) {
+        JanelaAtendimento janela = new JanelaAtendimento();
+        janela.setData(data);
+        janela.setHoraInicio(inicio);
+        janela.setHoraFim(fim);
+        janela.setCapacidade(capacidade);
+        janela.setCanalEntrada(CanalEntrada.PORTARIA_PRINCIPAL);
+        return entityManager.persist(janela);
+    }
+
+    private Agendamento criarAgendamento(String codigo,
+                                         Transportadora transportadora,
+                                         Motorista motorista,
+                                         Veiculo veiculo,
+                                         JanelaAtendimento janela,
+                                         TipoOperacao tipoOperacao,
+                                         StatusAgendamento status,
+                                         LocalDateTime previstoChegada,
+                                         LocalDateTime previstoSaida,
+                                         LocalDateTime realChegada,
+                                         LocalDateTime realSaida) {
+        Agendamento agendamento = new Agendamento();
+        agendamento.setCodigo(codigo);
+        agendamento.setTransportadora(transportadora);
+        agendamento.setMotorista(motorista);
+        agendamento.setVeiculo(veiculo);
+        agendamento.setJanelaAtendimento(janela);
+        agendamento.setTipoOperacao(tipoOperacao);
+        agendamento.setStatus(status);
+        agendamento.setHorarioPrevistoChegada(previstoChegada);
+        agendamento.setHorarioPrevistoSaida(previstoSaida);
+        agendamento.setHorarioRealChegada(realChegada);
+        agendamento.setHorarioRealSaida(realSaida);
+        return entityManager.persist(agendamento);
+    }
+}


### PR DESCRIPTION
## Resumo
- adiciona controllers para dashboard e relatórios com filtros de período, transportadora e tipo de operação
- implementa serviço de dashboard com agregações, exportação CSV/Excel e transmissão SSE para atualizações em tempo real
- cria projeções, DTOs e testes de repositório para validar métricas agregadas
- inclui dependências para OpenCSV, Apache POI e H2 para suporte a exportações e testes

## Testes
- mvn -q test *(falha: bloqueio 403 ao baixar dependências do parent Spring Boot)*

------
https://chatgpt.com/codex/tasks/task_e_68eb8e30eb308327b52e69b843ce6afd