### PR TITLE
feat(gate): implementar portal de agendamentos com gestão de documentos

### DIFF
--- a/frontend/cloudport/src/app/app.module.ts
+++ b/frontend/cloudport/src/app/app.module.ts
@@ -14,7 +14,6 @@ import { FooterComponent } from './componentes/footer/footer.component';
 import { NavbarComponent } from './componentes/navbar/navbar.component';
 import { RoleTabelaComponent } from './componentes/role/role-tabela/role-tabela.component';
 import { ContextMenuComponent } from './componentes/context-menu/context-menu.component';
-import { DynamicTableComponent } from './componentes/dynamic-table/dynamic-table.component';
 import { AgGridModule } from 'ag-grid-angular';
 import { CustomReuseStrategy } from './componentes/tab-content/customreusestrategy';
 import { RouteReuseStrategy } from '@angular/router';
@@ -25,6 +24,8 @@ import { SegurancaComponent } from './componentes/seguranca/seguranca.component'
 import { NotificacoesComponent } from './componentes/notificacoes/notificacoes.component';
 import { PrivacidadeComponent } from './componentes/privacidade/privacidade.component';
 import { UsuariosListaComponent } from './componentes/usuarios-lista/usuarios-lista.component';
+import { DynamicTableModule } from './componentes/dynamic-table/dynamic-table.module';
+import { ConfirmacaoModalComponent } from './componentes/modal/confirmacao-modal/confirmacao-modal.component';
 
 @NgModule({
   declarations: [
@@ -36,8 +37,8 @@ import { UsuariosListaComponent } from './componentes/usuarios-lista/usuarios-li
     NavbarComponent,
     RoleTabelaComponent,
     ContextMenuComponent,
-    DynamicTableComponent,
     ModalComponent,
+    ConfirmacaoModalComponent,
     RoleCadastroComponent,
     SegurancaComponent,
     NotificacoesComponent,
@@ -53,7 +54,8 @@ import { UsuariosListaComponent } from './componentes/usuarios-lista/usuarios-li
     FormsModule,
     HttpClientModule,
     TranslateModule.forRoot(),
-    AgGridModule
+    AgGridModule,
+    DynamicTableModule
   ],
   providers: [
     { provide: RouteReuseStrategy, useClass: CustomReuseStrategy },

--- a/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.module.ts
+++ b/frontend/cloudport/src/app/componentes/dynamic-table/dynamic-table.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AgGridModule } from 'ag-grid-angular';
+import { DynamicTableComponent } from './dynamic-table.component';
+
+@NgModule({
+  declarations: [DynamicTableComponent],
+  imports: [CommonModule, AgGridModule],
+  exports: [DynamicTableComponent]
+})
+export class DynamicTableModule {}
+

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.css
@@ -1,7 +1,47 @@
 .gate-agendamentos {
-  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.05), transparent);
+  min-height: 100vh;
 }
 
-.gate-agendamentos h2 {
-  margin-bottom: 0.75rem;
+.gate-agendamentos__cabecalho h2 {
+  margin: 0;
+  font-size: 2rem;
+  color: #1f2937;
+}
+
+.gate-agendamentos__cabecalho p {
+  margin: 6px 0 0;
+  color: #6b7280;
+}
+
+.gate-agendamentos__conteudo {
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.gate-agendamentos__form {
+  animation: surgir 0.3s ease;
+}
+
+@keyframes surgir {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1100px) {
+  .gate-agendamentos__conteudo {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.html
@@ -1,4 +1,44 @@
 <section class="gate-agendamentos">
-  <h2>{{ titulo }}</h2>
-  <p>Selecione um agendamento para visualizar os detalhes.</p>
+  <header class="gate-agendamentos__cabecalho">
+    <div>
+      <h2>{{ titulo }}</h2>
+      <p>Gestão integrada de janelas, documentos e status em tempo real.</p>
+    </div>
+  </header>
+
+  <div class="gate-agendamentos__conteudo">
+    <app-agendamentos-list
+      class="gate-agendamentos__lista"
+      [agendamentos]="agendamentos$ | async"
+      [loading]="carregandoLista"
+      [selectedId]="selecionadoId"
+      (selecionar)="selecionarAgendamento($event)"
+      (editar)="editarAgendamento($event)"
+      (cancelar)="cancelarAgendamento($event)"
+      (criar)="criarAgendamento()"
+      (atualizar)="atualizarLista()"
+    ></app-agendamentos-list>
+
+    <app-agendamento-detalhe
+      class="gate-agendamentos__detalhe"
+      [agendamento]="selecionado"
+      [uploadStatus]="uploadStatus"
+      (anexarDocumentos)="anexarDocumentos($event)"
+    ></app-agendamento-detalhe>
+  </div>
+
+  <section class="gate-agendamentos__form" *ngIf="exibirFormulario">
+    <app-agendamento-form
+      [agendamento]="emEdicao"
+      [tiposOperacao$]="tiposOperacao$"
+      [status$]="status$"
+      [janelas$]="janelas$"
+      [documentosExistentes]="documentosExistentes"
+      [uploadStatus]="uploadStatus"
+      (salvar)="salvar($event)"
+      (cancelar)="cancelarFormulario()"
+    ></app-agendamento-form>
+  </section>
+
+  <app-modal></app-modal>
 </section>

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.ts
@@ -1,10 +1,242 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { BehaviorSubject, EMPTY, Observable, Subject, from, of } from 'rxjs';
+import { catchError, concatMap, finalize, map, shareReplay, switchMap, take, takeUntil, tap, toArray } from 'rxjs/operators';
+import { GateApiService } from '../../service/servico-gate/gate-api.service';
+import { Agendamento, AgendamentoFormPayload, DocumentoAgendamento, UploadDocumentoStatus } from '../../model/gate/agendamento.model';
+import { JanelaAtendimento } from '../../model/gate/janela.model';
+import { PopupService } from '../../service/popupService';
+import { HttpEventType } from '@angular/common/http';
 
 @Component({
   selector: 'app-gate-agendamentos',
   templateUrl: './gate-agendamentos.component.html',
   styleUrls: ['./gate-agendamentos.component.css']
 })
-export class GateAgendamentosComponent {
+export class GateAgendamentosComponent implements OnInit, OnDestroy {
   readonly titulo = 'Agendamentos do Gate';
+
+  private readonly destruir$ = new Subject<void>();
+  private readonly agendamentosSubject = new BehaviorSubject<Agendamento[]>([]);
+  readonly agendamentos$ = this.agendamentosSubject.asObservable();
+
+  readonly tiposOperacao$ = this.gateApi.listarTiposOperacao().pipe(shareReplay(1));
+  readonly status$ = this.gateApi.listarStatusAgendamento().pipe(shareReplay(1));
+  readonly janelas$: Observable<JanelaAtendimento[]> = this.gateApi
+    .listarJanelas({ size: 200 })
+    .pipe(map((pagina) => pagina.content), shareReplay(1));
+
+  selecionadoId: number | null = null;
+  selecionado: Agendamento | null = null;
+  emEdicao: Agendamento | null = null;
+  exibirFormulario = false;
+  carregandoLista = false;
+  carregandoDetalhe = false;
+  uploadStatus: UploadDocumentoStatus[] = [];
+  documentosExistentes: DocumentoAgendamento[] | null = [];
+
+  constructor(private readonly gateApi: GateApiService, private readonly popupService: PopupService) {}
+
+  ngOnInit(): void {
+    this.carregarAgendamentos();
+  }
+
+  ngOnDestroy(): void {
+    this.destruir$.next();
+    this.destruir$.complete();
+  }
+
+  carregarAgendamentos(): void {
+    this.carregandoLista = true;
+    this.gateApi
+      .listarAgendamentos({ size: 100 })
+      .pipe(
+        finalize(() => (this.carregandoLista = false)),
+        takeUntil(this.destruir$)
+      )
+      .subscribe((pagina) => {
+        this.agendamentosSubject.next(pagina.content);
+        if (this.selecionadoId) {
+          const existe = pagina.content.some((item) => item.id === this.selecionadoId);
+          if (!existe) {
+            this.selecionadoId = null;
+            this.selecionado = null;
+          }
+        }
+      });
+  }
+
+  selecionarAgendamento(id: number): void {
+    this.selecionadoId = id;
+    this.carregandoDetalhe = true;
+    this.gateApi
+      .obterAgendamentoPorId(id)
+      .pipe(
+        finalize(() => (this.carregandoDetalhe = false)),
+        takeUntil(this.destruir$)
+      )
+      .subscribe((agendamento) => {
+        this.selecionado = agendamento;
+        this.documentosExistentes = agendamento.documentos ?? [];
+        if (!this.exibirFormulario) {
+          this.emEdicao = null;
+        }
+      });
+  }
+
+  criarAgendamento(): void {
+    this.emEdicao = null;
+    this.documentosExistentes = [];
+    this.exibirFormulario = true;
+  }
+
+  editarAgendamento(id: number): void {
+    this.popupService
+      .openConfirmacao({
+        titulo: 'Editar agendamento',
+        mensagem: 'Deseja editar o agendamento selecionado?',
+        textoConfirmar: 'Editar'
+      })
+      .pipe(take(1))
+      .subscribe((confirmado) => {
+        if (confirmado) {
+          this.iniciarEdicao(id);
+        }
+      });
+  }
+
+  cancelarAgendamento(id: number): void {
+    this.popupService
+      .openConfirmacao({
+        titulo: 'Cancelar agendamento',
+        mensagem: 'Confirma o cancelamento deste agendamento?',
+        textoConfirmar: 'Cancelar',
+        textoCancelar: 'Manter'
+      })
+      .pipe(take(1), switchMap((confirmado) => (confirmado ? this.gateApi.cancelarAgendamento(id) : EMPTY)))
+      .subscribe({
+        next: () => {
+          if (this.selecionadoId === id) {
+            this.selecionadoId = null;
+            this.selecionado = null;
+          }
+          this.carregarAgendamentos();
+        }
+      });
+  }
+
+  salvar(payload: AgendamentoFormPayload): void {
+    const acao$ = this.emEdicao
+      ? this.gateApi.atualizarAgendamento(this.emEdicao.id, payload.request)
+      : this.gateApi.criarAgendamento(payload.request);
+
+    acao$
+      .pipe(
+        switchMap((agendamento) =>
+          this.processarUploads(agendamento.id, payload.arquivos).pipe(map(() => agendamento))
+        ),
+        finalize(() => (this.uploadStatus = [])),
+        takeUntil(this.destruir$)
+      )
+      .subscribe((agendamento) => {
+        this.exibirFormulario = false;
+        this.emEdicao = null;
+        this.documentosExistentes = agendamento.documentos ?? [];
+        this.carregarAgendamentos();
+        this.selecionarAgendamento(agendamento.id);
+      });
+  }
+
+  cancelarFormulario(): void {
+    this.exibirFormulario = false;
+    this.emEdicao = null;
+    this.documentosExistentes = this.selecionado?.documentos ?? [];
+  }
+
+  atualizarLista(): void {
+    this.carregarAgendamentos();
+  }
+
+  anexarDocumentos(files: File[]): void {
+    if (!this.selecionadoId || !files.length) {
+      return;
+    }
+    this.processarUploads(this.selecionadoId, files)
+      .pipe(takeUntil(this.destruir$))
+      .subscribe(() => {
+        if (this.selecionadoId) {
+          this.selecionarAgendamento(this.selecionadoId);
+        }
+        this.carregarAgendamentos();
+      });
+  }
+
+  private iniciarEdicao(id: number): void {
+    this.gateApi
+      .obterAgendamentoPorId(id)
+      .pipe(take(1))
+      .subscribe((agendamento) => {
+        this.emEdicao = agendamento;
+        this.documentosExistentes = agendamento.documentos ?? [];
+        this.exibirFormulario = true;
+      });
+  }
+
+  private processarUploads(id: number, arquivos: File[]): Observable<DocumentoAgendamento[]> {
+    if (!arquivos.length) {
+      return of([]);
+    }
+
+    this.uploadStatus = arquivos.map((arquivo) => ({ fileName: arquivo.name, progress: 0, status: 'pendente' }));
+
+    return from(arquivos).pipe(
+      concatMap((arquivo) =>
+        this.gateApi.uploadDocumentoAgendamento(id, arquivo).pipe(
+          tap((evento) => this.atualizarStatusUpload(arquivo.name, evento)),
+          catchError(() => {
+            this.atualizarStatusUpload(arquivo.name, null, true);
+            return EMPTY;
+          }),
+          switchMap((evento) =>
+            evento.type === HttpEventType.Response ? of(evento.body as DocumentoAgendamento) : EMPTY
+          )
+        )
+      ),
+      toArray(),
+      finalize(() => {
+        setTimeout(() => (this.uploadStatus = []), 800);
+      })
+    );
+  }
+
+  private atualizarStatusUpload(nome: string, evento: any, erro = false): void {
+    this.uploadStatus = this.uploadStatus.map((status) => {
+      if (status.fileName !== nome) {
+        return status;
+      }
+
+      if (erro) {
+        return { ...status, status: 'erro' };
+      }
+
+      if (!evento) {
+        return status;
+      }
+
+      if (evento.type === HttpEventType.Sent) {
+        return { ...status, status: 'enviando', progress: 0 };
+      }
+
+      if (evento.type === HttpEventType.UploadProgress) {
+        const total = evento.total ?? evento.loaded ?? 1;
+        const progresso = total ? Math.round((evento.loaded * 100) / total) : status.progress;
+        return { ...status, status: 'enviando', progress: progresso };
+      }
+
+      if (evento.type === HttpEventType.Response) {
+        return { ...status, status: 'concluido', progress: 100 };
+      }
+
+      return status;
+    });
+  }
 }

--- a/frontend/cloudport/src/app/componentes/gate/gate.module.ts
+++ b/frontend/cloudport/src/app/componentes/gate/gate.module.ts
@@ -4,15 +4,26 @@ import { GateRoutingModule } from './gate-routing.module';
 import { GateAgendamentosComponent } from './agendamentos/gate-agendamentos.component';
 import { GateJanelasComponent } from './janelas/gate-janelas.component';
 import { GateDashboardComponent } from './dashboard/gate-dashboard.component';
+import { AgendamentosListComponent } from './portal/agendamentos-list/agendamentos-list.component';
+import { AgendamentoFormComponent } from './portal/agendamento-form/agendamento-form.component';
+import { AgendamentoDetalheComponent } from './portal/agendamento-detalhe/agendamento-detalhe.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { DynamicTableModule } from '../../dynamic-table/dynamic-table.module';
 
 @NgModule({
   declarations: [
     GateAgendamentosComponent,
     GateJanelasComponent,
-    GateDashboardComponent
+    GateDashboardComponent,
+    AgendamentosListComponent,
+    AgendamentoFormComponent,
+    AgendamentoDetalheComponent
   ],
   imports: [
     CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    DynamicTableModule,
     GateRoutingModule
   ]
 })

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.css
@@ -1,0 +1,245 @@
+.agendamento-detalhe {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.agendamento-detalhe--vazio {
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  color: #6b7280;
+  font-size: 1rem;
+}
+
+.agendamento-detalhe__cabecalho {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.agendamento-detalhe__cabecalho h3 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #1f2937;
+}
+
+.agendamento-detalhe__cabecalho p {
+  margin: 6px 0 0;
+  color: #6b7280;
+}
+
+.badge {
+  background: #2563eb;
+  color: #fff;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.agendamento-detalhe__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.agendamento-detalhe__grid div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: #f9fafb;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.rotulo {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #9ca3af;
+  letter-spacing: 0.05em;
+}
+
+.agendamento-detalhe__documentos header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.agendamento-detalhe__documentos h4,
+.agendamento-detalhe__upload h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1f2937;
+}
+
+.documentos {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.documento {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f3f4f6;
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.documento div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.documento a {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.documentos__vazio {
+  margin: 0;
+  color: #6b7280;
+}
+
+.upload__botao {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 10px;
+  padding: 10px 16px;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+  width: fit-content;
+}
+
+.upload__botao input {
+  display: none;
+}
+
+.previews {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+  margin: 16px 0;
+}
+
+.preview {
+  background: #f9fafb;
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: inset 0 0 0 1px rgba(209, 213, 219, 0.6);
+}
+
+.preview__thumb {
+  width: 100%;
+  aspect-ratio: 4/3;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.preview__icone {
+  background: #1f2937;
+  color: #fff;
+  padding: 12px;
+  border-radius: 10px;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.preview__dados {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.preview__dados strong {
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.preview__dados small {
+  color: #6b7280;
+}
+
+.preview__progresso {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.barra {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: #e5e7eb;
+  overflow: hidden;
+}
+
+.preenchimento {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, #2563eb, #60a5fa);
+  transition: width 0.2s ease;
+}
+
+.status {
+  font-size: 0.8rem;
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.status--erro {
+  color: #dc2626;
+}
+
+.btn {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 16px;
+  cursor: pointer;
+  font-weight: 600;
+  background: #e5e7eb;
+  color: #1f2937;
+  width: fit-content;
+}
+
+.btn--primario {
+  background: #2563eb;
+  color: #fff;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.html
@@ -1,0 +1,107 @@
+<section class="agendamento-detalhe" *ngIf="agendamento; else selecione">
+  <header class="agendamento-detalhe__cabecalho">
+    <div>
+      <h3>{{ agendamento?.codigo }}</h3>
+      <p>{{ agendamento?.transportadoraNome || 'Transportadora não informada' }}</p>
+    </div>
+    <span class="badge">{{ agendamento?.statusDescricao || agendamento?.status }}</span>
+  </header>
+
+  <div class="agendamento-detalhe__grid">
+    <div>
+      <span class="rotulo">Operação</span>
+      <span>{{ agendamento?.tipoOperacaoDescricao || agendamento?.tipoOperacao }}</span>
+    </div>
+    <div>
+      <span class="rotulo">Janela</span>
+      <span>
+        {{ agendamento?.dataJanela | date: 'dd/MM/yyyy' }}
+        {{ agendamento?.horaInicioJanela }} - {{ agendamento?.horaFimJanela }}
+      </span>
+    </div>
+    <div>
+      <span class="rotulo">Motorista</span>
+      <span>{{ agendamento?.motoristaNome || '—' }}</span>
+    </div>
+    <div>
+      <span class="rotulo">Placa</span>
+      <span>{{ agendamento?.placaVeiculo || '—' }}</span>
+    </div>
+    <div>
+      <span class="rotulo">Chegada Prevista</span>
+      <span>{{ agendamento?.horarioPrevistoChegada || '—' }}</span>
+    </div>
+    <div>
+      <span class="rotulo">Saída Prevista</span>
+      <span>{{ agendamento?.horarioPrevistoSaida || '—' }}</span>
+    </div>
+  </div>
+
+  <section class="agendamento-detalhe__documentos">
+    <header>
+      <h4>Documentos anexados</h4>
+      <span>{{ agendamento?.documentos?.length || 0 }} documentos</span>
+    </header>
+
+    <ul class="documentos" *ngIf="agendamento?.documentos?.length; else nenhumDocumento" [attr.aria-live]="'polite'">
+      <li class="documento" *ngFor="let documento of agendamento?.documentos; trackBy: trackPorDocumento">
+        <div>
+          <strong>{{ documento.nomeArquivo }}</strong>
+          <span>{{ documento.tamanhoBytes / 1024 | number: '1.0-0' }} KB</span>
+        </div>
+        <a [href]="documento.urlDocumento" target="_blank" rel="noopener">Abrir</a>
+      </li>
+    </ul>
+
+    <ng-template #nenhumDocumento>
+      <p class="documentos__vazio">Nenhum documento enviado ainda.</p>
+    </ng-template>
+  </section>
+
+  <section class="agendamento-detalhe__upload">
+    <h4>Adicionar documentos</h4>
+    <label class="upload__botao">
+      Selecionar arquivos
+      <input type="file" multiple (change)="aoSelecionarArquivos($event)" [disabled]="existeUploadEmAndamento()" />
+    </label>
+
+    <div class="previews" *ngIf="documentosSelecionados.length">
+      <article class="preview" *ngFor="let preview of documentosSelecionados; trackBy: trackPorPreview">
+        <div class="preview__thumb" *ngIf="preview.url; else icone">
+          <img [src]="preview.url" [alt]="preview.nome" />
+        </div>
+        <ng-template #icone>
+          <div class="preview__icone">{{ preview.tipo.split('/')[1] || 'arquivo' }}</div>
+        </ng-template>
+        <div class="preview__dados">
+          <strong>{{ preview.nome }}</strong>
+          <small>{{ preview.tamanho }}</small>
+        </div>
+        <div class="preview__progresso" *ngIf="acompanharProgresso(preview.nome) as progresso">
+          <div class="barra">
+            <span class="preenchimento" [style.width.%]="progresso.progress"></span>
+          </div>
+          <small class="status" [class.status--erro]="progresso.status === 'erro'">
+            {{ progresso.status === 'concluido' ? 'Concluído' : progresso.status === 'erro' ? 'Erro' : progresso.progress + '%' }}
+          </small>
+        </div>
+      </article>
+    </div>
+
+    <button
+      type="button"
+      class="btn btn--primario"
+      [disabled]="!documentosSelecionados.length || existeUploadEmAndamento()"
+      (click)="enviarDocumentos()"
+    >
+      Enviar documentos
+    </button>
+  </section>
+</section>
+
+<ng-template #selecione>
+  <section class="agendamento-detalhe agendamento-detalhe--vazio">
+    <p>Selecione um agendamento para visualizar os detalhes.</p>
+  </section>
+</ng-template>
+

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.ts
@@ -1,0 +1,92 @@
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges } from '@angular/core';
+import { Agendamento, DocumentoAgendamento, UploadDocumentoStatus } from '../../../model/gate/agendamento.model';
+
+interface DocumentoPreview {
+  nome: string;
+  tamanho: string;
+  tipo: string;
+  url?: string;
+  arquivo: File;
+}
+
+@Component({
+  selector: 'app-agendamento-detalhe',
+  templateUrl: './agendamento-detalhe.component.html',
+  styleUrls: ['./agendamento-detalhe.component.css']
+})
+export class AgendamentoDetalheComponent implements OnChanges, OnDestroy {
+  @Input() agendamento: Agendamento | null = null;
+  @Input() uploadStatus: UploadDocumentoStatus[] = [];
+  @Output() anexarDocumentos = new EventEmitter<File[]>();
+
+  documentosSelecionados: DocumentoPreview[] = [];
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['agendamento']) {
+      this.limparSelecao();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.liberarPreviews();
+  }
+
+  aoSelecionarArquivos(evento: Event): void {
+    const input = evento.target as HTMLInputElement | null;
+    const arquivos = Array.from(input?.files ?? []);
+    this.liberarPreviews();
+    this.documentosSelecionados = arquivos.map((arquivo) => ({
+      nome: arquivo.name,
+      tamanho: this.formatarTamanho(arquivo.size),
+      tipo: arquivo.type || 'application/octet-stream',
+      url: arquivo.type.startsWith('image/') ? URL.createObjectURL(arquivo) : undefined,
+      arquivo
+    }));
+  }
+
+  enviarDocumentos(): void {
+    if (!this.documentosSelecionados.length) {
+      return;
+    }
+    this.anexarDocumentos.emit(this.documentosSelecionados.map((item) => item.arquivo));
+    this.limparSelecao();
+  }
+
+  acompanharProgresso(nomeArquivo: string): UploadDocumentoStatus | undefined {
+    return this.uploadStatus.find((status) => status.fileName === nomeArquivo);
+  }
+
+  existeUploadEmAndamento(): boolean {
+    return this.uploadStatus.some((status) => status.status === 'enviando');
+  }
+
+  private limparSelecao(): void {
+    this.liberarPreviews();
+    this.documentosSelecionados = [];
+  }
+
+  private liberarPreviews(): void {
+    this.documentosSelecionados
+      .filter((preview) => preview.url)
+      .forEach((preview) => URL.revokeObjectURL(preview.url!));
+  }
+
+  private formatarTamanho(bytes: number): string {
+    if (bytes === 0) {
+      return '0 B';
+    }
+    const unidades = ['B', 'KB', 'MB', 'GB'];
+    const indice = Math.floor(Math.log(bytes) / Math.log(1024));
+    const tamanho = bytes / Math.pow(1024, indice);
+    return `${tamanho.toFixed(1)} ${unidades[indice]}`;
+  }
+
+  trackPorDocumento(_: number, documento: DocumentoAgendamento): number {
+    return documento.id;
+  }
+
+  trackPorPreview(_: number, preview: DocumentoPreview): string {
+    return preview.nome;
+  }
+}
+

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamento-form/agendamento-form.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamento-form/agendamento-form.component.css
@@ -1,0 +1,262 @@
+.agendamento-formulario {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.agendamento-formulario__cabecalho h3 {
+  margin: 0 0 4px;
+  font-size: 1.5rem;
+  color: #1f2937;
+}
+
+.agendamento-formulario__cabecalho p {
+  margin: 0;
+  color: #6b7280;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.campo span {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.campo input,
+.campo select,
+.campo textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.campo input:focus,
+.campo select:focus,
+.campo textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.campo small {
+  color: #dc2626;
+  font-size: 0.8rem;
+}
+
+.campo--full {
+  grid-column: 1 / -1;
+}
+
+.alerta {
+  background: #fef3c7;
+  color: #92400e;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-size: 0.9rem;
+}
+
+.documentos {
+  background: #f9fafb;
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.documentos header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.documentos h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #1f2937;
+}
+
+.documentos p {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.documentos__contador {
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.documentos__existentes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.documentos__item {
+  background: #fff;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: inset 0 0 0 1px rgba(209, 213, 219, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.upload {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  border-radius: 10px;
+  padding: 10px 16px;
+  cursor: pointer;
+  width: fit-content;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+}
+
+.upload input {
+  display: none;
+}
+
+.previews {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.preview {
+  background: #fff;
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: inset 0 0 0 1px rgba(209, 213, 219, 0.6);
+  display: flex;
+  gap: 12px;
+}
+
+.preview__icone {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  background: #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #1f2937;
+  text-transform: uppercase;
+}
+
+.preview__icone--imagem img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.preview__dados {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.preview__dados strong {
+  color: #1f2937;
+}
+
+.preview__dados small {
+  color: #6b7280;
+}
+
+.preview__progresso {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.barra {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: #e5e7eb;
+  overflow: hidden;
+}
+
+.preenchimento {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, #2563eb, #60a5fa);
+  transition: width 0.2s ease;
+}
+
+.preview__progresso small {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.preview__progresso .status--erro {
+  color: #dc2626;
+}
+
+.erro {
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
+.acoes {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.btn {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  background: #e5e7eb;
+  color: #1f2937;
+}
+
+.btn--primario {
+  background: #2563eb;
+  color: #fff;
+}
+
+.btn:hover:not(:disabled) {
+  box-shadow: 0 8px 18px rgba(107, 114, 128, 0.2);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamento-form/agendamento-form.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamento-form/agendamento-form.component.html
@@ -1,0 +1,177 @@
+<section class="agendamento-formulario">
+  <header class="agendamento-formulario__cabecalho">
+    <div>
+      <h3>{{ emEdicao ? 'Editar agendamento' : 'Novo agendamento' }}</h3>
+      <p>Preencha os campos obrigatórios e valide os horários dentro da janela selecionada.</p>
+    </div>
+  </header>
+
+  <form [formGroup]="formulario" (ngSubmit)="onSubmit()" novalidate>
+    <div class="grid">
+      <label class="campo">
+        <span>Código *</span>
+        <input type="text" formControlName="codigo" autocomplete="off" />
+        <small *ngIf="formulario.get('codigo')?.touched && formulario.get('codigo')?.invalid">Informe o código.</small>
+      </label>
+
+      <label class="campo">
+        <span>Tipo de operação *</span>
+        <select formControlName="tipoOperacao">
+          <option value="" disabled>Selecione</option>
+          <option *ngFor="let opcao of (tiposOperacao$ | async)" [value]="opcao.codigo">
+            {{ opcao.descricao }}
+          </option>
+        </select>
+        <small *ngIf="formulario.get('tipoOperacao')?.touched && formulario.get('tipoOperacao')?.invalid">
+          Selecione um tipo de operação.
+        </small>
+      </label>
+
+      <label class="campo">
+        <span>Status *</span>
+        <select formControlName="status">
+          <option value="" disabled>Selecione</option>
+          <option *ngFor="let opcao of (status$ | async)" [value]="opcao.codigo">
+            {{ opcao.descricao }}
+          </option>
+        </select>
+        <small *ngIf="formulario.get('status')?.touched && formulario.get('status')?.invalid">
+          Informe o status do agendamento.
+        </small>
+      </label>
+
+      <label class="campo">
+        <span>ID Transportadora *</span>
+        <input type="number" formControlName="transportadoraId" />
+        <small *ngIf="formulario.get('transportadoraId')?.touched && formulario.get('transportadoraId')?.invalid">
+          Informe a transportadora.
+        </small>
+      </label>
+
+      <label class="campo">
+        <span>ID Motorista *</span>
+        <input type="number" formControlName="motoristaId" />
+        <small *ngIf="formulario.get('motoristaId')?.touched && formulario.get('motoristaId')?.invalid">
+          Informe o motorista.
+        </small>
+      </label>
+
+      <label class="campo">
+        <span>CPF do motorista *</span>
+        <input
+          type="text"
+          formControlName="motoristaCpf"
+          maxlength="14"
+          (input)="aplicarMascaraCpf($event)"
+          autocomplete="off"
+        />
+        <small *ngIf="formulario.get('motoristaCpf')?.touched && formulario.get('motoristaCpf')?.hasError('cpfInvalido')">
+          CPF inválido.
+        </small>
+      </label>
+
+      <label class="campo">
+        <span>ID Veículo *</span>
+        <input type="number" formControlName="veiculoId" />
+        <small *ngIf="formulario.get('veiculoId')?.touched && formulario.get('veiculoId')?.invalid">
+          Informe o veículo.
+        </small>
+      </label>
+
+      <label class="campo">
+        <span>Placa *</span>
+        <input type="text" formControlName="placaVeiculo" maxlength="8" (input)="aplicarMascaraPlaca($event)" />
+        <small *ngIf="formulario.get('placaVeiculo')?.touched && formulario.get('placaVeiculo')?.hasError('placaInvalida')">
+          Placa inválida.
+        </small>
+      </label>
+
+      <label class="campo">
+        <span>Janela de atendimento *</span>
+        <select formControlName="janelaAtendimentoId">
+          <option value="" disabled>Selecione</option>
+          <option *ngFor="let janela of janelasDisponiveis" [value]="janela.id">
+            {{ janela.data | date: 'dd/MM/yyyy' }} - {{ janela.horaInicio }} / {{ janela.horaFim }}
+          </option>
+        </select>
+        <small *ngIf="formulario.get('janelaAtendimentoId')?.touched && formulario.get('janelaAtendimentoId')?.invalid">
+          Escolha uma janela.
+        </small>
+      </label>
+
+      <label class="campo">
+        <span>Horário previsto de chegada *</span>
+        <input type="time" formControlName="horarioPrevistoChegada" />
+      </label>
+
+      <label class="campo">
+        <span>Horário previsto de saída *</span>
+        <input type="time" formControlName="horarioPrevistoSaida" />
+      </label>
+
+      <label class="campo campo--full">
+        <span>Observações</span>
+        <textarea formControlName="observacoes" rows="3" placeholder="Informações relevantes para a operação"></textarea>
+      </label>
+    </div>
+
+    <div class="alerta" *ngIf="formulario.errors?.horarioJanelaInvalido">
+      Os horários previstos devem estar dentro da janela selecionada e a saída deve ser posterior à chegada.
+    </div>
+
+    <section class="documentos">
+      <header>
+        <div>
+          <h4>Documentos obrigatórios</h4>
+          <p>Envie todos os comprovantes necessários. Formatos suportados: PDF, imagens e planilhas.</p>
+        </div>
+        <span class="documentos__contador">
+          {{ documentosExistentes?.length || 0 }} anexos existentes
+        </span>
+      </header>
+
+      <div class="documentos__existentes" *ngIf="documentosExistentes?.length">
+        <article class="documentos__item" *ngFor="let documento of documentosExistentes">
+          <strong>{{ documento.nomeArquivo }}</strong>
+          <small>{{ documento.tamanhoBytes / 1024 | number: '1.0-0' }} KB</small>
+        </article>
+      </div>
+
+      <label class="upload">
+        Selecionar arquivos
+        <input type="file" multiple (change)="aoSelecionarArquivos($event)" />
+      </label>
+
+      <div class="previews" *ngIf="documentosSelecionados.length">
+        <article class="preview" *ngFor="let preview of documentosSelecionados">
+          <div class="preview__icone" [class.preview__icone--imagem]="preview.url">
+            <img *ngIf="preview.url" [src]="preview.url" [alt]="preview.nome" />
+            <span *ngIf="!preview.url">{{ preview.tipo.split('/')[1] || 'arquivo' }}</span>
+          </div>
+          <div class="preview__dados">
+            <strong>{{ preview.nome }}</strong>
+            <small>{{ preview.tamanho }}</small>
+            <div class="preview__progresso" *ngIf="acompanharProgresso(preview.nome) as progresso">
+              <div class="barra">
+                <span class="preenchimento" [style.width.%]="progresso.progress"></span>
+              </div>
+              <small [class.status--erro]="progresso.status === 'erro'">
+                {{ progresso.status === 'concluido' ? 'Concluído' : progresso.status === 'erro' ? 'Erro' : progresso.progress + '%' }}
+              </small>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <small class="erro" *ngIf="formulario.get('documentos')?.touched && formulario.get('documentos')?.hasError('documentosObrigatorios')">
+        Anexe ao menos um documento.
+      </small>
+    </section>
+
+    <footer class="acoes">
+      <button type="submit" class="btn btn--primario">Salvar</button>
+      <button type="button" class="btn" (click)="cancelarEdicao()">Cancelar</button>
+    </footer>
+  </form>
+</section>
+

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamento-form/agendamento-form.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamento-form/agendamento-form.component.ts
@@ -1,0 +1,330 @@
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { Agendamento, AgendamentoFormPayload, AgendamentoRequest, DocumentoAgendamento, GateEnumOption, UploadDocumentoStatus } from '../../../model/gate/agendamento.model';
+import { JanelaAtendimento } from '../../../model/gate/janela.model';
+
+interface DocumentoPreview {
+  nome: string;
+  tamanho: string;
+  tipo: string;
+  url?: string;
+  arquivo: File;
+}
+
+@Component({
+  selector: 'app-agendamento-form',
+  templateUrl: './agendamento-form.component.html',
+  styleUrls: ['./agendamento-form.component.css']
+})
+export class AgendamentoFormComponent implements OnInit, OnChanges, OnDestroy {
+  @Input() agendamento: Agendamento | null = null;
+  @Input() tiposOperacao$: Observable<GateEnumOption[]> | null = null;
+  @Input() status$: Observable<GateEnumOption[]> | null = null;
+  @Input() janelas$: Observable<JanelaAtendimento[]> | null = null;
+  @Input() documentosExistentes: DocumentoAgendamento[] | null = [];
+  @Input() uploadStatus: UploadDocumentoStatus[] = [];
+
+  @Output() salvar = new EventEmitter<AgendamentoFormPayload>();
+  @Output() cancelar = new EventEmitter<void>();
+
+  formulario!: FormGroup;
+  documentosSelecionados: DocumentoPreview[] = [];
+  janelasDisponiveis: JanelaAtendimento[] = [];
+
+  private readonly destruir$ = new Subject<void>();
+
+  constructor(private readonly formBuilder: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.formulario = this.formBuilder.group({
+      codigo: ['', Validators.required],
+      tipoOperacao: [null, Validators.required],
+      status: [null, Validators.required],
+      transportadoraId: [null, Validators.required],
+      motoristaId: [null, Validators.required],
+      motoristaCpf: ['', [Validators.required, this.cpfValidator()]],
+      veiculoId: [null, Validators.required],
+      placaVeiculo: ['', [Validators.required, this.placaValidator()]],
+      janelaAtendimentoId: [null, Validators.required],
+      horarioPrevistoChegada: ['', Validators.required],
+      horarioPrevistoSaida: ['', Validators.required],
+      observacoes: [''],
+      documentos: [[], this.documentosValidator()]
+    }, { validators: [this.horarioDentroDaJanelaValidator()] });
+
+    if (this.janelas$) {
+      this.janelas$
+        .pipe(takeUntil(this.destruir$))
+        .subscribe((janelas) => {
+          this.janelasDisponiveis = janelas;
+          this.formulario.updateValueAndValidity({ emitEvent: false });
+        });
+    }
+
+    this.preencherFormulario();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['agendamento'] && !changes['agendamento'].firstChange) {
+      this.preencherFormulario();
+    }
+    if (changes['documentosExistentes'] && this.formulario) {
+      this.formulario.get('documentos')?.updateValueAndValidity();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destruir$.next();
+    this.destruir$.complete();
+    this.liberarPreviews();
+  }
+
+  get emEdicao(): boolean {
+    return !!this.agendamento;
+  }
+
+  onSubmit(): void {
+    if (this.formulario.invalid) {
+      this.formulario.markAllAsTouched();
+      return;
+    }
+
+    const valor = this.formulario.value;
+
+    const request: AgendamentoRequest = {
+      codigo: valor.codigo,
+      tipoOperacao: valor.tipoOperacao,
+      status: valor.status,
+      transportadoraId: Number(valor.transportadoraId),
+      motoristaId: Number(valor.motoristaId),
+      veiculoId: Number(valor.veiculoId),
+      janelaAtendimentoId: Number(valor.janelaAtendimentoId),
+      horarioPrevistoChegada: valor.horarioPrevistoChegada,
+      horarioPrevistoSaida: valor.horarioPrevistoSaida,
+      observacoes: valor.observacoes,
+      placaVeiculo: this.sanitizarPlaca(valor.placaVeiculo),
+      motoristaCpf: this.sanitizarCpf(valor.motoristaCpf)
+    };
+
+    const arquivos = this.documentosSelecionados.map((preview) => preview.arquivo);
+
+    this.salvar.emit({
+      request,
+      arquivos
+    });
+  }
+
+  cancelarEdicao(): void {
+    this.cancelar.emit();
+    this.liberarPreviews();
+    this.formulario.reset();
+    this.documentosSelecionados = [];
+    this.formulario.get('documentos')?.setValue([]);
+  }
+
+  aoSelecionarArquivos(evento: Event): void {
+    const input = evento.target as HTMLInputElement | null;
+    const arquivos = Array.from(input?.files ?? []);
+    this.liberarPreviews();
+    this.documentosSelecionados = arquivos.map((arquivo) => ({
+      nome: arquivo.name,
+      tamanho: this.formatarTamanho(arquivo.size),
+      tipo: arquivo.type || 'application/octet-stream',
+      url: arquivo.type.startsWith('image/') ? URL.createObjectURL(arquivo) : undefined,
+      arquivo
+    }));
+    this.formulario.get('documentos')?.setValue(this.documentosSelecionados.map((item) => item.arquivo));
+    this.formulario.get('documentos')?.markAsDirty();
+    this.formulario.get('documentos')?.updateValueAndValidity();
+  }
+
+  acompanharProgresso(nomeArquivo: string): UploadDocumentoStatus | undefined {
+    return this.uploadStatus.find((status) => status.fileName === nomeArquivo);
+  }
+
+  aplicarMascaraCpf(evento: Event): void {
+    const input = evento.target as HTMLInputElement;
+    const valorFormatado = this.formatarCpf(input.value);
+    input.value = valorFormatado;
+    this.formulario.get('motoristaCpf')?.setValue(valorFormatado, { emitEvent: false });
+  }
+
+  aplicarMascaraPlaca(evento: Event): void {
+    const input = evento.target as HTMLInputElement;
+    const valorFormatado = this.formatarPlaca(input.value);
+    input.value = valorFormatado;
+    this.formulario.get('placaVeiculo')?.setValue(valorFormatado, { emitEvent: false });
+  }
+
+  private preencherFormulario(): void {
+    if (!this.formulario) {
+      return;
+    }
+
+    this.liberarPreviews();
+    this.documentosSelecionados = [];
+
+    if (this.agendamento) {
+      this.formulario.patchValue({
+        codigo: this.agendamento.codigo,
+        tipoOperacao: this.agendamento.tipoOperacao,
+        status: this.agendamento.status,
+        transportadoraId: this.agendamento.transportadoraId,
+        motoristaId: this.agendamento.motoristaId,
+        motoristaCpf: '',
+        veiculoId: this.agendamento.veiculoId,
+        placaVeiculo: this.formatarPlaca(this.agendamento.placaVeiculo ?? ''),
+        janelaAtendimentoId: this.agendamento.janelaAtendimentoId,
+        horarioPrevistoChegada: this.agendamento.horarioPrevistoChegada,
+        horarioPrevistoSaida: this.agendamento.horarioPrevistoSaida,
+        observacoes: this.agendamento.observacoes || ''
+      });
+    } else {
+      this.formulario.reset();
+      this.formulario.get('documentos')?.setValue([]);
+    }
+
+    this.formulario.get('documentos')?.updateValueAndValidity();
+  }
+
+  private horarioDentroDaJanelaValidator(): ValidatorFn {
+    return (controle: AbstractControl): ValidationErrors | null => {
+      const janelaId = controle.get('janelaAtendimentoId')?.value;
+      const chegada = controle.get('horarioPrevistoChegada')?.value;
+      const saida = controle.get('horarioPrevistoSaida')?.value;
+
+      if (!janelaId || !chegada || !saida) {
+        return null;
+      }
+
+      const janela = this.janelasDisponiveis.find((item) => item.id === Number(janelaId));
+      if (!janela) {
+        return null;
+      }
+
+      const inicio = this.converterHoraParaMinutos(janela.horaInicio);
+      const fim = this.converterHoraParaMinutos(janela.horaFim);
+      const chegadaMin = this.converterHoraParaMinutos(chegada);
+      const saidaMin = this.converterHoraParaMinutos(saida);
+
+      if (chegadaMin < inicio || saidaMin > fim || chegadaMin >= saidaMin) {
+        return { horarioJanelaInvalido: true };
+      }
+
+      return null;
+    };
+  }
+
+  private documentosValidator(): ValidatorFn {
+    return (controle: AbstractControl): ValidationErrors | null => {
+      const arquivosSelecionados = Array.isArray(controle.value) ? controle.value : [];
+      const possuiExistentes = (this.documentosExistentes?.length ?? 0) > 0;
+      if (!arquivosSelecionados.length && !possuiExistentes) {
+        return { documentosObrigatorios: true };
+      }
+      return null;
+    };
+  }
+
+  private cpfValidator(): ValidatorFn {
+    return (controle: AbstractControl): ValidationErrors | null => {
+      const valor = (controle.value ?? '') as string;
+      const cpf = this.sanitizarCpf(valor);
+      if (!cpf || cpf.length !== 11 || /^([0-9])\1+$/.test(cpf)) {
+        return { cpfInvalido: true };
+      }
+
+      const digitoValido = (base: number): number => {
+        let soma = 0;
+        for (let i = 0; i < base; i++) {
+          soma += parseInt(cpf.charAt(i), 10) * (base + 1 - i);
+        }
+        const resto = (soma * 10) % 11;
+        return resto === 10 ? 0 : resto;
+      };
+
+      if (digitoValido(9) !== parseInt(cpf.charAt(9), 10) || digitoValido(10) !== parseInt(cpf.charAt(10), 10)) {
+        return { cpfInvalido: true };
+      }
+
+      return null;
+    };
+  }
+
+  private placaValidator(): ValidatorFn {
+    const regex = /^[A-Z]{3}-?[0-9][A-Z0-9][0-9]{2}$/;
+    return (controle: AbstractControl): ValidationErrors | null => {
+      const valor = (controle.value ?? '') as string;
+      if (!valor) {
+        return { placaInvalida: true };
+      }
+      const placa = valor.toUpperCase();
+      if (!regex.test(placa)) {
+        return { placaInvalida: true };
+      }
+      return null;
+    };
+  }
+
+  private converterHoraParaMinutos(valor: string): number {
+    const [horas, minutos] = valor.split(':').map(Number);
+    return horas * 60 + minutos;
+  }
+
+  private formatarTamanho(bytes: number): string {
+    if (!bytes) {
+      return '0 B';
+    }
+    const unidades = ['B', 'KB', 'MB', 'GB'];
+    const indice = Math.floor(Math.log(bytes) / Math.log(1024));
+    const tamanho = bytes / Math.pow(1024, indice);
+    return `${tamanho.toFixed(1)} ${unidades[indice]}`;
+  }
+
+  private formatarCpf(valor: string): string {
+    const numeros = valor.replace(/\D/g, '').slice(0, 11);
+    const partes = [
+      numeros.slice(0, 3),
+      numeros.slice(3, 6),
+      numeros.slice(6, 9),
+      numeros.slice(9, 11)
+    ].filter(Boolean);
+    if (partes.length > 3) {
+      return `${partes[0]}.${partes[1]}.${partes[2]}-${partes[3]}`;
+    }
+    if (partes.length > 2) {
+      return `${partes[0]}.${partes[1]}.${partes[2]}`;
+    }
+    if (partes.length > 1) {
+      return `${partes[0]}.${partes[1]}`;
+    }
+    return partes[0] ?? '';
+  }
+
+  private formatarPlaca(valor: string): string {
+    const caracteres = valor.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 7);
+    if (caracteres.length <= 3) {
+      return caracteres;
+    }
+    return `${caracteres.slice(0, 3)}-${caracteres.slice(3)}`;
+  }
+
+  private sanitizarCpf(valor: string): string | null {
+    const digits = valor.replace(/\D/g, '');
+    return digits.length ? digits : null;
+  }
+
+  private sanitizarPlaca(valor: string): string | null {
+    const sanitized = valor.toUpperCase().replace(/[^A-Z0-9]/g, '');
+    return sanitized.length ? sanitized : null;
+  }
+
+  private liberarPreviews(): void {
+    this.documentosSelecionados
+      .filter((preview) => preview.url)
+      .forEach((preview) => URL.revokeObjectURL(preview.url!));
+  }
+}
+

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamentos-list/agendamentos-list.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamentos-list/agendamentos-list.component.css
@@ -1,0 +1,96 @@
+.agendamentos-lista {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  height: 100%;
+}
+
+.agendamentos-lista__cabecalho {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.agendamentos-lista__cabecalho h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #1f2937;
+}
+
+.agendamentos-lista__subtitulo {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.agendamentos-lista__acoes {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.agendamentos-lista__tabela {
+  flex: 1;
+}
+
+.agendamentos-lista__estado {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 32px;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.btn {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 16px;
+  cursor: pointer;
+  font-weight: 600;
+  background: #e5e7eb;
+  color: #1f2937;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(107, 114, 128, 0.2);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.btn--primario {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.btn--perigo {
+  background: #dc2626;
+  color: #ffffff;
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 3px solid rgba(37, 99, 235, 0.25);
+  border-top-color: #2563eb;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamentos-list/agendamentos-list.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamentos-list/agendamentos-list.component.html
@@ -1,0 +1,59 @@
+<section class="agendamentos-lista">
+  <header class="agendamentos-lista__cabecalho">
+    <div>
+      <h3>Agendamentos</h3>
+      <p class="agendamentos-lista__subtitulo">
+        {{ loading ? 'Atualizando agendamentos...' : 'Selecione uma linha para visualizar os detalhes.' }}
+      </p>
+    </div>
+    <div class="agendamentos-lista__acoes">
+      <button type="button" class="btn btn--primario" (click)="novoAgendamento()">
+        Novo
+      </button>
+      <button
+        type="button"
+        class="btn"
+        [disabled]="selectedId === null"
+        (click)="editarAgendamento()"
+      >
+        Editar
+      </button>
+      <button
+        type="button"
+        class="btn btn--perigo"
+        [disabled]="selectedId === null"
+        (click)="cancelarAgendamento()"
+      >
+        Cancelar
+      </button>
+      <button type="button" class="btn" (click)="atualizarLista()">
+        Atualizar
+      </button>
+    </div>
+  </header>
+
+  <ng-container *ngIf="!loading; else carregando">
+    <div class="agendamentos-lista__tabela" *ngIf="dadosTabela.length; else vazio">
+      <app-dynamic-table
+        [columns]="colunas"
+        [data]="dadosTabela"
+        (rowClicked)="onRowClicked($event)"
+        (rowDoubleClicked)="onRowDoubleClicked($event)"
+      ></app-dynamic-table>
+    </div>
+  </ng-container>
+
+  <ng-template #carregando>
+    <div class="agendamentos-lista__estado">
+      <span class="spinner"></span>
+      <span>Carregando agendamentos...</span>
+    </div>
+  </ng-template>
+
+  <ng-template #vazio>
+    <div class="agendamentos-lista__estado">
+      Nenhum agendamento encontrado para o filtro atual.
+    </div>
+  </ng-template>
+</section>
+

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamentos-list/agendamentos-list.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamentos-list/agendamentos-list.component.ts
@@ -1,0 +1,108 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Agendamento } from '../../../model/gate/agendamento.model';
+
+interface AgendamentoRow {
+  __id: number;
+  Código: string;
+  Operação: string;
+  Status: string;
+  Transportadora: string;
+  Janela: string;
+  'Chegada Prevista': string;
+  'Saída Prevista': string;
+}
+
+@Component({
+  selector: 'app-agendamentos-list',
+  templateUrl: './agendamentos-list.component.html',
+  styleUrls: ['./agendamentos-list.component.css']
+})
+export class AgendamentosListComponent implements OnChanges {
+  @Input() agendamentos: Agendamento[] | null = [];
+  @Input() loading = false;
+  @Input() selectedId: number | null = null;
+
+  @Output() selecionar = new EventEmitter<number>();
+  @Output() editar = new EventEmitter<number>();
+  @Output() cancelar = new EventEmitter<number>();
+  @Output() criar = new EventEmitter<void>();
+  @Output() atualizar = new EventEmitter<void>();
+
+  readonly colunas = ['Código', 'Operação', 'Status', 'Transportadora', 'Janela', 'Chegada Prevista', 'Saída Prevista'];
+
+  dadosTabela: AgendamentoRow[] = [];
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['agendamentos']) {
+      this.dadosTabela = (this.agendamentos ?? []).map((item) => this.mapearParaLinha(item));
+    }
+  }
+
+  onRowClicked(evento: any): void {
+    const idSelecionado = evento?.data?.__id as number | undefined;
+    if (typeof idSelecionado !== 'number') {
+      return;
+    }
+    this.selectedId = idSelecionado;
+    this.selecionar.emit(idSelecionado);
+  }
+
+  onRowDoubleClicked(evento: any): void {
+    const idSelecionado = evento?.data?.__id as number | undefined;
+    if (typeof idSelecionado !== 'number') {
+      return;
+    }
+    this.editar.emit(idSelecionado);
+  }
+
+  novoAgendamento(): void {
+    this.criar.emit();
+  }
+
+  editarAgendamento(): void {
+    if (this.selectedId === null) {
+      return;
+    }
+    this.editar.emit(this.selectedId);
+  }
+
+  cancelarAgendamento(): void {
+    if (this.selectedId === null) {
+      return;
+    }
+    this.cancelar.emit(this.selectedId);
+  }
+
+  atualizarLista(): void {
+    this.atualizar.emit();
+  }
+
+  private mapearParaLinha(agendamento: Agendamento): AgendamentoRow {
+    return {
+      __id: agendamento.id,
+      Código: agendamento.codigo,
+      Operação: agendamento.tipoOperacaoDescricao || agendamento.tipoOperacao,
+      Status: agendamento.statusDescricao || agendamento.status,
+      Transportadora: agendamento.transportadoraNome || '—',
+      Janela: this.formatarJanela(agendamento),
+      'Chegada Prevista': this.formatarHora(agendamento.horarioPrevistoChegada),
+      'Saída Prevista': this.formatarHora(agendamento.horarioPrevistoSaida)
+    };
+  }
+
+  private formatarJanela(agendamento: Agendamento): string {
+    if (!agendamento.dataJanela) {
+      return '—';
+    }
+    const inicio = this.formatarHora(agendamento.horaInicioJanela);
+    const fim = this.formatarHora(agendamento.horaFimJanela);
+    const data = new Date(agendamento.dataJanela);
+    const dataFormatada = data.toLocaleDateString('pt-BR');
+    return `${dataFormatada} ${inicio} - ${fim}`.trim();
+  }
+
+  private formatarHora(valor: string | null): string {
+    return valor ? valor.substring(0, 5) : '—';
+  }
+}
+

--- a/frontend/cloudport/src/app/componentes/modal/confirmacao-modal/confirmacao-modal.component.css
+++ b/frontend/cloudport/src/app/componentes/modal/confirmacao-modal/confirmacao-modal.component.css
@@ -1,0 +1,71 @@
+.confirmacao-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1050;
+}
+
+.confirmacao-modal__content {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  width: min(420px, 90vw);
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.2);
+}
+
+.confirmacao-modal__titulo {
+  margin: 0 0 8px;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.confirmacao-modal__mensagem {
+  margin: 0 0 20px;
+  color: #4b5563;
+  line-height: 1.4;
+}
+
+.confirmacao-modal__acoes {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.btn {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 18px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.btn--primario {
+  background: #2563eb;
+  color: #fff;
+}
+
+.btn--primario:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+}
+
+.btn--secundario {
+  background: #e5e7eb;
+  color: #1f2937;
+}
+
+.btn--secundario:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(156, 163, 175, 0.2);
+}
+

--- a/frontend/cloudport/src/app/componentes/modal/confirmacao-modal/confirmacao-modal.component.html
+++ b/frontend/cloudport/src/app/componentes/modal/confirmacao-modal/confirmacao-modal.component.html
@@ -1,0 +1,15 @@
+<div class="confirmacao-modal">
+  <div class="confirmacao-modal__content">
+    <h3 class="confirmacao-modal__titulo">{{ data?.titulo || 'Confirmação' }}</h3>
+    <p class="confirmacao-modal__mensagem">{{ data?.mensagem }}</p>
+    <div class="confirmacao-modal__acoes">
+      <button type="button" class="btn btn--secundario" (click)="cancelar()">
+        {{ data?.textoCancelar || 'Cancelar' }}
+      </button>
+      <button type="button" class="btn btn--primario" (click)="confirmar()">
+        {{ data?.textoConfirmar || 'Confirmar' }}
+      </button>
+    </div>
+  </div>
+</div>
+

--- a/frontend/cloudport/src/app/componentes/modal/confirmacao-modal/confirmacao-modal.component.ts
+++ b/frontend/cloudport/src/app/componentes/modal/confirmacao-modal/confirmacao-modal.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input } from '@angular/core';
+import { PopupService, ConfirmacaoModalData } from '../../service/popupService';
+
+@Component({
+  selector: 'app-confirmacao-modal',
+  templateUrl: './confirmacao-modal.component.html',
+  styleUrls: ['./confirmacao-modal.component.css']
+})
+export class ConfirmacaoModalComponent {
+  @Input() data: ConfirmacaoModalData | null = null;
+
+  constructor(private readonly popupService: PopupService) {}
+
+  confirmar(): void {
+    this.popupService.resolveConfirmacao(true);
+  }
+
+  cancelar(): void {
+    this.popupService.resolveConfirmacao(false);
+  }
+}
+

--- a/frontend/cloudport/src/app/componentes/model/gate/agendamento.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/gate/agendamento.model.ts
@@ -92,4 +92,17 @@ export interface AgendamentoRequest {
   horarioPrevistoChegada: string;
   horarioPrevistoSaida: string;
   observacoes?: string | null;
+  placaVeiculo?: string | null;
+  motoristaCpf?: string | null;
+}
+
+export interface UploadDocumentoStatus {
+  fileName: string;
+  progress: number;
+  status: 'pendente' | 'enviando' | 'concluido' | 'erro';
+}
+
+export interface AgendamentoFormPayload {
+  request: AgendamentoRequest;
+  arquivos: File[];
 }

--- a/frontend/cloudport/src/app/componentes/service/servico-gate/gate-api.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-gate/gate-api.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpEvent, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 import {
   Agendamento,
   AgendamentoFiltro,
   AgendamentoRequest,
+  DocumentoAgendamento,
   GateEnumOption,
   Page
 } from '../../model/gate/agendamento.model';
@@ -86,6 +87,15 @@ export class GateApiService {
 
   listarCanaisEntrada(): Observable<GateEnumOption[]> {
     return this.http.get<GateEnumOption[]>(`${this.configUrl}/canais-entrada`);
+  }
+
+  uploadDocumentoAgendamento(id: number, arquivo: File): Observable<HttpEvent<DocumentoAgendamento>> {
+    const formData = new FormData();
+    formData.append('arquivo', arquivo, arquivo.name);
+    return this.http.post<DocumentoAgendamento>(`${this.agendamentosUrl}/${id}/documentos`, formData, {
+      reportProgress: true,
+      observe: 'events'
+    });
   }
 
   private buildParams(filters?: Record<string, string | number | boolean | undefined | null>): HttpParams {


### PR DESCRIPTION
## Resumo
- cria componentes de portal para listar, detalhar e editar agendamentos usando a DynamicTable e dados do backend
- adiciona formulário reativo com máscaras, validações de janela e anexos com progresso e pré-visualização
- habilita confirmações via ModalComponent e upload de documentos no serviço do gate

## Testes
- `npm run build -- --configuration=development` *(falha: ng não encontrado no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68ed0a71180c8327b69710d2e144bf4e