### PR TITLE
Ajusta fechamento do menu de contexto

### DIFF
--- a/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
+++ b/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.component.ts
@@ -205,11 +205,26 @@ console.log("handleTableContextMenu: ", event)
 
 
   closeContextMenu(event: MouseEvent): void {
-    const target = event?.target as Node | null;
-    const clickedInsideGrid = !!(target && this.gridTable?.nativeElement?.contains(target));
+    if (!event) {
+      return;
+    }
 
-    const contextMenuElement = document.querySelector('.context-menu');
-    const clickedInsideMenu = !!(target && contextMenuElement?.contains(target));
+    const target = event.target as Node | null;
+    const gridElement = this.gridTable?.nativeElement as HTMLElement | undefined;
+    const contextMenuElement = document.querySelector('.context-menu') as HTMLElement | null;
+    const eventPath: EventTarget[] = typeof event.composedPath === 'function' ? event.composedPath() : [];
+
+    const clickedInsideGrid = !!(
+      target &&
+      gridElement &&
+      (gridElement.contains(target) || eventPath.includes(gridElement))
+    );
+
+    const clickedInsideMenu = !!(
+      target &&
+      contextMenuElement &&
+      (contextMenuElement.contains(target) || eventPath.includes(contextMenuElement))
+    );
 
     if (!clickedInsideGrid && !clickedInsideMenu) {
       this.rightClick.emit(null);


### PR DESCRIPTION
## Summary
- impede o fechamento imediato do menu de contexto quando o clique ocorre no grid ou no próprio menu
- adiciona validações adicionais ao método `closeContextMenu` para identificar cliques dentro ou fora da área da tabela

## Testing
- not run (não é possível realizar testes manuais neste ambiente)


------
https://chatgpt.com/codex/tasks/task_e_68ecee548628832783965fe22ebd06d0