### PR TITLE
Ajusta fluxo de validação de token no serviço de autenticação

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/TokenService.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/TokenService.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import java.util.Optional;
 
 @Service
 public class TokenService {
@@ -32,17 +33,18 @@ public class TokenService {
         }
     }
 
-    public String validateToken(String token){
+    public Optional<String> validateToken(String token){
         try {
             Algorithm algorithm = Algorithm.HMAC256(secret);
-            return JWT.require(algorithm)
+            var subject = JWT.require(algorithm)
                     .withIssuer("auth-api")
                     .build()
                     .verify(token)
                     .getSubject();
+            return Optional.ofNullable(subject);
         } catch (JWTVerificationException exception){
-            // SECURITY: retorna nulo para evitar autenticação com tokens inválidos
-            return null;
+            // SECURITY: evita autenticação com tokens inválidos propagando ausência de subject
+            return Optional.empty();
         }
     }
 

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/config/SecurityFilterTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/config/SecurityFilterTest.java
@@ -1,0 +1,64 @@
+package br.com.cloudport.servicoautenticacao.config;
+
+import br.com.cloudport.servicoautenticacao.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SecurityFilterTest {
+
+    private SecurityFilter securityFilter;
+    private TokenService tokenService;
+    private UserRepository userRepository;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        securityFilter = new SecurityFilter();
+        tokenService = mock(TokenService.class);
+        userRepository = mock(UserRepository.class);
+        filterChain = mock(FilterChain.class);
+
+        securityFilter.tokenService = tokenService;
+        securityFilter.userRepository = userRepository;
+    }
+
+    @Test
+    void deveRetornar401QuandoTokenInvalidoSemConsultarRepositorio() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer invalid");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(tokenService.validateToken("invalid")).thenReturn(Optional.empty());
+
+        securityFilter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(401, response.getStatus());
+        verify(tokenService).validateToken("invalid");
+        verifyNoInteractions(userRepository);
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void deveRetornar401QuandoTokenAusenteSemConsultarTokenService() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        securityFilter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(401, response.getStatus());
+        verifyNoInteractions(tokenService);
+        verifyNoInteractions(userRepository);
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+}


### PR DESCRIPTION
## Resumo
- altera a validação do TokenService para retornar Optional e sinalizar tokens inválidos
- atualiza o SecurityFilter para responder 401 quando o token estiver ausente ou inválido, evitando consultas ao repositório
- adiciona testes unitários assegurando que tokens inválidos não disparam consultas ao repositório e geram 401

## Testes
- `mvn test` *(falha: impossibilidade de baixar dependências do Spring Boot Starter Parent - HTTP 403 do Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68eceece6e888327921b3d82125fcf1c