### PR TITLE
feat: configurar declarações AMQP para hardware do gate

### DIFF
--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/HardwareRabbitConfiguration.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/HardwareRabbitConfiguration.java
@@ -1,0 +1,28 @@
+package br.com.cloudport.servicogate.config;
+
+import org.springframework.amqp.core.Declarables;
+import org.springframework.amqp.core.ExchangeBuilder;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@Configuration
+@EnableConfigurationProperties(HardwareIntegrationProperties.class)
+public class HardwareRabbitConfiguration {
+
+    private final HardwareIntegrationProperties properties;
+
+    public HardwareRabbitConfiguration(HardwareIntegrationProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean
+    public Declarables gateHardwareDeclarables() {
+        return new Declarables(
+                QueueBuilder.durable(properties.getEntradaQueue()).build(),
+                QueueBuilder.durable(properties.getSaidaQueue()).build(),
+                ExchangeBuilder.directExchange(properties.getDecisaoExchange()).durable(true).build()
+        );
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/OpenApiConfig.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/OpenApiConfig.java
@@ -13,8 +13,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 @EnableConfigurationProperties({
         AgendamentoRulesProperties.class,
         DocumentoStorageProperties.class,
-        GateFlowProperties.class,
-        HardwareIntegrationProperties.class
+        GateFlowProperties.class
 })
 public class OpenApiConfig {
 


### PR DESCRIPTION
## Resumo
- adiciona a configuração `HardwareRabbitConfiguration` para declarar as filas de entrada/saída e o exchange de decisões do gate
- centraliza o carregamento das propriedades de integração de hardware na nova configuração

## Testes
- `mvn test` *(falhou: erro 403 ao baixar dependências do Maven Central no ambiente de execução)*

------
https://chatgpt.com/codex/tasks/task_e_68ecee38aafc8327a370a13cb290a202