### PR TITLE
Add role-based security integration across gate and auth services

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/SecurityConfigurations.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/SecurityConfigurations.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfigurations {
 
     @Autowired
@@ -45,7 +47,7 @@ public class SecurityConfigurations {
                     .antMatchers(HttpMethod.POST, "/auth").permitAll()
                     .antMatchers(HttpMethod.POST, "/auth/login").permitAll()
                     .antMatchers(HttpMethod.POST, "/auth/register").permitAll()
-                    .antMatchers(HttpMethod.POST, "/product").hasRole("ADMIN")
+                    .antMatchers(HttpMethod.POST, "/product").hasRole("ADMIN_PORTO")
                     .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/TokenService.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/TokenService.java
@@ -4,15 +4,22 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import br.com.cloudport.servicoautenticacao.model.Role;
 import br.com.cloudport.servicoautenticacao.model.User;
+import br.com.cloudport.servicoautenticacao.model.UserRole;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 @Service
 public class TokenService {
@@ -22,12 +29,26 @@ public class TokenService {
     public String generateToken(User user){
         try{
             Algorithm algorithm = Algorithm.HMAC256(secret);
-            String token = JWT.create()
+            Set<String> roles = Optional.ofNullable(user.getRoles()).orElseGet(java.util.Collections::emptySet).stream()
+                    .map(UserRole::getRole)
+                    .map(Role::getName)
+                    .filter(StringUtils::hasText)
+                    .map(role -> role.startsWith("ROLE_") ? role : "ROLE_" + role.toUpperCase())
+                    .collect(Collectors.toSet());
+
+            String perfil = roles.stream().findFirst().orElse(null);
+
+            return JWT.create()
                     .withIssuer("auth-api")
                     .withSubject(user.getLogin())
+                    .withClaim("userId", user.getId() != null ? user.getId().toString() : null)
+                    .withClaim("nome", user.getNome())
+                    .withClaim("perfil", perfil)
+                    .withClaim("roles", CollectionUtils.isEmpty(roles) ? null : roles)
+                    .withClaim("transportadoraDocumento", user.getTransportadoraDocumento())
+                    .withClaim("transportadoraNome", user.getTransportadoraNome())
                     .withExpiresAt(Date.from(genExpirationDate()))
                     .sign(algorithm);
-            return token;
         } catch (JWTCreationException exception) {
             throw new RuntimeException("Error while generating token", exception);
         }

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java
@@ -27,18 +27,17 @@ public class UserInitializer implements CommandLineRunner {
         String adminLogin = "gitpod";
         String adminPassword = new BCryptPasswordEncoder().encode("gitpod");
 
-        Role adminRole = roleRepository.findByName("ADMIN")
-                             .orElseGet(() -> {
-                                 Role newAdminRole = new Role("ADMIN");
-                                 roleRepository.save(newAdminRole);
-                                 return newAdminRole;
-                             });
+        Role adminRole = ensureRoleExists("ROLE_ADMIN_PORTO");
+        ensureRoleExists("ROLE_PLANEJADOR");
+        ensureRoleExists("ROLE_OPERADOR_GATE");
+        ensureRoleExists("ROLE_TRANSPORTADORA");
 
         Set<UserRole> roles = new HashSet<>();
         roles.add(new UserRole(adminRole));
 
         if (!userRepository.findByLogin(adminLogin).isPresent()) {
-            User adminUser = new User(adminLogin, adminPassword, roles);
+            User adminUser = new User(adminLogin, adminPassword, "Administrador CloudPort",
+                    null, null, roles);
 
             for (UserRole userRole : roles) {
                 userRole.setUser(adminUser);
@@ -46,5 +45,13 @@ public class UserInitializer implements CommandLineRunner {
 
             userRepository.save(adminUser);
         }
+    }
+
+    private Role ensureRoleExists(String roleName) {
+        return roleRepository.findByName(roleName)
+                .orElseGet(() -> {
+                    Role role = new Role(roleName);
+                    return roleRepository.save(role);
+                });
     }
 }

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/LoginResponseDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/LoginResponseDTO.java
@@ -11,14 +11,25 @@ public class LoginResponseDTO {
     private final String perfil;
     private final String token;
     private final Set<String> roles;
+    private final String transportadoraDocumento;
+    private final String transportadoraNome;
 
-    public LoginResponseDTO(UUID id, String login, String nome, String perfil, String token, Set<String> roles) {
+    public LoginResponseDTO(UUID id,
+                            String login,
+                            String nome,
+                            String perfil,
+                            String token,
+                            Set<String> roles,
+                            String transportadoraDocumento,
+                            String transportadoraNome) {
         this.id = id;
         this.login = login;
         this.nome = nome;
         this.perfil = perfil;
         this.token = token;
         this.roles = roles;
+        this.transportadoraDocumento = transportadoraDocumento;
+        this.transportadoraNome = transportadoraNome;
     }
 
     public UUID getId() {
@@ -43,6 +54,14 @@ public class LoginResponseDTO {
 
     public Set<String> getRoles() {
         return roles;
+    }
+
+    public String getTransportadoraDocumento() {
+        return transportadoraDocumento;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
     }
 }
 

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/RegisterDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/RegisterDTO.java
@@ -19,12 +19,26 @@ public class RegisterDTO {
     @NotEmpty(message = "Informe ao menos uma role.")
     private Set<@NotBlank(message = "A role não pode ser vazia.") String> roles;
 
+    private String nome;
+
+    private String transportadoraDocumento;
+
+    private String transportadoraNome;
+
     public RegisterDTO() {}
 
     public RegisterDTO(String login, String password, Set<String> roles) {
         this.login = login;
         this.password = password;
         this.roles = roles;
+    }
+
+    public RegisterDTO(String login, String password, Set<String> roles, String nome,
+                       String transportadoraDocumento, String transportadoraNome) {
+        this(login, password, roles);
+        this.nome = nome;
+        this.transportadoraDocumento = transportadoraDocumento;
+        this.transportadoraNome = transportadoraNome;
     }
 
     public String getLogin() {
@@ -49,5 +63,29 @@ public class RegisterDTO {
 
     public void setRoles(Set<String> roles) {
         this.roles = roles;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getTransportadoraDocumento() {
+        return transportadoraDocumento;
+    }
+
+    public void setTransportadoraDocumento(String transportadoraDocumento) {
+        this.transportadoraDocumento = transportadoraDocumento;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+
+    public void setTransportadoraNome(String transportadoraNome) {
+        this.transportadoraNome = transportadoraNome;
     }
 }

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/UserInfoDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/UserInfoDTO.java
@@ -1,0 +1,85 @@
+package br.com.cloudport.servicoautenticacao.dto;
+
+import br.com.cloudport.servicoautenticacao.model.Role;
+import br.com.cloudport.servicoautenticacao.model.User;
+import br.com.cloudport.servicoautenticacao.model.UserRole;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.util.StringUtils;
+
+public class UserInfoDTO {
+
+    private final UUID id;
+    private final String login;
+    private final String nome;
+    private final Set<String> roles;
+    private final String perfil;
+    private final String transportadoraDocumento;
+    private final String transportadoraNome;
+
+    public UserInfoDTO(UUID id,
+                       String login,
+                       String nome,
+                       Set<String> roles,
+                       String perfil,
+                       String transportadoraDocumento,
+                       String transportadoraNome) {
+        this.id = id;
+        this.login = login;
+        this.nome = nome;
+        this.roles = roles;
+        this.perfil = perfil;
+        this.transportadoraDocumento = transportadoraDocumento;
+        this.transportadoraNome = transportadoraNome;
+    }
+
+    public static UserInfoDTO fromUser(User user) {
+        Set<String> roles = user.getRoles().stream()
+                .map(UserRole::getRole)
+                .map(Role::getName)
+                .filter(StringUtils::hasText)
+                .map(roleName -> roleName.startsWith("ROLE_") ? roleName : "ROLE_" + roleName.toUpperCase())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        String perfil = roles.stream().findFirst().orElse("");
+        String nome = StringUtils.hasText(user.getNome()) ? user.getNome() : user.getLogin();
+        return new UserInfoDTO(
+                user.getId(),
+                user.getLogin(),
+                nome,
+                roles,
+                perfil,
+                user.getTransportadoraDocumento(),
+                user.getTransportadoraNome()
+        );
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public String getPerfil() {
+        return perfil;
+    }
+
+    public String getTransportadoraDocumento() {
+        return transportadoraDocumento;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/model/User.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/model/User.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -30,6 +31,15 @@ public class User implements UserDetails {
     @Column
     private String password;
 
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "transportadora_documento")
+    private String transportadoraDocumento;
+
+    @Column(name = "transportadora_nome")
+    private String transportadoraNome;
+
     @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private Set<UserRole> roles;
 
@@ -40,10 +50,23 @@ public class User implements UserDetails {
         this.roles = roles;
     }
 
+    public User(String login, String password, String nome, String transportadoraDocumento,
+                String transportadoraNome, Set<UserRole> roles) {
+        this(login, password, roles);
+        this.nome = nome;
+        this.transportadoraDocumento = transportadoraDocumento;
+        this.transportadoraNome = transportadoraNome;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return this.roles.stream()
-                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.getRole().getName().toUpperCase()))
+                .map(UserRole::getRole)
+                .filter(Objects::nonNull)
+                .map(Role::getName)
+                .filter(Objects::nonNull)
+                .map(name -> name.startsWith("ROLE_") ? name : "ROLE_" + name.toUpperCase())
+                .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }
 
@@ -75,5 +98,29 @@ public class User implements UserDetails {
     @Override
     public String getPassword() {
         return password;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getTransportadoraDocumento() {
+        return transportadoraDocumento;
+    }
+
+    public void setTransportadoraDocumento(String transportadoraDocumento) {
+        this.transportadoraDocumento = transportadoraDocumento;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+
+    public void setTransportadoraNome(String transportadoraNome) {
+        this.transportadoraNome = transportadoraNome;
     }
 }

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/model/UserRoleEnum.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/model/UserRoleEnum.java
@@ -1,8 +1,10 @@
 package br.com.cloudport.servicoautenticacao.model;
 
 public enum UserRoleEnum {
-    ADMIN("admin"),
-    USER("user");
+    ADMIN_PORTO("ROLE_ADMIN_PORTO"),
+    PLANEJADOR("ROLE_PLANEJADOR"),
+    OPERADOR_GATE("ROLE_OPERADOR_GATE"),
+    TRANSPORTADORA("ROLE_TRANSPORTADORA");
 
     private final String role;
 

--- a/backend/servico-gate/pom.xml
+++ b/backend/servico-gate/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
@@ -95,6 +99,11 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/GateFlowProperties.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/GateFlowProperties.java
@@ -2,6 +2,7 @@ package br.com.cloudport.servicogate.config;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -12,7 +13,7 @@ public class GateFlowProperties {
     private Duration toleranciaEntradaAtraso = Duration.ofMinutes(30);
     private Duration toleranciaSaidaAntecipada = Duration.ofMinutes(30);
     private Duration toleranciaSaidaAtraso = Duration.ofMinutes(30);
-    private List<String> rolesLiberacaoManual = new ArrayList<>();
+    private List<String> rolesLiberacaoManual = new ArrayList<>(Collections.singletonList("ROLE_OPERADOR_GATE"));
 
     public Duration getToleranciaEntradaAntecipada() {
         return toleranciaEntradaAntecipada;

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/SecurityConfig.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/config/SecurityConfig.java
@@ -1,0 +1,132 @@
+package br.com.cloudport.servicogate.config;
+
+import br.com.cloudport.servicogate.security.TransportadoraSynchronizationFilter;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+
+    private final TransportadoraSynchronizationFilter transportadoraSynchronizationFilter;
+    private final String jwtSecret;
+    private final String allowedOrigins;
+
+    public SecurityConfig(TransportadoraSynchronizationFilter transportadoraSynchronizationFilter,
+                          @Value("${cloudport.security.jwt.secret}") String jwtSecret,
+                          @Value("${cloudport.security.cors.allowed-origins:http://localhost:3000}") String allowedOrigins) {
+        this.transportadoraSynchronizationFilter = transportadoraSynchronizationFilter;
+        this.jwtSecret = jwtSecret;
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors().configurationSource(corsConfigurationSource()).and()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+                .authorizeRequests(authorize -> authorize
+                        .antMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .antMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
+                        .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
+
+        http.addFilterAfter(transportadoraSynchronizationFilter, BearerTokenAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        SecretKey secretKey = new SecretKeySpec(jwtSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(secretKey).build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(jwtGrantedAuthoritiesConverter());
+        converter.setPrincipalClaimName(JwtClaimNames.SUB);
+        return converter;
+    }
+
+    private Converter<Jwt, List<SimpleGrantedAuthority>> jwtGrantedAuthoritiesConverter() {
+        return jwt -> {
+            List<String> roles = Optional.ofNullable(jwt.getClaimAsStringList("roles"))
+                    .orElseGet(() -> {
+                        String role = jwt.getClaimAsString("role");
+                        return StringUtils.hasText(role) ? Collections.singletonList(role) : Collections.emptyList();
+                    });
+
+            return roles.stream()
+                    .filter(StringUtils::hasText)
+                    .map(role -> role.startsWith("ROLE_") ? role : "ROLE_" + role.toUpperCase(Locale.ROOT))
+                    .distinct()
+                    .map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toList());
+        };
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toList());
+        if (origins.isEmpty()) {
+            origins = Collections.singletonList("http://localhost:3000");
+        }
+        configuration.setAllowedOrigins(origins);
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Accept"));
+        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(Duration.ofHours(1));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public RestTemplate securityRestTemplate(RestTemplateBuilder builder) {
+        return builder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/AgendamentoController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/AgendamentoController.java
@@ -20,6 +20,7 @@ import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,6 +48,7 @@ public class AgendamentoController {
 
     @GetMapping
     @Operation(summary = "Lista agendamentos com filtros de período e paginação")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE','TRANSPORTADORA')")
     public Page<AgendamentoDTO> listar(@Parameter(description = "Data inicial do período (inclusive)")
                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicio,
                                        @Parameter(description = "Data final do período (inclusive)")
@@ -57,12 +59,14 @@ public class AgendamentoController {
 
     @GetMapping("/{id}")
     @Operation(summary = "Detalha um agendamento específico")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE','TRANSPORTADORA')")
     public AgendamentoDTO buscarPorId(@PathVariable Long id) {
         return agendamentoService.buscarPorId(id);
     }
 
     @PostMapping
     @Operation(summary = "Cria um novo agendamento")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR')")
     public ResponseEntity<AgendamentoDTO> criar(@Valid @RequestBody AgendamentoRequest request) {
         AgendamentoDTO criado = agendamentoService.criar(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(criado);
@@ -70,12 +74,14 @@ public class AgendamentoController {
 
     @PutMapping("/{id}")
     @Operation(summary = "Atualiza um agendamento existente")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR')")
     public AgendamentoDTO atualizar(@PathVariable Long id, @Valid @RequestBody AgendamentoRequest request) {
         return agendamentoService.atualizar(id, request);
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Cancela um agendamento")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR')")
     public ResponseEntity<Void> cancelar(@PathVariable Long id) {
         agendamentoService.cancelar(id);
         return ResponseEntity.noContent().build();
@@ -83,6 +89,7 @@ public class AgendamentoController {
 
     @PostMapping(value = "/{id}/documentos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "Realiza upload de documento para o agendamento")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE','TRANSPORTADORA')")
     public ResponseEntity<DocumentoAgendamentoDTO> uploadDocumento(@PathVariable Long id,
                                                                    @Valid @RequestPart("metadata") DocumentoUploadRequest metadata,
                                                                    @RequestPart("file") MultipartFile arquivo) {
@@ -92,12 +99,14 @@ public class AgendamentoController {
 
     @GetMapping("/{id}/documentos")
     @Operation(summary = "Lista documentos de um agendamento")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE','TRANSPORTADORA')")
     public List<DocumentoAgendamentoDTO> listarDocumentos(@PathVariable Long id) {
         return agendamentoService.listarDocumentos(id);
     }
 
     @GetMapping("/{agendamentoId}/documentos/{documentoId}")
     @Operation(summary = "Download de documento do agendamento")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE','TRANSPORTADORA')")
     public ResponseEntity<org.springframework.core.io.Resource> downloadDocumento(@PathVariable Long agendamentoId,
                                                                                   @PathVariable Long documentoId) {
         DocumentoDownload download = agendamentoService.baixarDocumento(agendamentoId, documentoId);

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/ConfigController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/ConfigController.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,30 +29,35 @@ public class ConfigController {
 
     @GetMapping("/tipos-operacao")
     @Operation(summary = "Lista os tipos de operação disponíveis")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<List<EnumResponseDTO>> listarTiposOperacao() {
         return buildEnumResponse(TipoOperacao.values(), TipoOperacao::getDescricao);
     }
 
     @GetMapping("/status-agendamento")
     @Operation(summary = "Lista os status possíveis de um agendamento")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<List<EnumResponseDTO>> listarStatusAgendamento() {
         return buildEnumResponse(StatusAgendamento.values(), StatusAgendamento::getDescricao);
     }
 
     @GetMapping("/status-gate")
     @Operation(summary = "Lista os status disponíveis para um gate pass")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<List<EnumResponseDTO>> listarStatusGate() {
         return buildEnumResponse(StatusGate.values(), StatusGate::getDescricao);
     }
 
     @GetMapping("/motivos-excecao")
     @Operation(summary = "Lista os motivos de exceção configurados")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<List<EnumResponseDTO>> listarMotivosExcecao() {
         return buildEnumResponse(MotivoExcecao.values(), MotivoExcecao::getDescricao);
     }
 
     @GetMapping("/canais-entrada")
     @Operation(summary = "Lista os canais de entrada aceitos pela operação")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<List<EnumResponseDTO>> listarCanaisEntrada() {
         return buildEnumResponse(CanalEntrada.values(), CanalEntrada::getDescricao);
     }

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/DashboardController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/DashboardController.java
@@ -7,6 +7,7 @@ import br.com.cloudport.servicogate.service.DashboardService;
 import java.time.LocalDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,6 +25,7 @@ public class DashboardController {
     }
 
     @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE')")
     public DashboardResumoDTO consultar(
             @RequestParam(value = "inicio", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime inicio,
@@ -37,6 +39,7 @@ public class DashboardController {
     }
 
     @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE')")
     public SseEmitter streamDashboard() {
         return dashboardService.registrarAssinante();
     }

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/GateFlowController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/GateFlowController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,6 +30,7 @@ public class GateFlowController {
 
     @PostMapping("/entrada")
     @Operation(summary = "Processa um evento de entrada identificado por placa ou QR code")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE')")
     public ResponseEntity<GateDecisionDTO> registrarEntrada(@Valid @RequestBody GateFlowRequest request) {
         GateDecisionDTO decision = gateFlowService.registrarEntrada(request);
         return ResponseEntity.ok(decision);
@@ -36,6 +38,7 @@ public class GateFlowController {
 
     @PostMapping("/saida")
     @Operation(summary = "Processa um evento de saída identificado por placa ou QR code")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE')")
     public ResponseEntity<GateDecisionDTO> registrarSaida(@Valid @RequestBody GateFlowRequest request) {
         GateDecisionDTO decision = gateFlowService.registrarSaida(request);
         return ResponseEntity.ok(decision);
@@ -43,6 +46,7 @@ public class GateFlowController {
 
     @PostMapping("/agendamentos/{id}/liberacao-manual")
     @Operation(summary = "Registra liberação ou bloqueio manual para um agendamento")
+    @PreAuthorize("hasRole('OPERADOR_GATE')")
     public ResponseEntity<GateEventDTO> liberarManual(@PathVariable("id") Long agendamentoId,
                                                       @Valid @RequestBody ManualReleaseRequest request) {
         GateEventDTO evento = gateFlowService.liberarManual(agendamentoId, request);
@@ -51,6 +55,7 @@ public class GateFlowController {
 
     @PostMapping("/agendamentos/{id}/sincronizar")
     @Operation(summary = "Força a ressincronização das informações do agendamento com o TOS")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE','PLANEJADOR')")
     public ResponseEntity<TosSyncResponse> sincronizar(@PathVariable("id") Long agendamentoId) {
         TosSyncResponse sincronizacao = gateFlowService.sincronizarAgendamento(agendamentoId);
         return ResponseEntity.ok(sincronizacao);

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/RelatorioController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/RelatorioController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,6 +30,7 @@ public class RelatorioController {
     }
 
     @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE')")
     public RelatorioResponseDTO consultar(
             @RequestParam(value = "inicio", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime inicio,
@@ -43,6 +45,7 @@ public class RelatorioController {
     }
 
     @GetMapping("/export")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE')")
     public ResponseEntity<byte[]> exportar(
             @RequestParam(value = "inicio", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime inicio,

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/security/AutenticacaoClient.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/security/AutenticacaoClient.java
@@ -1,0 +1,49 @@
+package br.com.cloudport.servicogate.security;
+
+import java.net.URI;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class AutenticacaoClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutenticacaoClient.class);
+
+    private final RestTemplate restTemplate;
+    private final String autenticacaoBaseUrl;
+
+    public AutenticacaoClient(RestTemplate restTemplate,
+                              @Value("${cloudport.security.autenticacao.base-url}") String autenticacaoBaseUrl) {
+        this.restTemplate = restTemplate;
+        this.autenticacaoBaseUrl = autenticacaoBaseUrl;
+    }
+
+    public Optional<UserInfoResponse> buscarUsuario(String login, String authorizationHeader) {
+        if (!StringUtils.hasText(autenticacaoBaseUrl) || !StringUtils.hasText(login)) {
+            return Optional.empty();
+        }
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            if (StringUtils.hasText(authorizationHeader)) {
+                headers.set(HttpHeaders.AUTHORIZATION, authorizationHeader);
+            }
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+            URI uri = URI.create(String.format("%s/auth/usuarios/%s", autenticacaoBaseUrl, login));
+            ResponseEntity<UserInfoResponse> response = restTemplate.exchange(uri, HttpMethod.GET, entity, UserInfoResponse.class);
+            return Optional.ofNullable(response.getBody());
+        } catch (RestClientException ex) {
+            LOGGER.debug("Falha ao buscar usuário {} no serviço de autenticação", login, ex);
+            return Optional.empty();
+        }
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/security/TransportadoraSyncService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/security/TransportadoraSyncService.java
@@ -1,0 +1,42 @@
+package br.com.cloudport.servicogate.security;
+
+import br.com.cloudport.servicogate.model.Transportadora;
+import br.com.cloudport.servicogate.repository.TransportadoraRepository;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class TransportadoraSyncService {
+
+    private final TransportadoraRepository transportadoraRepository;
+
+    public TransportadoraSyncService(TransportadoraRepository transportadoraRepository) {
+        this.transportadoraRepository = transportadoraRepository;
+    }
+
+    @Transactional
+    public void sincronizarTransportadora(String documento, String nome) {
+        if (!StringUtils.hasText(documento)) {
+            return;
+        }
+
+        String normalizedDocumento = documento.replaceAll("[^0-9A-Za-z]", "").toUpperCase(Locale.ROOT);
+        Optional<Transportadora> existente = transportadoraRepository.findByDocumento(normalizedDocumento);
+        if (existente.isPresent()) {
+            Transportadora transportadora = existente.get();
+            if (StringUtils.hasText(nome) && !nome.equals(transportadora.getNome())) {
+                transportadora.setNome(nome);
+                transportadoraRepository.save(transportadora);
+            }
+            return;
+        }
+
+        Transportadora nova = new Transportadora();
+        nova.setDocumento(normalizedDocumento);
+        nova.setNome(StringUtils.hasText(nome) ? nome : normalizedDocumento);
+        transportadoraRepository.save(nova);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/security/TransportadoraSynchronizationFilter.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/security/TransportadoraSynchronizationFilter.java
@@ -1,0 +1,59 @@
+package br.com.cloudport.servicogate.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class TransportadoraSynchronizationFilter extends OncePerRequestFilter {
+
+    private final TransportadoraSyncService transportadoraSyncService;
+    private final AutenticacaoClient autenticacaoClient;
+
+    public TransportadoraSynchronizationFilter(TransportadoraSyncService transportadoraSyncService,
+                                               AutenticacaoClient autenticacaoClient) {
+        this.transportadoraSyncService = transportadoraSyncService;
+        this.autenticacaoClient = autenticacaoClient;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof JwtAuthenticationToken) {
+            JwtAuthenticationToken jwtAuthentication = (JwtAuthenticationToken) authentication;
+            Jwt token = jwtAuthentication.getToken();
+            String documento = token.getClaimAsString("transportadoraDocumento");
+            if (!StringUtils.hasText(documento)) {
+                documento = token.getClaimAsString("transportadoraCnpj");
+            }
+            String nome = token.getClaimAsString("transportadoraNome");
+
+            if (!StringUtils.hasText(documento) || !StringUtils.hasText(nome)) {
+                var info = autenticacaoClient.buscarUsuario(token.getSubject(), request.getHeader(HttpHeaders.AUTHORIZATION));
+                if (!StringUtils.hasText(documento)) {
+                    documento = info.map(UserInfoResponse::getTransportadoraDocumento).orElse(null);
+                }
+                if (!StringUtils.hasText(nome)) {
+                    nome = info.map(UserInfoResponse::getTransportadoraNome).orElse(null);
+                }
+            }
+
+            if (StringUtils.hasText(documento)) {
+                transportadoraSyncService.sincronizarTransportadora(documento, nome);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/security/UserInfoResponse.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/security/UserInfoResponse.java
@@ -1,0 +1,73 @@
+package br.com.cloudport.servicogate.security;
+
+import java.util.Set;
+
+public class UserInfoResponse {
+
+    private String id;
+    private String login;
+    private String nome;
+    private String perfil;
+    private Set<String> roles;
+    private String transportadoraDocumento;
+    private String transportadoraNome;
+
+    public UserInfoResponse() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getPerfil() {
+        return perfil;
+    }
+
+    public void setPerfil(String perfil) {
+        this.perfil = perfil;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+
+    public String getTransportadoraDocumento() {
+        return transportadoraDocumento;
+    }
+
+    public void setTransportadoraDocumento(String transportadoraDocumento) {
+        this.transportadoraDocumento = transportadoraDocumento;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+
+    public void setTransportadoraNome(String transportadoraNome) {
+        this.transportadoraNome = transportadoraNome;
+    }
+}

--- a/backend/servico-gate/src/main/resources/application.properties
+++ b/backend/servico-gate/src/main/resources/application.properties
@@ -17,6 +17,10 @@ spring.rabbitmq.port=${GATE_RABBIT_PORT:5672}
 spring.rabbitmq.username=${GATE_RABBIT_USERNAME:guest}
 spring.rabbitmq.password=${GATE_RABBIT_PASSWORD:guest}
 
+cloudport.security.jwt.secret=${GATE_SECURITY_JWT_SECRET:change-me}
+cloudport.security.cors.allowed-origins=${GATE_SECURITY_CORS_ALLOWED_ORIGINS:http://localhost:3000}
+cloudport.security.autenticacao.base-url=${GATE_SECURITY_AUTENTICACAO_BASE_URL:http://localhost:8081}
+
 management.endpoints.web.exposure.include=health,info,metrics
 management.endpoint.health.probes.enabled=true
 springdoc.api-docs.path=/api-docs
@@ -41,7 +45,7 @@ cloudport.gate.flow.tolerancia-entrada-antecipada=${GATE_TOL_ENTRADA_ANTEC:PT30M
 cloudport.gate.flow.tolerancia-entrada-atraso=${GATE_TOL_ENTRADA_ATRASO:PT30M}
 cloudport.gate.flow.tolerancia-saida-antecipada=${GATE_TOL_SAIDA_ANTEC:PT30M}
 cloudport.gate.flow.tolerancia-saida-atraso=${GATE_TOL_SAIDA_ATRASO:PT30M}
-cloudport.gate.flow.roles-liberacao-manual=${GATE_ROLES_LIBERACAO_MANUAL:ROLE_SUPERVISOR,ROLE_COORDENADOR,ROLE_ADMIN}
+cloudport.gate.flow.roles-liberacao-manual=${GATE_ROLES_LIBERACAO_MANUAL:ROLE_OPERADOR_GATE}
 
 cloudport.gate.hardware.entrada-queue=${GATE_HARDWARE_ENTRADA_QUEUE:gate.hardware.entrada}
 cloudport.gate.hardware.saida-queue=${GATE_HARDWARE_SAIDA_QUEUE:gate.hardware.saida}

--- a/backend/servico-gate/src/test/java/br/com/cloudport/servicogate/controllers/AgendamentoControllerSecurityTest.java
+++ b/backend/servico-gate/src/test/java/br/com/cloudport/servicogate/controllers/AgendamentoControllerSecurityTest.java
@@ -1,0 +1,101 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.config.SecurityConfig;
+import br.com.cloudport.servicogate.dto.AgendamentoDTO;
+import br.com.cloudport.servicogate.dto.AgendamentoRequest;
+import br.com.cloudport.servicogate.security.TransportadoraSynchronizationFilter;
+import br.com.cloudport.servicogate.service.AgendamentoService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AgendamentoController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = {
+        "cloudport.security.jwt.secret=test-secret",
+        "cloudport.security.cors.allowed-origins=http://localhost:4200"
+})
+class AgendamentoControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AgendamentoService agendamentoService;
+
+    @MockBean
+    private TransportadoraSynchronizationFilter transportadoraSynchronizationFilter;
+
+    @Test
+    void criarAgendamento_requerAutenticacao() throws Exception {
+        mockMvc.perform(post("/gate/agendamentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(buildRequest())))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void criarAgendamento_autorizadoParaAdmin() throws Exception {
+        when(agendamentoService.criar(any())).thenReturn(new AgendamentoDTO());
+
+        mockMvc.perform(post("/gate/agendamentos")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN_PORTO")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(buildRequest())))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void criarAgendamento_negadoParaTransportadora() throws Exception {
+        mockMvc.perform(post("/gate/agendamentos")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_TRANSPORTADORA")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(buildRequest())))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void listarAgendamentos_permitidoParaTransportadora() throws Exception {
+        when(agendamentoService.buscar(any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(java.util.List.of()));
+
+        mockMvc.perform(get("/gate/agendamentos")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_TRANSPORTADORA"))))
+                .andExpect(status().isOk());
+    }
+
+    private AgendamentoRequest buildRequest() {
+        AgendamentoRequest request = new AgendamentoRequest();
+        request.setCodigo("AG-001");
+        request.setTipoOperacao("IMPORTACAO");
+        request.setStatus("CONFIRMADO");
+        request.setTransportadoraId(1L);
+        request.setMotoristaId(1L);
+        request.setVeiculoId(1L);
+        request.setJanelaAtendimentoId(1L);
+        request.setHorarioPrevistoChegada(LocalDateTime.now().plusHours(2));
+        request.setHorarioPrevistoSaida(LocalDateTime.now().plusHours(4));
+        request.setObservacoes("Teste");
+        return request;
+    }
+}

--- a/backend/servico-gate/src/test/java/br/com/cloudport/servicogate/controllers/GateFlowControllerSecurityTest.java
+++ b/backend/servico-gate/src/test/java/br/com/cloudport/servicogate/controllers/GateFlowControllerSecurityTest.java
@@ -1,0 +1,85 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.config.SecurityConfig;
+import br.com.cloudport.servicogate.dto.GateEventDTO;
+import br.com.cloudport.servicogate.dto.ManualReleaseAction;
+import br.com.cloudport.servicogate.dto.ManualReleaseRequest;
+import br.com.cloudport.servicogate.security.TransportadoraSynchronizationFilter;
+import br.com.cloudport.servicogate.service.GateFlowService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GateFlowController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = {
+        "cloudport.security.jwt.secret=test-secret",
+        "cloudport.security.cors.allowed-origins=http://localhost:4200"
+})
+class GateFlowControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private GateFlowService gateFlowService;
+
+    @MockBean
+    private TransportadoraSynchronizationFilter transportadoraSynchronizationFilter;
+
+    @Test
+    void liberarManual_retornaUnauthorized_semToken() throws Exception {
+        ManualReleaseRequest request = new ManualReleaseRequest();
+        request.setAcao(ManualReleaseAction.LIBERAR);
+        String payload = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(post("/gate/agendamentos/1/liberacao-manual")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void liberarManual_permitidoParaOperador() throws Exception {
+        ManualReleaseRequest request = new ManualReleaseRequest();
+        request.setAcao(ManualReleaseAction.LIBERAR);
+        request.setObservacao("Liberado");
+
+        when(gateFlowService.liberarManual(eq(1L), any())).thenReturn(new GateEventDTO());
+
+        mockMvc.perform(post("/gate/agendamentos/1/liberacao-manual")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_OPERADOR_GATE")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void liberarManual_negadoParaPlanejador() throws Exception {
+        ManualReleaseRequest request = new ManualReleaseRequest();
+        request.setAcao(ManualReleaseAction.LIBERAR);
+
+        mockMvc.perform(post("/gate/agendamentos/1/liberacao-manual")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_PLANEJADOR")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/frontend/cloudport/src/app/componentes/model/user.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/user.model.ts
@@ -6,7 +6,9 @@ export class User {
       email: string = '',
       senha: string = '',
       perfil: string = '',
-      roles: string[] = []
+      roles: string[] = [],
+      transportadoraDocumento: string | null = null,
+      transportadoraNome: string | null = null
     ) {
       this.id = id;
       this.nome = nome;
@@ -15,6 +17,8 @@ export class User {
       this.senha = senha;
       this.perfil = perfil;
       this.roles = roles;
+      this.transportadoraDocumento = transportadoraDocumento;
+      this.transportadoraNome = transportadoraNome;
     }
 
     public id: string;
@@ -24,5 +28,7 @@ export class User {
     public senha: string;
     public perfil: string;
     public roles: string[];
+    public transportadoraDocumento: string | null;
+    public transportadoraNome: string | null;
   }
 

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
@@ -1,23 +1,14 @@
 <nav class="app-navbar" *ngIf="mostrarMenu">
   <ul>
-    <li (click)="toggleSubmenu($event)">
-      <a href="#">Configurações</a>
-      <ul>
-        <li><a (click)="openTab('Role')">Geral</a></li>
-        <li><a (click)="openTab('Role')">Perfil</a></li>
-        <li><a (click)="openTab('login')">Segurança</a></li>
-        <li><a (click)="openTab('login')">Notificações</a></li>
-        <li><a (click)="openTab('login')">Privacidade</a></li>
-      </ul>
-    </li>
-    <li (click)="toggleSubmenu($event)">
-      <a href="#">Usuários</a>
-      <ul>
-        <li><a (click)="openTab('login')">Lista de usuários</a></li>
-        <li><a (click)="openTab('Role')">Adicionar usuário</a></li>
-        <li><a (click)="openTab('Role')">Gerenciar usuários</a></li>
-        <li><a (click)="openTab('Role')">Role</a></li>
-      </ul>
-    </li>
+    <ng-container *ngFor="let item of menuItems">
+      <li *ngIf="canDisplay(item.roles)" (click)="toggleSubmenu($event)">
+        <a href="#">{{ item.label }}</a>
+        <ul>
+          <ng-container *ngFor="let child of item.children">
+            <li *ngIf="canDisplay(child.roles)"><a (click)="openTab(child.tab); $event.stopPropagation();">{{ child.label }}</a></li>
+          </ng-container>
+        </ul>
+      </li>
+    </ng-container>
   </ul>
 </nav>

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -1,8 +1,8 @@
-import { Component, HostListener, ElementRef, OnDestroy, OnInit } from '@angular/core';
-import { AuthenticationService } from '../service/servico-autenticacao/authentication.service';
-import { Router, ActivatedRoute } from '@angular/router';
-import { TabService } from './TabService';
+import { Component, ElementRef, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { AuthenticationService } from '../service/servico-autenticacao/authentication.service';
+import { TabService } from '../service/tab.service';
 
 function logMethod(target: any, key: string, descriptor: PropertyDescriptor) {
   const originalMethod = descriptor.value;
@@ -13,7 +13,17 @@ function logMethod(target: any, key: string, descriptor: PropertyDescriptor) {
   return descriptor;
 }
 
+interface NavbarChildItem {
+  label: string;
+  tab: string;
+  roles?: string[];
+}
 
+interface NavbarItem {
+  label: string;
+  roles?: string[];
+  children: NavbarChildItem[];
+}
 
 @Component({
   selector: 'app-navbar',
@@ -23,8 +33,39 @@ function logMethod(target: any, key: string, descriptor: PropertyDescriptor) {
 export class NavbarComponent implements OnInit, OnDestroy {
   mostrarMenu: boolean = false;
   private readonly defaultChildRoute = 'role';
-  private readonly validChildRoutes = new Set([this.defaultChildRoute]);
+  private readonly validChildRoutes = new Set(['role', 'login']);
   private menuStatusSubscription?: Subscription;
+
+  menuItems: NavbarItem[] = [
+    {
+      label: 'Configurações',
+      roles: ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'],
+      children: [
+        { label: 'Geral', tab: 'Role', roles: ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'] },
+        { label: 'Perfil', tab: 'Role', roles: ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'] },
+        { label: 'Segurança', tab: 'login', roles: ['ROLE_ADMIN_PORTO'] },
+        { label: 'Notificações', tab: 'login', roles: ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'] },
+        { label: 'Privacidade', tab: 'login', roles: ['ROLE_ADMIN_PORTO'] }
+      ]
+    },
+    {
+      label: 'Usuários',
+      roles: ['ROLE_ADMIN_PORTO'],
+      children: [
+        { label: 'Lista de usuários', tab: 'login', roles: ['ROLE_ADMIN_PORTO'] },
+        { label: 'Adicionar usuário', tab: 'Role', roles: ['ROLE_ADMIN_PORTO'] },
+        { label: 'Gerenciar usuários', tab: 'Role', roles: ['ROLE_ADMIN_PORTO'] },
+        { label: 'Role', tab: 'Role', roles: ['ROLE_ADMIN_PORTO'] }
+      ]
+    },
+    {
+      label: 'Transportadora',
+      roles: ['ROLE_TRANSPORTADORA'],
+      children: [
+        { label: 'Meus agendamentos', tab: 'Role', roles: ['ROLE_TRANSPORTADORA'] }
+      ]
+    }
+  ];
 
   constructor(
       private authenticationService: AuthenticationService,
@@ -32,44 +73,42 @@ export class NavbarComponent implements OnInit, OnDestroy {
       private tabService: TabService,
       private eRef: ElementRef
   ) {
-    console.log("Classe NavbarComponent: Método construtor chamado.");
+    console.log('Classe NavbarComponent: Método construtor chamado.');
   }
 
-
   ngOnInit(): void {
-      console.log("Classe NavbarComponent: Método ngOnInit iniciado.");
+      console.log('Classe NavbarComponent: Método ngOnInit iniciado.');
       this.menuStatusSubscription = this.authenticationService.currentMenuStatus.subscribe(
           mostrar => this.mostrarMenu = mostrar
       );
-      console.log("Classe NavbarComponent: Método ngOnInit finalizado.");
+      console.log('Classe NavbarComponent: Método ngOnInit finalizado.');
   }
 
   ngOnDestroy(): void {
       this.menuStatusSubscription?.unsubscribe();
   }
 
-  // ... (resto do código)
-
+  @logMethod
   openTab(tabName: string) {
-
+    if (!tabName) {
+      return;
+    }
     let content = { message: `Conteúdo padrão para a aba ${tabName}` };
     this.tabService.openTab(tabName);
     this.router.navigate(['/home', this.resolveChildRoute(tabName)]);
     content = this.tabService.getTabContent(tabName);
     this.tabService.openTab(tabName, content);
-
   }
 
-
-
+  @logMethod
   toggleSubmenu(event: Event) {
-    console.log("Classe NavbarComponent: Método toggleSubmenu chamado.");
+    console.log('Classe NavbarComponent: Método toggleSubmenu chamado.');
     event.preventDefault();
     event.stopPropagation();
-  
+
     const target = event.target as HTMLElement;
     const submenu = target.nextElementSibling as HTMLElement;
-  
+
     if (submenu) {
       if (submenu.style.display === 'none' || submenu.style.display === '') {
         submenu.style.display = 'block';
@@ -78,15 +117,20 @@ export class NavbarComponent implements OnInit, OnDestroy {
       }
     }
   }
-  
 
   @HostListener('document:click', ['$event'])
   clickout(event: MouseEvent) {
-    //console.log("Classe NavbarComponent: Método clickout chamado.");
     if (!this.eRef.nativeElement.contains(event.target)) {
       const submenus = this.eRef.nativeElement.querySelectorAll('.app-navbar ul li > ul');
       submenus.forEach((submenu: HTMLElement) => submenu.style.display = 'none');
     }
+  }
+
+  canDisplay(roles?: string[]): boolean {
+    if (!roles || roles.length === 0) {
+      return true;
+    }
+    return this.authenticationService.hasAnyRole(...roles);
   }
 
   private resolveChildRoute(tabName: string): string {


### PR DESCRIPTION
## Summary
- add OAuth2 resource server configuration with JWT authority mapping, CORS policy, and transportadora synchronization filter in the gate service
- annotate gate controllers with fine-grained role checks, add MockMvc security tests, and integrate with the authentication service for carrier data
- enrich servico-autenticacao tokens with role and transportadora claims, expose a user info endpoint, and update the Angular client for claim-driven menus

## Testing
- `mvn test` *(fails: unable to resolve Spring Boot parent POM from Maven Central – HTTP 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecfa19dc7083279629e4ca73251641