### PR TITLE
Adjust home routing to default role tab

### DIFF
--- a/frontend/cloudport/src/app/app-routing.module.ts
+++ b/frontend/cloudport/src/app/app-routing.module.ts
@@ -5,16 +5,18 @@ import { HomeComponent } from './componentes/home/home.component';
 import { RoleTabelaComponent } from './componentes/role/role-tabela/role-tabela.component';
 import { AuthGuard } from './componentes/service/servico-autenticacao/auth.guard';
 
+const homeChildRoutes: Routes = [
+  { path: '', redirectTo: 'role', pathMatch: 'full' },
+  { path: 'role', component: RoleTabelaComponent },
+];
+
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
   {
     path: 'home',
     component: HomeComponent,
     canActivate: [AuthGuard],
-    children: [
-      { path: '', redirectTo: 'role', pathMatch: 'full' },
-      { path: 'role', component: RoleTabelaComponent },
-    ]
+    children: homeChildRoutes
   },
   { path: '', redirectTo: 'home', pathMatch: 'full' },
 ];

--- a/frontend/cloudport/src/app/componentes/home/home.component.ts
+++ b/frontend/cloudport/src/app/componentes/home/home.component.ts
@@ -19,7 +19,8 @@ export class HomeComponent implements OnInit  {
   filteredData: any[] = [];
   data: { [key: string]: any } = {};
   tabContent: { [key: string]: any } = {};
-  private readonly validChildRoutes = new Set(['role']);
+  private readonly defaultChildRoute = 'role';
+  private readonly validChildRoutes = new Set([this.defaultChildRoute]);
 
   constructor(
     private router: Router,
@@ -42,6 +43,9 @@ export class HomeComponent implements OnInit  {
       if (tabs.length > 0) {
         this.selectedTab = tabs[tabs.length - 1];
         this.router.navigate(['/home', this.resolveChildRoute(this.selectedTab)]);
+      } else {
+        this.selectedTab = this.defaultChildRoute;
+        this.router.navigate(['/home', this.defaultChildRoute]);
       }
     });
     (this.reuseStrategy as CustomReuseStrategy).markForDestruction('login'.toLowerCase());
@@ -83,7 +87,7 @@ export class HomeComponent implements OnInit  {
 
   private resolveChildRoute(tabName: string): string {
     const normalizedTab = tabName ? tabName.toLowerCase() : '';
-    return this.validChildRoutes.has(normalizedTab) ? normalizedTab : 'role';
+    return this.validChildRoutes.has(normalizedTab) ? normalizedTab : this.defaultChildRoute;
   }
 
 

--- a/frontend/cloudport/src/app/componentes/login/login.component.spec.ts
+++ b/frontend/cloudport/src/app/componentes/login/login.component.spec.ts
@@ -50,17 +50,17 @@ describe('LoginComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should default returnUrl to /home when query param is missing', () => {
-    expect(component.returnUrl).toBe('/home');
+  it('should default returnUrl to /home/role when query param is missing', () => {
+    expect(component.returnUrl).toBe('/home/role');
   });
 
-  it('should redirect to /home when login succeeds without returnUrl', () => {
+  it('should redirect to /home/role when login succeeds without returnUrl', () => {
     const router = TestBed.inject(Router);
     const navigateSpy = spyOn(router, 'navigateByUrl');
 
     component.loginForm.setValue({ username: 'john', password: 'secret' });
     component.onSubmit();
 
-    expect(navigateSpy).toHaveBeenCalledWith('/home');
+    expect(navigateSpy).toHaveBeenCalledWith('/home/role');
   });
 });

--- a/frontend/cloudport/src/app/componentes/login/login.component.ts
+++ b/frontend/cloudport/src/app/componentes/login/login.component.ts
@@ -22,11 +22,13 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
         ])
     ]
 })
+const DEFAULT_PROTECTED_ROUTE = '/home/role';
+
 export class LoginComponent implements OnInit {
     loginForm: FormGroup = this.formBuilder.group({}); // Initialized here
     loading = false;
     submitted = false;
-    returnUrl: string = '/home'; // Initialized with a sensible default route
+    returnUrl: string = DEFAULT_PROTECTED_ROUTE; // Initialized with a sensible default route
     error = '';
 
     constructor(
@@ -53,7 +55,7 @@ export class LoginComponent implements OnInit {
         // get return url from route parameters or default to '/'
         const requestedReturnUrl = this.route.snapshot.queryParams['returnUrl'];
         const hasCustomReturnUrl = typeof requestedReturnUrl === 'string' && requestedReturnUrl.trim().length > 0;
-        this.returnUrl = hasCustomReturnUrl ? requestedReturnUrl : '/home';
+        this.returnUrl = hasCustomReturnUrl ? requestedReturnUrl : DEFAULT_PROTECTED_ROUTE;
         (this.reuseStrategy as CustomReuseStrategy).markForDestruction('login'.toLowerCase());
     }
 

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -22,7 +22,8 @@ function logMethod(target: any, key: string, descriptor: PropertyDescriptor) {
 })
 export class NavbarComponent implements OnInit, OnDestroy {
   mostrarMenu: boolean = false;
-  private readonly validChildRoutes = new Set(['role']);
+  private readonly defaultChildRoute = 'role';
+  private readonly validChildRoutes = new Set([this.defaultChildRoute]);
   private menuStatusSubscription?: Subscription;
 
   constructor(
@@ -91,6 +92,6 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   private resolveChildRoute(tabName: string): string {
     const normalizedTab = tabName ? tabName.toLowerCase() : '';
-    return this.validChildRoutes.has(normalizedTab) ? normalizedTab : 'role';
+    return this.validChildRoutes.has(normalizedTab) ? normalizedTab : this.defaultChildRoute;
   }
 }


### PR DESCRIPTION
## Summary
- isolate the protected /home children to internal routes and add a default redirect to the role tab
- default HomeComponent and Navbar navigation helpers to the role child route when no specific tab is open
- ensure the login flow routes authenticated users to the protected role tab by default and update related tests

## Testing
- `npm test -- --watch=false` *(fails: ng command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf1c1d23c8327ad95cd73085228d6