### PR TITLE
feat: adicionar módulo Gate com serviços e modelos

### DIFF
--- a/frontend/cloudport/src/app/app-routing.module.ts
+++ b/frontend/cloudport/src/app/app-routing.module.ts
@@ -15,12 +15,11 @@ const homeChildRoutes: Routes = [
   { path: 'seguranca', component: SegurancaComponent },
   { path: 'notificacoes', component: NotificacoesComponent },
   { path: 'privacidade', component: PrivacidadeComponent },
-  { path: 'lista-de-usuarios', component: UsuariosListaComponent }
-];
-
-const homeChildRoutes: Routes = [
-  { path: '', redirectTo: 'role', pathMatch: 'full' },
-  { path: 'role', component: RoleTabelaComponent },
+  { path: 'lista-de-usuarios', component: UsuariosListaComponent },
+  {
+    path: 'gate',
+    loadChildren: () => import('./componentes/gate/gate.module').then(m => m.GateModule)
+  }
 ];
 
 const routes: Routes = [
@@ -31,7 +30,7 @@ const routes: Routes = [
     canActivate: [AuthGuard],
     children: homeChildRoutes
   },
-  { path: '', redirectTo: 'home', pathMatch: 'full' },
+  { path: '', redirectTo: 'home', pathMatch: 'full' }
 ];
 
 @NgModule({

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.css
@@ -1,0 +1,7 @@
+.gate-agendamentos {
+  padding: 1.5rem;
+}
+
+.gate-agendamentos h2 {
+  margin-bottom: 0.75rem;
+}

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.html
@@ -1,0 +1,4 @@
+<section class="gate-agendamentos">
+  <h2>{{ titulo }}</h2>
+  <p>Selecione um agendamento para visualizar os detalhes.</p>
+</section>

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-gate-agendamentos',
+  templateUrl: './gate-agendamentos.component.html',
+  styleUrls: ['./gate-agendamentos.component.css']
+})
+export class GateAgendamentosComponent {
+  readonly titulo = 'Agendamentos do Gate';
+}

--- a/frontend/cloudport/src/app/componentes/gate/dashboard/gate-dashboard.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/dashboard/gate-dashboard.component.css
@@ -1,0 +1,7 @@
+.gate-dashboard {
+  padding: 1.5rem;
+}
+
+.gate-dashboard h2 {
+  margin-bottom: 0.75rem;
+}

--- a/frontend/cloudport/src/app/componentes/gate/dashboard/gate-dashboard.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/dashboard/gate-dashboard.component.html
@@ -1,0 +1,4 @@
+<section class="gate-dashboard">
+  <h2>{{ titulo }}</h2>
+  <p>Acompanhe os indicadores operacionais em tempo real.</p>
+</section>

--- a/frontend/cloudport/src/app/componentes/gate/dashboard/gate-dashboard.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/dashboard/gate-dashboard.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-gate-dashboard',
+  templateUrl: './gate-dashboard.component.html',
+  styleUrls: ['./gate-dashboard.component.css']
+})
+export class GateDashboardComponent {
+  readonly titulo = 'Dashboard do Gate';
+}

--- a/frontend/cloudport/src/app/componentes/gate/gate-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/gate/gate-routing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { GateAgendamentosComponent } from './agendamentos/gate-agendamentos.component';
+import { GateJanelasComponent } from './janelas/gate-janelas.component';
+import { GateDashboardComponent } from './dashboard/gate-dashboard.component';
+
+const routes: Routes = [
+  { path: '', redirectTo: 'agendamentos', pathMatch: 'full' },
+  { path: 'agendamentos', component: GateAgendamentosComponent },
+  { path: 'janelas', component: GateJanelasComponent },
+  { path: 'dashboard', component: GateDashboardComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class GateRoutingModule { }

--- a/frontend/cloudport/src/app/componentes/gate/gate.module.ts
+++ b/frontend/cloudport/src/app/componentes/gate/gate.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { GateRoutingModule } from './gate-routing.module';
+import { GateAgendamentosComponent } from './agendamentos/gate-agendamentos.component';
+import { GateJanelasComponent } from './janelas/gate-janelas.component';
+import { GateDashboardComponent } from './dashboard/gate-dashboard.component';
+
+@NgModule({
+  declarations: [
+    GateAgendamentosComponent,
+    GateJanelasComponent,
+    GateDashboardComponent
+  ],
+  imports: [
+    CommonModule,
+    GateRoutingModule
+  ]
+})
+export class GateModule { }

--- a/frontend/cloudport/src/app/componentes/gate/janelas/gate-janelas.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/janelas/gate-janelas.component.css
@@ -1,0 +1,7 @@
+.gate-janelas {
+  padding: 1.5rem;
+}
+
+.gate-janelas h2 {
+  margin-bottom: 0.75rem;
+}

--- a/frontend/cloudport/src/app/componentes/gate/janelas/gate-janelas.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/janelas/gate-janelas.component.html
@@ -1,0 +1,4 @@
+<section class="gate-janelas">
+  <h2>{{ titulo }}</h2>
+  <p>Gerencie as janelas de atendimento disponíveis para o gate.</p>
+</section>

--- a/frontend/cloudport/src/app/componentes/gate/janelas/gate-janelas.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/janelas/gate-janelas.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-gate-janelas',
+  templateUrl: './gate-janelas.component.html',
+  styleUrls: ['./gate-janelas.component.css']
+})
+export class GateJanelasComponent {
+  readonly titulo = 'Janelas de Atendimento';
+}

--- a/frontend/cloudport/src/app/componentes/home/home.component.ts
+++ b/frontend/cloudport/src/app/componentes/home/home.component.ts
@@ -49,7 +49,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       const route = this.resolveChildRoute(lastTab.id);
       this.selectedTabId = route;
       this.tabContent[route] = this.tabService.getTabContent(route);
-      this.router.navigate(['/home', route]);
+      this.navigateToChild(route);
     });
     (this.reuseStrategy as CustomReuseStrategy).markForDestruction('login'.toLowerCase());
   }
@@ -62,7 +62,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     const route = this.resolveChildRoute(tabId);
     this.selectedTabId = route;
     this.tabContent[route] = this.tabService.getTabContent(route);
-    this.router.navigate(['/home', route]);
+    this.navigateToChild(route);
   }
 
   logout() {
@@ -98,6 +98,11 @@ export class HomeComponent implements OnInit, OnDestroy {
     if (this.defaultTab) {
       this.tabService.openTab(this.defaultTab);
     }
-    this.router.navigate(['/home', this.defaultChildRoute]);
+    this.navigateToChild(this.defaultChildRoute);
+  }
+
+  private navigateToChild(route: string): void {
+    const commands = ['/home', ...route.split('/')];
+    this.router.navigate(commands);
   }
 }

--- a/frontend/cloudport/src/app/componentes/model/gate/agendamento.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/gate/agendamento.model.ts
@@ -1,0 +1,95 @@
+export interface GateEnumOption {
+  codigo: string;
+  descricao: string;
+}
+
+export interface DocumentoAgendamento {
+  id: number;
+  tipoDocumento: string;
+  numero: string;
+  urlDocumento: string;
+  nomeArquivo: string;
+  contentType: string;
+  tamanhoBytes: number;
+}
+
+export interface GateEvent {
+  id: number;
+  status: string;
+  statusDescricao: string | null;
+  motivoExcecao: string | null;
+  motivoExcecaoDescricao: string | null;
+  observacao: string | null;
+  usuarioResponsavel: string | null;
+  registradoEm: string;
+}
+
+export interface GatePass {
+  id: number;
+  codigo: string;
+  status: string;
+  statusDescricao: string | null;
+  dataEntrada: string | null;
+  dataSaida: string | null;
+  eventos: GateEvent[] | null;
+}
+
+export interface Agendamento {
+  id: number;
+  codigo: string;
+  tipoOperacao: string;
+  tipoOperacaoDescricao: string | null;
+  status: string;
+  statusDescricao: string | null;
+  transportadoraId: number | null;
+  transportadoraNome: string | null;
+  motoristaId: number | null;
+  motoristaNome: string | null;
+  veiculoId: number | null;
+  placaVeiculo: string | null;
+  janelaAtendimentoId: number | null;
+  dataJanela: string | null;
+  horaInicioJanela: string | null;
+  horaFimJanela: string | null;
+  horarioPrevistoChegada: string | null;
+  horarioPrevistoSaida: string | null;
+  horarioRealChegada: string | null;
+  horarioRealSaida: string | null;
+  observacoes: string | null;
+  documentos: DocumentoAgendamento[] | null;
+  gatePass: GatePass | null;
+}
+
+export interface Page<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+  first: boolean;
+  last: boolean;
+}
+
+export interface AgendamentoFiltro {
+  dataInicio?: string;
+  dataFim?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+  transportadoraId?: number;
+  tipoOperacao?: string;
+  status?: string;
+}
+
+export interface AgendamentoRequest {
+  codigo: string;
+  tipoOperacao: string;
+  status: string;
+  transportadoraId: number;
+  motoristaId: number;
+  veiculoId: number;
+  janelaAtendimentoId: number;
+  horarioPrevistoChegada: string;
+  horarioPrevistoSaida: string;
+  observacoes?: string | null;
+}

--- a/frontend/cloudport/src/app/componentes/model/gate/dashboard.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/gate/dashboard.model.ts
@@ -1,0 +1,27 @@
+export interface OcupacaoPorHora {
+  horaInicio: string;
+  totalAgendamentos: number;
+  capacidadeSlot: number;
+}
+
+export interface TempoMedioPermanencia {
+  dia: string;
+  tempoMedioMinutos: number | null;
+}
+
+export interface DashboardResumo {
+  totalAgendamentos: number;
+  percentualPontualidade: number;
+  percentualNoShow: number;
+  percentualOcupacaoSlots: number;
+  tempoMedioTurnaroundMinutos: number;
+  ocupacaoPorHora: OcupacaoPorHora[];
+  turnaroundPorDia: TempoMedioPermanencia[];
+}
+
+export interface DashboardFiltro {
+  inicio?: string;
+  fim?: string;
+  transportadoraId?: number;
+  tipoOperacao?: string;
+}

--- a/frontend/cloudport/src/app/componentes/model/gate/janela.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/gate/janela.model.ts
@@ -1,0 +1,31 @@
+import { GateEnumOption, Page } from './agendamento.model';
+
+export interface JanelaAtendimento {
+  id: number;
+  data: string;
+  horaInicio: string;
+  horaFim: string;
+  capacidade: number;
+  canalEntrada: string;
+  canalEntradaDescricao: string | null;
+}
+
+export interface JanelaFiltro {
+  dataInicio?: string;
+  dataFim?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export interface JanelaAtendimentoRequest {
+  data: string;
+  horaInicio: string;
+  horaFim: string;
+  capacidade: number;
+  canalEntrada: string;
+}
+
+export type JanelaAtendimentoPage = Page<JanelaAtendimento>;
+
+export type JanelaEnumOption = GateEnumOption;

--- a/frontend/cloudport/src/app/componentes/navbar/TabService.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/TabService.ts
@@ -13,7 +13,10 @@ export const TAB_REGISTRY: Readonly<Record<string, TabItem>> = {
   seguranca: { id: 'seguranca', label: 'Segurança' },
   notificacoes: { id: 'notificacoes', label: 'Notificações' },
   privacidade: { id: 'privacidade', label: 'Privacidade' },
-  'lista-de-usuarios': { id: 'lista-de-usuarios', label: 'Lista de usuários' }
+  'lista-de-usuarios': { id: 'lista-de-usuarios', label: 'Lista de usuários' },
+  'gate/agendamentos': { id: 'gate/agendamentos', label: 'Agendamentos do Gate' },
+  'gate/janelas': { id: 'gate/janelas', label: 'Janelas de Atendimento' },
+  'gate/dashboard': { id: 'gate/dashboard', label: 'Dashboard do Gate' }
 };
 
 export const VALID_TAB_IDS = new Set<string>(Object.keys(TAB_REGISTRY));
@@ -34,7 +37,7 @@ export class TabService {
 
   private tabContents: { [tabId: string]: any } = {};
 
-  openTab(tab: TabItem, content?: any) {
+  openTab(tab: TabItem, content?: any): void {
     const normalizedId = normalizeTabId(tab.id);
     const registeredTab = TAB_REGISTRY[normalizedId] ?? {
       id: normalizedId,
@@ -50,11 +53,11 @@ export class TabService {
     }
   }
 
-  setContent(content: any) {
+  setContent(content: any): void {
     this.contentSubject.next(content);
   }
 
-  closeTab(tabId: string) {
+  closeTab(tabId: string): void {
     const normalizedId = normalizeTabId(tabId);
     const tabs = this.tabsSubject.value;
     this.tabsSubject.next(tabs.filter(t => t.id !== normalizedId));
@@ -65,7 +68,7 @@ export class TabService {
     return this.tabContents[normalizeTabId(tabId)];
   }
 
-  setTabContent(tabId: string, content: any) {
+  setTabContent(tabId: string, content: any): void {
     this.tabContents[normalizeTabId(tabId)] = content;
   }
 }

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <nav class="app-navbar" *ngIf="mostrarMenu">
   <ul>
-    <li (click)="toggleSubmenu($event)">
+    <li *ngIf="configurationTabs.length" (click)="toggleSubmenu($event)">
       <a href="#">Configurações</a>
       <ul>
         <li *ngFor="let tab of configurationTabs">
@@ -8,7 +8,15 @@
         </li>
       </ul>
     </li>
-    <li (click)="toggleSubmenu($event)">
+    <li *ngIf="gateTabs.length" (click)="toggleSubmenu($event)">
+      <a href="#">Gate</a>
+      <ul>
+        <li *ngFor="let tab of gateTabs">
+          <a (click)="openTab(tab)">{{ tab.label }}</a>
+        </li>
+      </ul>
+    </li>
+    <li *ngIf="userTabs.length" (click)="toggleSubmenu($event)">
       <a href="#">Usuários</a>
       <ul>
         <li *ngFor="let tab of userTabs">

--- a/frontend/cloudport/src/app/componentes/service/servico-gate/gate-api.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-gate/gate-api.service.ts
@@ -1,0 +1,105 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import {
+  Agendamento,
+  AgendamentoFiltro,
+  AgendamentoRequest,
+  GateEnumOption,
+  Page
+} from '../../model/gate/agendamento.model';
+import {
+  JanelaAtendimento,
+  JanelaAtendimentoRequest,
+  JanelaFiltro
+} from '../../model/gate/janela.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GateApiService {
+  private readonly baseUrl = `${environment.baseApiUrl}/gate`;
+  private readonly agendamentosUrl = `${this.baseUrl}/agendamentos`;
+  private readonly janelasUrl = `${this.baseUrl}/janelas`;
+  private readonly configUrl = `${this.baseUrl}/config`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  listarAgendamentos(filtro?: AgendamentoFiltro): Observable<Page<Agendamento>> {
+    const params = this.buildParams(filtro);
+    return this.http.get<Page<Agendamento>>(this.agendamentosUrl, { params });
+  }
+
+  obterAgendamentoPorId(id: number): Observable<Agendamento> {
+    return this.http.get<Agendamento>(`${this.agendamentosUrl}/${id}`);
+  }
+
+  criarAgendamento(request: AgendamentoRequest): Observable<Agendamento> {
+    return this.http.post<Agendamento>(this.agendamentosUrl, request);
+  }
+
+  atualizarAgendamento(id: number, request: AgendamentoRequest): Observable<Agendamento> {
+    return this.http.put<Agendamento>(`${this.agendamentosUrl}/${id}`, request);
+  }
+
+  cancelarAgendamento(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.agendamentosUrl}/${id}`);
+  }
+
+  listarJanelas(filtro?: JanelaFiltro): Observable<Page<JanelaAtendimento>> {
+    const params = this.buildParams(filtro);
+    return this.http.get<Page<JanelaAtendimento>>(this.janelasUrl, { params });
+  }
+
+  obterJanelaPorId(id: number): Observable<JanelaAtendimento> {
+    return this.http.get<JanelaAtendimento>(`${this.janelasUrl}/${id}`);
+  }
+
+  criarJanela(request: JanelaAtendimentoRequest): Observable<JanelaAtendimento> {
+    return this.http.post<JanelaAtendimento>(this.janelasUrl, request);
+  }
+
+  atualizarJanela(id: number, request: JanelaAtendimentoRequest): Observable<JanelaAtendimento> {
+    return this.http.put<JanelaAtendimento>(`${this.janelasUrl}/${id}`, request);
+  }
+
+  removerJanela(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.janelasUrl}/${id}`);
+  }
+
+  listarTiposOperacao(): Observable<GateEnumOption[]> {
+    return this.http.get<GateEnumOption[]>(`${this.configUrl}/tipos-operacao`);
+  }
+
+  listarStatusAgendamento(): Observable<GateEnumOption[]> {
+    return this.http.get<GateEnumOption[]>(`${this.configUrl}/status-agendamento`);
+  }
+
+  listarStatusGate(): Observable<GateEnumOption[]> {
+    return this.http.get<GateEnumOption[]>(`${this.configUrl}/status-gate`);
+  }
+
+  listarMotivosExcecao(): Observable<GateEnumOption[]> {
+    return this.http.get<GateEnumOption[]>(`${this.configUrl}/motivos-excecao`);
+  }
+
+  listarCanaisEntrada(): Observable<GateEnumOption[]> {
+    return this.http.get<GateEnumOption[]>(`${this.configUrl}/canais-entrada`);
+  }
+
+  private buildParams(filters?: Record<string, string | number | boolean | undefined | null>): HttpParams {
+    let params = new HttpParams();
+    if (!filters) {
+      return params;
+    }
+
+    Object.entries(filters)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .forEach(([key, value]) => {
+        params = params.set(key, String(value));
+      });
+
+    return params;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/service/servico-gate/gate-dashboard.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-gate/gate-dashboard.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { DashboardFiltro, DashboardResumo } from '../../model/gate/dashboard.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GateDashboardService {
+  private readonly dashboardUrl = `${environment.baseApiUrl}/gate/dashboard`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  consultarResumo(filtro?: DashboardFiltro): Observable<DashboardResumo> {
+    const params = this.buildParams(filtro);
+    return this.http.get<DashboardResumo>(this.dashboardUrl, { params });
+  }
+
+  registrarStream(filtro?: DashboardFiltro): EventSource {
+    const params = this.buildParams(filtro);
+    const query = params.toString();
+    const url = query ? `${this.dashboardUrl}/stream?${query}` : `${this.dashboardUrl}/stream`;
+    return new EventSource(url, { withCredentials: true });
+  }
+
+  private buildParams(filters?: DashboardFiltro): HttpParams {
+    let params = new HttpParams();
+    if (!filters) {
+      return params;
+    }
+
+    Object.entries(filters)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .forEach(([key, value]) => {
+        params = params.set(key, String(value));
+      });
+
+    return params;
+  }
+}


### PR DESCRIPTION
## Summary
- cria o módulo Gate com componentes básicos, roteamento interno e carregamento preguiçoso sob /home/gate
- adiciona serviços e modelos para consumir os endpoints do backend de gate e manter enums sincronizados
- atualiza TabService e Navbar para suportar as novas abas e respeitar os perfis de acesso existentes

## Testing
- not run (npm indisponível no ambiente de execução)


------
https://chatgpt.com/codex/tasks/task_e_68ed024bf9508327b76b78a3bd632e36