### PR TITLE
feat: adicionar console e eventos do operador do gate

### DIFF
--- a/frontend/cloudport/src/app/componentes/gate/gate-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/gate/gate-routing.module.ts
@@ -3,12 +3,22 @@ import { RouterModule, Routes } from '@angular/router';
 import { GateAgendamentosComponent } from './agendamentos/gate-agendamentos.component';
 import { GateJanelasComponent } from './janelas/gate-janelas.component';
 import { GateDashboardComponent } from './dashboard/gate-dashboard.component';
+import { GateOperadorConsoleComponent } from './operador/gate-operador-console/gate-operador-console.component';
+import { GateOperadorEventosComponent } from './operador/gate-operador-eventos/gate-operador-eventos.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'agendamentos', pathMatch: 'full' },
   { path: 'agendamentos', component: GateAgendamentosComponent },
   { path: 'janelas', component: GateJanelasComponent },
-  { path: 'dashboard', component: GateDashboardComponent }
+  { path: 'dashboard', component: GateDashboardComponent },
+  {
+    path: 'operador',
+    children: [
+      { path: '', redirectTo: 'console', pathMatch: 'full' },
+      { path: 'console', component: GateOperadorConsoleComponent },
+      { path: 'eventos', component: GateOperadorEventosComponent }
+    ]
+  }
 ];
 
 @NgModule({

--- a/frontend/cloudport/src/app/componentes/gate/gate.module.ts
+++ b/frontend/cloudport/src/app/componentes/gate/gate.module.ts
@@ -9,6 +9,8 @@ import { AgendamentoFormComponent } from './portal/agendamento-form/agendamento-
 import { AgendamentoDetalheComponent } from './portal/agendamento-detalhe/agendamento-detalhe.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DynamicTableModule } from '../../dynamic-table/dynamic-table.module';
+import { GateOperadorConsoleComponent } from './operador/gate-operador-console/gate-operador-console.component';
+import { GateOperadorEventosComponent } from './operador/gate-operador-eventos/gate-operador-eventos.component';
 
 @NgModule({
   declarations: [
@@ -17,7 +19,9 @@ import { DynamicTableModule } from '../../dynamic-table/dynamic-table.module';
     GateDashboardComponent,
     AgendamentosListComponent,
     AgendamentoFormComponent,
-    AgendamentoDetalheComponent
+    AgendamentoDetalheComponent,
+    GateOperadorConsoleComponent,
+    GateOperadorEventosComponent
   ],
   imports: [
     CommonModule,

--- a/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-console/gate-operador-console.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-console/gate-operador-console.component.css
@@ -1,0 +1,583 @@
+.console-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 1.5rem;
+  background: #f4f6fb;
+  min-height: 100vh;
+}
+
+.console-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.console-header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  color: #1a2b6d;
+}
+
+.console-header p {
+  margin: 0.25rem 0 0;
+  color: #4f5b7d;
+}
+
+.console-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  background: #e3e8ff;
+  color: #1a2b6d;
+  text-transform: capitalize;
+}
+
+.console-status .status-indicador {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: #1a2b6d;
+  box-shadow: 0 0 6px rgba(26, 43, 109, 0.4);
+}
+
+.console-status.desconectado {
+  background: #fdecea;
+  color: #b3261e;
+}
+
+.console-status.desconectado .status-indicador {
+  background: #d93025;
+  box-shadow: 0 0 6px rgba(217, 48, 37, 0.4);
+}
+
+.console-status.conectando {
+  background: #fff4e5;
+  color: #c77700;
+}
+
+.console-status.conectando .status-indicador {
+  background: #f29900;
+  box-shadow: 0 0 6px rgba(242, 153, 0, 0.4);
+}
+
+.alertas-realtime {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: #fff9e6;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.05);
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: all 0.3s ease;
+}
+
+.alertas-realtime-visivel {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.alertas-realtime h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #c77700;
+}
+
+.alerta-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: #fff;
+  border-left: 4px solid #f29900;
+}
+
+.alerta-card.alerta-critico {
+  border-left-color: #d93025;
+  background: #fdecea;
+}
+
+.alerta-card.alerta-atencao {
+  border-left-color: #f29900;
+  background: #fff4e5;
+}
+
+.alerta-descricao {
+  display: block;
+  color: #4f5b7d;
+  margin-top: 0.25rem;
+}
+
+.alerta-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #4f5b7d;
+  font-size: 0.85rem;
+}
+
+.filas-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.fila-coluna {
+  background: #fff;
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.fila-coluna header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.fila-coluna h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #1a2b6d;
+}
+
+.fila-contador {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.fila-espera {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.veiculos-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.veiculo-card {
+  background: #f9fbff;
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-left: 4px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.veiculo-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.veiculo-identificacao {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.placa {
+  font-size: 1.3rem;
+  letter-spacing: 0.05em;
+  color: #1a2b6d;
+}
+
+.status {
+  background: #e0e7ff;
+  color: #1a2b6d;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.veiculo-tempo {
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.veiculo-detalhes {
+  display: grid;
+  gap: 0.25rem;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.veiculo-excecoes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.excecoes-titulo {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.excecoes-lista {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.excecao-badge {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: #e5f2ff;
+  color: #1a2b6d;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.excecao-badge-critica {
+  background: #fdecea;
+  color: #b3261e;
+}
+
+.excecao-badge-alerta {
+  background: #fff4e5;
+  color: #c77700;
+}
+
+.veiculo-contatos {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.veiculo-contatos ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.veiculo-contatos a {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.75rem;
+  background: #e0f2fe;
+  color: #0c4a6e;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.veiculo-acoes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.btn {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.15);
+}
+
+.btn.primario {
+  background: #2563eb;
+  color: #fff;
+}
+
+.btn.secundario {
+  background: #e0e7ff;
+  color: #1a2b6d;
+}
+
+.btn.terciario {
+  background: #fce7f3;
+  color: #9d174d;
+}
+
+.btn.texto {
+  background: transparent;
+  color: #1a2b6d;
+  text-decoration: underline;
+  padding-left: 0;
+}
+
+.veiculo-excecao-critica {
+  border-left-color: #d93025;
+  background: #fdecea;
+}
+
+.veiculo-excecao-alerta {
+  border-left-color: #f29900;
+  background: #fff4e5;
+}
+
+.atendimento-container {
+  background: #fff;
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.atendimento-container header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.atendimento-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.atendimento-card {
+  background: #f9fbff;
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.historico-container {
+  background: #fff;
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.historico-container header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.historico-container ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.historico-container li {
+  display: flex;
+  justify-content: space-between;
+  background: #f8fafc;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border-left: 4px solid transparent;
+  gap: 1rem;
+}
+
+.historico-container li strong {
+  display: block;
+  color: #1a2b6d;
+}
+
+.historico-container li span {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.historico-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #475569;
+}
+
+.historico-critico {
+  border-left-color: #d93025;
+  background: #fdecea;
+}
+
+.historico-alerta {
+  border-left-color: #f29900;
+  background: #fff4e5;
+}
+
+.link-eventos {
+  text-decoration: none;
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal-conteudo {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  width: min(480px, 100%);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-conteudo header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.modal-conteudo h2 {
+  margin: 0;
+  color: #1a2b6d;
+}
+
+.modal-fechar {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+select,
+textarea,
+input[type='datetime-local'] {
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  background: #f8faff;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.checkbox-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.modal-acoes {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.erro-campo {
+  font-size: 0.8rem;
+  color: #d93025;
+}
+
+.feedback-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1100;
+}
+
+.feedback-mensagem,
+.feedback-erro {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.18);
+  background: #fff;
+}
+
+.feedback-mensagem {
+  border-left: 4px solid #22c55e;
+  color: #14532d;
+}
+
+.feedback-erro {
+  border-left: 4px solid #d93025;
+  color: #7f1d1d;
+}
+
+@media (max-width: 1024px) {
+  .console-wrapper {
+    padding: 1rem;
+  }
+
+  .filas-container {
+    grid-template-columns: 1fr;
+  }
+
+  .atendimento-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .veiculo-acoes {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 640px) {
+  .console-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .modal-conteudo {
+    padding: 1rem;
+  }
+
+  .feedback-container {
+    left: 1rem;
+    right: 1rem;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-console/gate-operador-console.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-console/gate-operador-console.component.html
@@ -1,0 +1,325 @@
+<div class="console-wrapper" *ngIf="(painel$ | async) as painel">
+  <header class="console-header">
+    <div>
+      <h1>Console do Operador de Gate</h1>
+      <p>Monitoramento em tempo real das filas de entrada e saída, veículos em atendimento e ocorrências recentes.</p>
+    </div>
+    <div class="console-status" [ngClass]="(statusConexao$ | async)">
+      <span class="status-indicador"></span>
+      <span class="status-texto">
+        Conexão: {{ (statusConexao$ | async) === 'conectado' ? 'Ativa' : (statusConexao$ | async) === 'conectando' ? 'Conectando...' : 'Offline' }}
+      </span>
+    </div>
+  </header>
+
+  <section class="alertas-realtime" *ngIf="(alertasRecentes$ | async)?.length as quantidadeAlertas" [class.alertas-realtime-visivel]="quantidadeAlertas > 0">
+    <h2>Alertas Recentes</h2>
+    <article *ngFor="let alerta of (alertasRecentes$ | async)" class="alerta-card" [ngClass]="{'alerta-critico': alerta.nivel === 'CRITICA', 'alerta-atencao': alerta.nivel === 'ALERTA'}">
+      <div>
+        <strong>{{ alerta.tipo }}</strong>
+        <span class="alerta-descricao">{{ alerta.descricao }}</span>
+      </div>
+      <div class="alerta-meta">
+        <span>{{ alerta.registradoEm | date:'shortTime' }}</span>
+        <span *ngIf="alerta.placaVeiculo">Placa: {{ alerta.placaVeiculo }}</span>
+      </div>
+    </article>
+  </section>
+
+  <section class="filas-container">
+    <div class="fila-coluna" *ngFor="let fila of painel.filasEntrada">
+      <header>
+        <h2>Fila de Entrada - {{ fila.nome }}</h2>
+        <span class="fila-contador">{{ fila.quantidade }} veículos</span>
+        <span class="fila-espera" *ngIf="fila.tempoMedioEsperaMinutos">Tempo médio: {{ fila.tempoMedioEsperaMinutos }} min</span>
+      </header>
+      <div class="veiculos-grid">
+        <article class="veiculo-card" *ngFor="let veiculo of fila.veiculos"
+                 [ngClass]="{
+                   'veiculo-excecao-critica': possuiExcecaoCritica(veiculo),
+                   'veiculo-excecao-alerta': !possuiExcecaoCritica(veiculo) && possuiExcecaoAlerta(veiculo)
+                 }">
+          <header>
+            <div class="veiculo-identificacao">
+              <strong class="placa">{{ veiculo.placa }}</strong>
+              <span class="status">{{ veiculo.statusDescricao || veiculo.status }}</span>
+            </div>
+            <div class="veiculo-tempo" *ngIf="veiculo.tempoFilaMinutos !== null && veiculo.tempoFilaMinutos !== undefined">
+              {{ veiculo.tempoFilaMinutos }} min em fila
+            </div>
+          </header>
+          <div class="veiculo-detalhes">
+            <p *ngIf="veiculo.transportadora"><strong>Transportadora:</strong> {{ veiculo.transportadora }}</p>
+            <p *ngIf="veiculo.documento"><strong>Documento:</strong> {{ veiculo.documento }}</p>
+            <p *ngIf="veiculo.motorista"><strong>Motorista:</strong> {{ veiculo.motorista }}</p>
+            <p *ngIf="veiculo.canalEntrada"><strong>Canal:</strong> {{ veiculo.canalEntrada }}</p>
+          </div>
+          <div class="veiculo-excecoes" *ngIf="veiculo.excecoes?.length">
+            <span class="excecoes-titulo">Exceções</span>
+            <div class="excecoes-lista">
+              <span *ngFor="let excecao of veiculo.excecoes" [ngClass]="classeExcecao(excecao)">
+                {{ excecao.descricao }}
+              </span>
+            </div>
+          </div>
+          <div class="veiculo-contatos" *ngIf="veiculo.contatos?.length">
+            <span class="contatos-titulo">Contato rápido</span>
+            <ul>
+              <li *ngFor="let contato of veiculo.contatos">
+                <a [href]="contatoLink(contato.tipo, contato.valor)" target="_blank" rel="noopener">
+                  {{ contatoDescricao(contato.tipo) }}
+                </a>
+              </li>
+            </ul>
+          </div>
+          <footer class="veiculo-acoes">
+            <button type="button" class="btn primario" (click)="abrirModalLiberacao(veiculo)">
+              Liberar manualmente
+            </button>
+            <button type="button" class="btn secundario" (click)="abrirModalBloqueio(veiculo)">
+              Bloquear
+            </button>
+            <button type="button" class="btn terciario" (click)="abrirModalOcorrencia(veiculo)">
+              Registrar ocorrência
+            </button>
+            <button type="button" class="btn texto" [disabled]="!veiculo.podeImprimirComprovante" (click)="imprimirComprovante(veiculo)">
+              Imprimir comprovante
+            </button>
+          </footer>
+        </article>
+      </div>
+    </div>
+
+    <div class="fila-coluna" *ngFor="let fila of painel.filasSaida">
+      <header>
+        <h2>Fila de Saída - {{ fila.nome }}</h2>
+        <span class="fila-contador">{{ fila.quantidade }} veículos</span>
+        <span class="fila-espera" *ngIf="fila.tempoMedioEsperaMinutos">Tempo médio: {{ fila.tempoMedioEsperaMinutos }} min</span>
+      </header>
+      <div class="veiculos-grid">
+        <article class="veiculo-card" *ngFor="let veiculo of fila.veiculos"
+                 [ngClass]="{
+                   'veiculo-excecao-critica': possuiExcecaoCritica(veiculo),
+                   'veiculo-excecao-alerta': !possuiExcecaoCritica(veiculo) && possuiExcecaoAlerta(veiculo)
+                 }">
+          <header>
+            <div class="veiculo-identificacao">
+              <strong class="placa">{{ veiculo.placa }}</strong>
+              <span class="status">{{ veiculo.statusDescricao || veiculo.status }}</span>
+            </div>
+            <div class="veiculo-tempo" *ngIf="veiculo.tempoFilaMinutos !== null && veiculo.tempoFilaMinutos !== undefined">
+              {{ veiculo.tempoFilaMinutos }} min em fila
+            </div>
+          </header>
+          <div class="veiculo-detalhes">
+            <p *ngIf="veiculo.transportadora"><strong>Transportadora:</strong> {{ veiculo.transportadora }}</p>
+            <p *ngIf="veiculo.documento"><strong>Documento:</strong> {{ veiculo.documento }}</p>
+            <p *ngIf="veiculo.motorista"><strong>Motorista:</strong> {{ veiculo.motorista }}</p>
+            <p *ngIf="veiculo.canalEntrada"><strong>Canal:</strong> {{ veiculo.canalEntrada }}</p>
+          </div>
+          <div class="veiculo-excecoes" *ngIf="veiculo.excecoes?.length">
+            <span class="excecoes-titulo">Exceções</span>
+            <div class="excecoes-lista">
+              <span *ngFor="let excecao of veiculo.excecoes" [ngClass]="classeExcecao(excecao)">
+                {{ excecao.descricao }}
+              </span>
+            </div>
+          </div>
+          <div class="veiculo-contatos" *ngIf="veiculo.contatos?.length">
+            <span class="contatos-titulo">Contato rápido</span>
+            <ul>
+              <li *ngFor="let contato of veiculo.contatos">
+                <a [href]="contatoLink(contato.tipo, contato.valor)" target="_blank" rel="noopener">
+                  {{ contatoDescricao(contato.tipo) }}
+                </a>
+              </li>
+            </ul>
+          </div>
+          <footer class="veiculo-acoes">
+            <button type="button" class="btn primario" (click)="abrirModalLiberacao(veiculo)">
+              Liberar manualmente
+            </button>
+            <button type="button" class="btn secundario" (click)="abrirModalBloqueio(veiculo)">
+              Bloquear
+            </button>
+            <button type="button" class="btn terciario" (click)="abrirModalOcorrencia(veiculo)">
+              Registrar ocorrência
+            </button>
+            <button type="button" class="btn texto" [disabled]="!veiculo.podeImprimirComprovante" (click)="imprimirComprovante(veiculo)">
+              Imprimir comprovante
+            </button>
+          </footer>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="atendimento-container">
+    <header>
+      <h2>Veículos em Atendimento</h2>
+      <span>{{ painel.veiculosAtendimento.length }} em atendimento</span>
+    </header>
+    <div class="atendimento-grid">
+      <article *ngFor="let veiculo of painel.veiculosAtendimento" class="atendimento-card"
+               [ngClass]="{
+                 'veiculo-excecao-critica': possuiExcecaoCritica(veiculo),
+                 'veiculo-excecao-alerta': !possuiExcecaoCritica(veiculo) && possuiExcecaoAlerta(veiculo)
+               }">
+        <header>
+          <strong class="placa">{{ veiculo.placa }}</strong>
+          <span class="status">{{ veiculo.statusDescricao || veiculo.status }}</span>
+        </header>
+        <p *ngIf="veiculo.transportadora"><strong>Transportadora:</strong> {{ veiculo.transportadora }}</p>
+        <p *ngIf="veiculo.motorista"><strong>Motorista:</strong> {{ veiculo.motorista }}</p>
+        <p *ngIf="veiculo.documento"><strong>Documento:</strong> {{ veiculo.documento }}</p>
+        <div class="veiculo-excecoes" *ngIf="veiculo.excecoes?.length">
+          <span class="excecoes-titulo">Exceções</span>
+          <div class="excecoes-lista">
+            <span *ngFor="let excecao of veiculo.excecoes" [ngClass]="classeExcecao(excecao)">
+              {{ excecao.descricao }}
+            </span>
+          </div>
+        </div>
+        <footer class="veiculo-acoes">
+          <button type="button" class="btn primario" (click)="abrirModalLiberacao(veiculo)">
+            Liberar manualmente
+          </button>
+          <button type="button" class="btn secundario" (click)="abrirModalBloqueio(veiculo)">
+            Bloquear
+          </button>
+          <button type="button" class="btn terciario" (click)="abrirModalOcorrencia(veiculo)">
+            Registrar ocorrência
+          </button>
+          <button type="button" class="btn texto" [disabled]="!veiculo.podeImprimirComprovante" (click)="imprimirComprovante(veiculo)">
+            Imprimir comprovante
+          </button>
+        </footer>
+      </article>
+    </div>
+  </section>
+
+  <section class="historico-container">
+    <header>
+      <h2>Histórico recente</h2>
+      <a routerLink="../eventos" class="link-eventos">Ver todos os eventos</a>
+    </header>
+    <ul>
+      <li *ngFor="let evento of painel.historico | slice:0:10" [ngClass]="{'historico-critico': evento.nivel === 'CRITICA', 'historico-alerta': evento.nivel === 'ALERTA'}">
+        <div>
+          <strong>{{ evento.tipo }}</strong>
+          <span>{{ evento.descricao }}</span>
+        </div>
+        <div class="historico-meta">
+          <span>{{ evento.registradoEm | date:'short' }}</span>
+          <span *ngIf="evento.placaVeiculo">Placa: {{ evento.placaVeiculo }}</span>
+        </div>
+      </li>
+    </ul>
+  </section>
+</div>
+
+<div class="modal-backdrop" *ngIf="modalLiberacaoAberto">
+  <div class="modal-conteudo">
+    <header>
+      <h2>Liberar veículo manualmente</h2>
+      <button type="button" class="modal-fechar" (click)="fecharModais()">&times;</button>
+    </header>
+    <form [formGroup]="formLiberacao" (ngSubmit)="confirmarLiberacao()">
+      <label for="canalEntrada">Canal de entrada</label>
+      <select id="canalEntrada" formControlName="canalEntrada">
+        <option value="" disabled>Selecione</option>
+        <option *ngFor="let canal of (canaisEntrada$ | async)" [value]="canal.codigo">{{ canal.descricao }}</option>
+      </select>
+      <div class="erro-campo" *ngIf="formLiberacao.controls.canalEntrada.invalid && formLiberacao.controls.canalEntrada.touched">
+        Informe o canal utilizado pelo veículo.
+      </div>
+
+      <label for="justificativaLiberacao">Justificativa</label>
+      <textarea id="justificativaLiberacao" rows="3" formControlName="justificativa" placeholder="Descreva o motivo da liberação manual"></textarea>
+      <div class="erro-campo" *ngIf="formLiberacao.controls.justificativa.invalid && formLiberacao.controls.justificativa.touched">
+        Informe uma justificativa com pelo menos 5 caracteres.
+      </div>
+
+      <label class="checkbox-inline">
+        <input type="checkbox" formControlName="notificarTransportadora" />
+        Notificar transportadora
+      </label>
+
+      <footer class="modal-acoes">
+        <button type="submit" class="btn primario" [disabled]="formLiberacao.invalid">Confirmar liberação</button>
+        <button type="button" class="btn secundario" (click)="fecharModais()">Cancelar</button>
+      </footer>
+    </form>
+  </div>
+</div>
+
+<div class="modal-backdrop" *ngIf="modalBloqueioAberto">
+  <div class="modal-conteudo">
+    <header>
+      <h2>Bloquear veículo</h2>
+      <button type="button" class="modal-fechar" (click)="fecharModais()">&times;</button>
+    </header>
+    <form [formGroup]="formBloqueio" (ngSubmit)="confirmarBloqueio()">
+      <label for="motivoBloqueio">Motivo do bloqueio</label>
+      <select id="motivoBloqueio" formControlName="motivoCodigo">
+        <option value="" disabled>Selecione</option>
+        <option *ngFor="let motivo of (motivosBloqueio$ | async)" [value]="motivo.codigo">{{ motivo.descricao }}</option>
+      </select>
+      <div class="erro-campo" *ngIf="formBloqueio.controls.motivoCodigo.invalid && formBloqueio.controls.motivoCodigo.touched">
+        Informe o motivo do bloqueio.
+      </div>
+
+      <label for="justificativaBloqueio">Justificativa</label>
+      <textarea id="justificativaBloqueio" rows="3" formControlName="justificativa"></textarea>
+      <div class="erro-campo" *ngIf="formBloqueio.controls.justificativa.invalid && formBloqueio.controls.justificativa.touched">
+        Informe uma justificativa com pelo menos 5 caracteres.
+      </div>
+
+      <label for="bloqueioAte">Bloqueio até</label>
+      <input id="bloqueioAte" type="datetime-local" formControlName="bloqueioAte" />
+      <div class="erro-campo" *ngIf="formBloqueio.controls.bloqueioAte.invalid && formBloqueio.controls.bloqueioAte.touched">
+        Informe a data e hora de revisão do bloqueio.
+      </div>
+
+      <footer class="modal-acoes">
+        <button type="submit" class="btn primario" [disabled]="formBloqueio.invalid">Confirmar bloqueio</button>
+        <button type="button" class="btn secundario" (click)="fecharModais()">Cancelar</button>
+      </footer>
+    </form>
+  </div>
+</div>
+
+<div class="modal-backdrop" *ngIf="modalOcorrenciaAberto">
+  <div class="modal-conteudo">
+    <header>
+      <h2>Registrar ocorrência</h2>
+      <button type="button" class="modal-fechar" (click)="fecharModais()">&times;</button>
+    </header>
+    <form [formGroup]="formOcorrencia" (ngSubmit)="confirmarOcorrencia()">
+      <label for="tipoOcorrencia">Tipo de ocorrência</label>
+      <select id="tipoOcorrencia" formControlName="tipoCodigo">
+        <option value="" disabled>Selecione</option>
+        <option *ngFor="let tipo of (tiposOcorrencia$ | async)" [value]="tipo.codigo">{{ tipo.descricao }}</option>
+      </select>
+      <div class="erro-campo" *ngIf="formOcorrencia.controls.tipoCodigo.invalid && formOcorrencia.controls.tipoCodigo.touched">
+        Informe o tipo de ocorrência.
+      </div>
+
+      <label for="descricaoOcorrencia">Descrição</label>
+      <textarea id="descricaoOcorrencia" rows="4" formControlName="descricao" placeholder="Descreva o que ocorreu"></textarea>
+      <div class="erro-campo" *ngIf="formOcorrencia.controls.descricao.invalid && formOcorrencia.controls.descricao.touched">
+        Informe uma descrição com pelo menos 5 caracteres.
+      </div>
+
+      <footer class="modal-acoes">
+        <button type="submit" class="btn primario" [disabled]="formOcorrencia.invalid">Enviar ocorrência</button>
+        <button type="button" class="btn secundario" (click)="fecharModais()">Cancelar</button>
+      </footer>
+    </form>
+  </div>
+</div>
+
+<div class="feedback-container" *ngIf="mensagemFeedback || erroAcao">
+  <div class="feedback-mensagem" *ngIf="mensagemFeedback">{{ mensagemFeedback }}</div>
+  <div class="feedback-erro" *ngIf="erroAcao">{{ erroAcao }}</div>
+</div>

--- a/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-console/gate-operador-console.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-console/gate-operador-console.component.ts
@@ -1,0 +1,264 @@
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { map, Observable, of, tap } from 'rxjs';
+import {
+  GateBloqueioRequest,
+  GateLiberacaoManualRequest,
+  GateOcorrenciaRequest,
+  GateOperadorEvento,
+  GateOperadorExcecao,
+  GateOperadorPainel,
+  GateOperadorVeiculo
+} from '../../../model/gate/operador.model';
+import { GateOperadorService } from '../../../service/servico-gate/gate-operador.service';
+import { GateEnumOption } from '../../../model/gate/agendamento.model';
+
+interface AlertaTemporario {
+  evento: GateOperadorEvento;
+  expiraEm: number;
+}
+
+@Component({
+  selector: 'app-gate-operador-console',
+  templateUrl: './gate-operador-console.component.html',
+  styleUrls: ['./gate-operador-console.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class GateOperadorConsoleComponent implements OnInit, OnDestroy {
+  readonly painel$: Observable<GateOperadorPainel> = this.gateOperadorService.painel$;
+  readonly eventos$: Observable<GateOperadorEvento[]> = this.gateOperadorService.eventos$;
+  readonly canaisEntrada$: Observable<GateEnumOption[]> = this.gateOperadorService.listarCanaisEntrada();
+  readonly motivosBloqueio$: Observable<GateEnumOption[]> = this.gateOperadorService.listarMotivosExcecao();
+  readonly tiposOcorrencia$: Observable<GateEnumOption[]> = this.gateOperadorService.listarTiposOcorrencia();
+  readonly statusConexao$ = this.gateOperadorService.statusConexao$;
+
+  readonly filaResumo$: Observable<{ titulo: string; dados: GateOperadorVeiculo[] }[]> = this.painel$.pipe(
+    map((painel) => [
+      { titulo: 'Entrada', dados: painel.filasEntrada.flatMap((fila) => fila.veiculos) },
+      { titulo: 'Saída', dados: painel.filasSaida.flatMap((fila) => fila.veiculos) }
+    ])
+  );
+
+  readonly formLiberacao = this.fb.group({
+    canalEntrada: [null, Validators.required],
+    justificativa: ['', [Validators.required, Validators.minLength(5)]],
+    notificarTransportadora: [true]
+  });
+
+  readonly formBloqueio = this.fb.group({
+    motivoCodigo: [null, Validators.required],
+    justificativa: ['', [Validators.required, Validators.minLength(5)]],
+    bloqueioAte: ['', Validators.required]
+  });
+
+  readonly formOcorrencia = this.fb.group({
+    tipoCodigo: [null, Validators.required],
+    descricao: ['', [Validators.required, Validators.minLength(5)]],
+    veiculoId: [null]
+  });
+
+  modalLiberacaoAberto = false;
+  modalBloqueioAberto = false;
+  modalOcorrenciaAberto = false;
+  veiculoSelecionado: GateOperadorVeiculo | null = null;
+  mensagemFeedback: string | null = null;
+  erroAcao: string | null = null;
+
+  alertasRecentes$: Observable<GateOperadorEvento[]> = of([]);
+
+  private readonly alertasBuffer: AlertaTemporario[] = [];
+
+  constructor(private readonly gateOperadorService: GateOperadorService, private readonly fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.gateOperadorService.carregarPainel().subscribe({
+      error: (erro) => console.warn('Não foi possível carregar o painel do Gate.', erro)
+    });
+    this.gateOperadorService.atualizarHistorico().subscribe({
+      error: (erro) => console.warn('Não foi possível carregar o histórico inicial do Gate.', erro)
+    });
+    this.gateOperadorService.conectarEventos();
+    this.alertasRecentes$ = this.gateOperadorService.alertas$.pipe(
+      tap((evento) => this.empilharAlerta(evento)),
+      map(() => this.obterAlertasAtivos())
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.gateOperadorService.desconectarEventos();
+  }
+
+  abrirModalLiberacao(veiculo: GateOperadorVeiculo): void {
+    this.veiculoSelecionado = veiculo;
+    this.formLiberacao.reset({ canalEntrada: null, justificativa: '', notificarTransportadora: true });
+    this.modalLiberacaoAberto = true;
+    this.mensagemFeedback = null;
+    this.erroAcao = null;
+  }
+
+  abrirModalBloqueio(veiculo: GateOperadorVeiculo): void {
+    this.veiculoSelecionado = veiculo;
+    this.formBloqueio.reset({ motivoCodigo: null, justificativa: '', bloqueioAte: '' });
+    this.modalBloqueioAberto = true;
+    this.mensagemFeedback = null;
+    this.erroAcao = null;
+  }
+
+  abrirModalOcorrencia(veiculo: GateOperadorVeiculo | null): void {
+    this.veiculoSelecionado = veiculo;
+    this.formOcorrencia.reset({ tipoCodigo: null, descricao: '', veiculoId: veiculo?.id ?? null });
+    this.modalOcorrenciaAberto = true;
+    this.mensagemFeedback = null;
+    this.erroAcao = null;
+  }
+
+  fecharModais(): void {
+    this.modalLiberacaoAberto = false;
+    this.modalBloqueioAberto = false;
+    this.modalOcorrenciaAberto = false;
+  }
+
+  confirmarLiberacao(): void {
+    if (!this.veiculoSelecionado || this.formLiberacao.invalid) {
+      this.formLiberacao.markAllAsTouched();
+      return;
+    }
+
+    const payload = this.formLiberacao.getRawValue() as GateLiberacaoManualRequest;
+    this.mensagemFeedback = 'Enviando liberação manual...';
+    this.erroAcao = null;
+
+    this.gateOperadorService.liberarVeiculo(this.veiculoSelecionado.id, payload).subscribe({
+      next: () => {
+        this.mensagemFeedback = 'Veículo liberado com sucesso.';
+        this.fecharModais();
+      },
+      error: () => {
+        this.erroAcao = 'Não foi possível liberar o veículo. Tente novamente em instantes.';
+      }
+    });
+  }
+
+  confirmarBloqueio(): void {
+    if (!this.veiculoSelecionado || this.formBloqueio.invalid) {
+      this.formBloqueio.markAllAsTouched();
+      return;
+    }
+
+    const payload = this.formBloqueio.getRawValue() as GateBloqueioRequest;
+    this.mensagemFeedback = 'Registrando bloqueio do veículo...';
+    this.erroAcao = null;
+
+    this.gateOperadorService.bloquearVeiculo(this.veiculoSelecionado.id, payload).subscribe({
+      next: () => {
+        this.mensagemFeedback = 'Bloqueio registrado com sucesso.';
+        this.fecharModais();
+      },
+      error: () => {
+        this.erroAcao = 'Não foi possível bloquear o veículo. Verifique os dados e tente novamente.';
+      }
+    });
+  }
+
+  confirmarOcorrencia(): void {
+    if (this.formOcorrencia.invalid) {
+      this.formOcorrencia.markAllAsTouched();
+      return;
+    }
+
+    const payload = this.formOcorrencia.getRawValue() as GateOcorrenciaRequest;
+    this.mensagemFeedback = 'Enviando ocorrência ao time de monitoramento...';
+    this.erroAcao = null;
+
+    this.gateOperadorService.registrarOcorrencia(payload).subscribe({
+      next: () => {
+        this.mensagemFeedback = 'Ocorrência registrada com sucesso.';
+        this.fecharModais();
+      },
+      error: () => {
+        this.erroAcao = 'Não foi possível registrar a ocorrência. Revise as informações e tente novamente.';
+      }
+    });
+  }
+
+  imprimirComprovante(veiculo: GateOperadorVeiculo): void {
+    if (!veiculo.podeImprimirComprovante) {
+      return;
+    }
+
+    this.mensagemFeedback = 'Preparando comprovante de gate...';
+    this.gateOperadorService.imprimirComprovante(veiculo.id).subscribe({
+      next: () => {
+        this.mensagemFeedback = 'Comprovante enviado para impressão.';
+      },
+      error: () => {
+        this.erroAcao = 'Não foi possível imprimir o comprovante. Tente novamente.';
+      }
+    });
+  }
+
+  possuiExcecaoCritica(veiculo: GateOperadorVeiculo | null | undefined): boolean {
+    return (veiculo?.excecoes ?? []).some((excecao) => (excecao.nivel ?? '').toUpperCase() === 'CRITICA');
+  }
+
+  possuiExcecaoAlerta(veiculo: GateOperadorVeiculo | null | undefined): boolean {
+    return (veiculo?.excecoes ?? []).some((excecao) => (excecao.nivel ?? '').toUpperCase() === 'ALERTA');
+  }
+
+  classeExcecao(excecao: GateOperadorExcecao): string {
+    const nivel = (excecao.nivel ?? '').toUpperCase();
+    if (nivel === 'CRITICA') {
+      return 'excecao-badge excecao-badge-critica';
+    }
+    if (nivel === 'ALERTA') {
+      return 'excecao-badge excecao-badge-alerta';
+    }
+    return 'excecao-badge';
+  }
+
+  contatoLink(tipo: string, valor: string): string {
+    const tipoUpper = (tipo || '').toUpperCase();
+    if (tipoUpper === 'TELEFONE' || tipoUpper === 'WHATSAPP') {
+      const numero = valor.replace(/[^0-9+]/g, '');
+      return `tel:${numero}`;
+    }
+    if (tipoUpper === 'EMAIL') {
+      return `mailto:${valor}`;
+    }
+    return valor;
+  }
+
+  contatoDescricao(tipo: string): string {
+    const tipoUpper = (tipo || '').toUpperCase();
+    if (tipoUpper === 'TELEFONE') {
+      return 'Ligar';
+    }
+    if (tipoUpper === 'WHATSAPP') {
+      return 'WhatsApp';
+    }
+    if (tipoUpper === 'EMAIL') {
+      return 'E-mail';
+    }
+    return tipo;
+  }
+
+  private empilharAlerta(evento: GateOperadorEvento): void {
+    const expiracao = Date.now() + 15000;
+    this.alertasBuffer.unshift({ evento, expiraEm: expiracao });
+    this.descartarAlertasExpirados();
+  }
+
+  private obterAlertasAtivos(): GateOperadorEvento[] {
+    this.descartarAlertasExpirados();
+    return this.alertasBuffer.map((item) => item.evento);
+  }
+
+  private descartarAlertasExpirados(): void {
+    const agora = Date.now();
+    for (let index = this.alertasBuffer.length - 1; index >= 0; index -= 1) {
+      if (this.alertasBuffer[index].expiraEm < agora) {
+        this.alertasBuffer.splice(index, 1);
+      }
+    }
+  }
+}

--- a/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-eventos/gate-operador-eventos.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-eventos/gate-operador-eventos.component.css
@@ -1,0 +1,171 @@
+.eventos-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background: #f4f6fb;
+  min-height: 100vh;
+}
+
+.eventos-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.eventos-header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  color: #1a2b6d;
+}
+
+.eventos-header p {
+  margin: 0.25rem 0 0;
+  color: #4f5b7d;
+}
+
+.status-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0c4a6e;
+  text-transform: capitalize;
+}
+
+.status-badge .indicador {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: #0ea5e9;
+  box-shadow: 0 0 6px rgba(14, 165, 233, 0.4);
+}
+
+.status-badge.desconectado {
+  background: #fdecea;
+  color: #b3261e;
+}
+
+.status-badge.desconectado .indicador {
+  background: #d93025;
+  box-shadow: 0 0 6px rgba(217, 48, 37, 0.4);
+}
+
+.status-badge.conectando {
+  background: #fff4e5;
+  color: #c77700;
+}
+
+.status-badge.conectando .indicador {
+  background: #f29900;
+  box-shadow: 0 0 6px rgba(242, 153, 0, 0.4);
+}
+
+.filtros {
+  background: #fff;
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
+}
+
+.filtros form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  align-items: end;
+}
+
+label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+select,
+input[type='search'] {
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  background: #f8faff;
+}
+
+.lista-eventos {
+  display: grid;
+  gap: 1rem;
+}
+
+.lista-eventos article {
+  background: #fff;
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
+  border-left: 4px solid transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lista-eventos article header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.lista-eventos article strong {
+  font-size: 1.1rem;
+  color: #1a2b6d;
+}
+
+.lista-eventos article span {
+  color: #475569;
+}
+
+.lista-eventos article p {
+  margin: 0;
+  color: #334155;
+}
+
+.lista-eventos article footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.evento-critico {
+  border-left-color: #d93025 !important;
+  background: #fdecea;
+}
+
+.evento-alerta {
+  border-left-color: #f29900 !important;
+  background: #fff4e5;
+}
+
+.evento-normal {
+  border-left-color: #a855f7 !important;
+  background: #f5f3ff;
+}
+
+.vazio {
+  text-align: center;
+  color: #64748b;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .eventos-wrapper {
+    padding: 1rem;
+  }
+
+  .eventos-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-eventos/gate-operador-eventos.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-eventos/gate-operador-eventos.component.html
@@ -1,0 +1,42 @@
+<section class="eventos-wrapper">
+  <header class="eventos-header">
+    <div>
+      <h1>Eventos do Gate</h1>
+      <p>Acompanhe a linha do tempo de eventos relevantes do gate com atualização contínua.</p>
+    </div>
+    <div class="status-badge" [ngClass]="(statusConexao$ | async)">
+      <span class="indicador"></span>
+      <span>
+        {{ (statusConexao$ | async) === 'conectado' ? 'Tempo real' : (statusConexao$ | async) === 'conectando' ? 'Reconectando...' : 'Sem conexão' }}
+      </span>
+    </div>
+  </header>
+
+  <section class="filtros">
+    <form [formGroup]="filtros">
+      <label for="nivelFiltro">Nível</label>
+      <select id="nivelFiltro" formControlName="nivel">
+        <option *ngFor="let nivel of (niveisEvento$ | async)" [value]="nivel.codigo">{{ nivel.descricao }}</option>
+      </select>
+
+      <label for="buscaFiltro">Buscar</label>
+      <input id="buscaFiltro" type="search" formControlName="busca" placeholder="Digite placa, transportadora ou palavra-chave" />
+    </form>
+  </section>
+
+  <section class="lista-eventos">
+    <article *ngFor="let evento of (eventosFiltrados$ | async)" [ngClass]="classeNivel(evento.nivel)">
+      <header>
+        <strong>{{ evento.tipo }}</strong>
+        <span>{{ evento.registradoEm | date:'short' }}</span>
+      </header>
+      <p>{{ evento.descricao }}</p>
+      <footer>
+        <span *ngIf="evento.placaVeiculo">Placa: {{ evento.placaVeiculo }}</span>
+        <span *ngIf="evento.transportadora">Transportadora: {{ evento.transportadora }}</span>
+        <span *ngIf="evento.usuario">Operador: {{ evento.usuario }}</span>
+      </footer>
+    </article>
+    <p class="vazio" *ngIf="!(eventosFiltrados$ | async)?.length">Nenhum evento encontrado para os filtros informados.</p>
+  </section>
+</section>

--- a/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-eventos/gate-operador-eventos.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/operador/gate-operador-eventos/gate-operador-eventos.component.ts
@@ -1,0 +1,75 @@
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { combineLatest, map, Observable, startWith, Subject, takeUntil } from 'rxjs';
+import { GateOperadorService } from '../../../service/servico-gate/gate-operador.service';
+import { GateOperadorEvento } from '../../../model/gate/operador.model';
+import { GateEnumOption } from '../../../model/gate/agendamento.model';
+
+@Component({
+  selector: 'app-gate-operador-eventos',
+  templateUrl: './gate-operador-eventos.component.html',
+  styleUrls: ['./gate-operador-eventos.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class GateOperadorEventosComponent implements OnInit, OnDestroy {
+  readonly statusConexao$ = this.gateOperadorService.statusConexao$;
+  readonly niveisEvento$: Observable<GateEnumOption[]> = this.gateOperadorService.listarNiveisEvento().pipe(
+    map((niveis) => [{ codigo: 'TODOS', descricao: 'Todos os níveis' }, ...niveis])
+  );
+  readonly eventos$: Observable<GateOperadorEvento[]> = this.gateOperadorService.eventos$;
+
+  readonly filtros = this.fb.group({
+    nivel: ['TODOS'],
+    busca: ['']
+  });
+
+  readonly eventosFiltrados$: Observable<GateOperadorEvento[]> = combineLatest([
+    this.eventos$,
+    this.filtros.get('nivel')!.valueChanges.pipe(startWith(this.filtros.get('nivel')!.value ?? 'TODOS')),
+    this.filtros.get('busca')!.valueChanges.pipe(startWith(this.filtros.get('busca')!.value ?? ''))
+  ]).pipe(
+    map(([eventos, nivelSelecionado, busca]) => {
+      const buscaNormalizada = (busca ?? '').toString().toLowerCase();
+      return eventos.filter((evento) => {
+        const nivelMatch = nivelSelecionado === 'TODOS' || (evento.nivel ?? '').toUpperCase() === (nivelSelecionado ?? '').toUpperCase();
+        const buscaMatch = !buscaNormalizada ||
+          `${evento.tipo} ${evento.descricao} ${evento.placaVeiculo ?? ''} ${evento.transportadora ?? ''}`
+            .toLowerCase()
+            .includes(buscaNormalizada);
+        return nivelMatch && buscaMatch;
+      });
+    })
+  );
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(private readonly gateOperadorService: GateOperadorService, private readonly fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.gateOperadorService.carregarPainel().subscribe({
+      error: (erro) => console.warn('Não foi possível atualizar o painel do Gate.', erro)
+    });
+    this.gateOperadorService.atualizarHistorico().subscribe({
+      error: (erro) => console.warn('Não foi possível carregar o histórico do Gate.', erro)
+    });
+    this.gateOperadorService.conectarEventos();
+
+    this.filtros.valueChanges.pipe(takeUntil(this.destroy$)).subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  classeNivel(nivel: string | null | undefined): string {
+    const nivelUpper = (nivel ?? '').toUpperCase();
+    if (nivelUpper === 'CRITICA') {
+      return 'evento-critico';
+    }
+    if (nivelUpper === 'ALERTA') {
+      return 'evento-alerta';
+    }
+    return 'evento-normal';
+  }
+}

--- a/frontend/cloudport/src/app/componentes/model/gate/operador.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/gate/operador.model.ts
@@ -1,0 +1,74 @@
+export type GateNivelEvento = 'INFO' | 'ALERTA' | 'CRITICA' | 'OPERACIONAL' | string;
+
+export interface GateOperadorExcecao {
+  codigo: string;
+  descricao: string;
+  nivel: GateNivelEvento;
+}
+
+export interface GateOperadorContato {
+  tipo: 'TELEFONE' | 'EMAIL' | 'WHATSAPP' | string;
+  valor: string;
+  descricao?: string | null;
+}
+
+export interface GateOperadorVeiculo {
+  id: number;
+  placa: string;
+  documento?: string | null;
+  motorista?: string | null;
+  status: string;
+  statusDescricao?: string | null;
+  tempoFilaMinutos?: number | null;
+  canalEntrada?: string | null;
+  transportadora?: string | null;
+  contatos?: GateOperadorContato[] | null;
+  excecoes?: GateOperadorExcecao[] | null;
+  podeImprimirComprovante?: boolean;
+}
+
+export interface GateOperadorFila {
+  id: number;
+  nome: string;
+  quantidade: number;
+  tempoMedioEsperaMinutos?: number | null;
+  veiculos: GateOperadorVeiculo[];
+}
+
+export interface GateOperadorEvento {
+  id: number;
+  tipo: string;
+  descricao: string;
+  nivel: GateNivelEvento;
+  registradoEm: string;
+  veiculoId?: number | null;
+  placaVeiculo?: string | null;
+  transportadora?: string | null;
+  usuario?: string | null;
+}
+
+export interface GateOperadorPainel {
+  filasEntrada: GateOperadorFila[];
+  filasSaida: GateOperadorFila[];
+  veiculosAtendimento: GateOperadorVeiculo[];
+  historico: GateOperadorEvento[];
+  ultimaAtualizacao: string;
+}
+
+export interface GateLiberacaoManualRequest {
+  canalEntrada: string;
+  justificativa: string;
+  notificarTransportadora: boolean;
+}
+
+export interface GateBloqueioRequest {
+  motivoCodigo: string;
+  justificativa: string;
+  bloqueioAte: string;
+}
+
+export interface GateOcorrenciaRequest {
+  tipoCodigo: string;
+  descricao: string;
+  veiculoId?: number | null;
+}

--- a/frontend/cloudport/src/app/componentes/service/servico-gate/gate-api.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-gate/gate-api.service.ts
@@ -89,6 +89,14 @@ export class GateApiService {
     return this.http.get<GateEnumOption[]>(`${this.configUrl}/canais-entrada`);
   }
 
+  listarTiposOcorrencia(): Observable<GateEnumOption[]> {
+    return this.http.get<GateEnumOption[]>(`${this.configUrl}/tipos-ocorrencia`);
+  }
+
+  listarNiveisEvento(): Observable<GateEnumOption[]> {
+    return this.http.get<GateEnumOption[]>(`${this.configUrl}/niveis-evento`);
+  }
+
   uploadDocumentoAgendamento(id: number, arquivo: File): Observable<HttpEvent<DocumentoAgendamento>> {
     const formData = new FormData();
     formData.append('arquivo', arquivo, arquivo.name);

--- a/frontend/cloudport/src/app/componentes/service/servico-gate/gate-operador.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-gate/gate-operador.service.ts
@@ -1,0 +1,221 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, Subject, map, tap } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { GateApiService } from './gate-api.service';
+import {
+  GateBloqueioRequest,
+  GateLiberacaoManualRequest,
+  GateNivelEvento,
+  GateOcorrenciaRequest,
+  GateOperadorEvento,
+  GateOperadorPainel
+} from '../../model/gate/operador.model';
+import { GateEnumOption } from '../../model/gate/agendamento.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GateOperadorService implements OnDestroy {
+  private readonly operadorUrl = `${environment.baseApiUrl}/gate/operador`;
+  private readonly painelUrl = `${this.operadorUrl}/painel`;
+  private readonly eventosUrl = `${this.operadorUrl}/eventos`;
+
+  private readonly painelSubject = new BehaviorSubject<GateOperadorPainel | null>(null);
+  private readonly eventosSubject = new BehaviorSubject<GateOperadorEvento[]>([]);
+  private readonly alertasSubject = new Subject<GateOperadorEvento>();
+  private readonly conexaoStatusSubject = new BehaviorSubject<'conectado' | 'desconectado' | 'conectando'>('desconectado');
+
+  readonly painel$ = this.painelSubject.asObservable().pipe(map((painel) => painel ?? {
+    filasEntrada: [],
+    filasSaida: [],
+    veiculosAtendimento: [],
+    historico: [],
+    ultimaAtualizacao: new Date().toISOString()
+  }));
+  readonly eventos$ = this.eventosSubject.asObservable();
+  readonly alertas$ = this.alertasSubject.asObservable();
+  readonly statusConexao$ = this.conexaoStatusSubject.asObservable();
+
+  private eventSource: EventSource | null = null;
+  private reconexaoTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly http: HttpClient, private readonly gateApi: GateApiService) {}
+
+  carregarPainel(): Observable<GateOperadorPainel> {
+    return this.http.get<GateOperadorPainel>(this.painelUrl).pipe(
+      tap((painel) => {
+        this.painelSubject.next(painel);
+        if (painel.historico) {
+          this.eventosSubject.next(painel.historico);
+        }
+      })
+    );
+  }
+
+  atualizarHistorico(): Observable<GateOperadorEvento[]> {
+    return this.http.get<GateOperadorEvento[]>(this.eventosUrl).pipe(
+      tap((eventos) => this.eventosSubject.next(eventos))
+    );
+  }
+
+  conectarEventos(): void {
+    if (this.eventSource || typeof window === 'undefined') {
+      return;
+    }
+
+    this.conexaoStatusSubject.next('conectando');
+    const streamUrl = `${this.eventosUrl}/stream`;
+
+    try {
+      this.eventSource = new EventSource(streamUrl);
+      this.eventSource.onopen = () => this.conexaoStatusSubject.next('conectado');
+      this.eventSource.onmessage = (event) => {
+        try {
+          const payload: GateOperadorEvento = JSON.parse(event.data);
+          this.alertasSubject.next(payload);
+          const historicoAtual = [payload, ...this.eventosSubject.value];
+          this.eventosSubject.next(historicoAtual.slice(0, 100));
+          this.recarregarPainelComEvento();
+          if (this.deveEmitirAlertaSonoro(payload.nivel)) {
+            this.emitirAlertaSonoro();
+          }
+        } catch (erro) {
+          console.warn('Não foi possível interpretar o evento recebido do Gate.', erro);
+        }
+      };
+      this.eventSource.onerror = () => {
+        this.conexaoStatusSubject.next('desconectado');
+        this.desconectarEventos();
+        this.agendarReconexao();
+      };
+    } catch (erro) {
+      console.error('Falha ao conectar no canal de eventos do Gate.', erro);
+      this.conexaoStatusSubject.next('desconectado');
+      this.agendarReconexao();
+    }
+  }
+
+  desconectarEventos(): void {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    if (this.reconexaoTimer) {
+      clearTimeout(this.reconexaoTimer);
+      this.reconexaoTimer = null;
+    }
+    this.conexaoStatusSubject.next('desconectado');
+  }
+
+  liberarVeiculo(veiculoId: number, payload: GateLiberacaoManualRequest): Observable<void> {
+    return this.http.post<void>(`${this.operadorUrl}/veiculos/${veiculoId}/liberacao`, payload).pipe(
+      tap(() => this.recarregarPainelComEvento())
+    );
+  }
+
+  bloquearVeiculo(veiculoId: number, payload: GateBloqueioRequest): Observable<void> {
+    return this.http.post<void>(`${this.operadorUrl}/veiculos/${veiculoId}/bloqueio`, payload).pipe(
+      tap(() => this.recarregarPainelComEvento())
+    );
+  }
+
+  registrarOcorrencia(payload: GateOcorrenciaRequest): Observable<void> {
+    return this.http.post<void>(`${this.operadorUrl}/ocorrencias`, payload).pipe(
+      tap(() => this.recarregarPainelComEvento())
+    );
+  }
+
+  imprimirComprovante(veiculoId: number): Observable<void> {
+    return this.http.get(`${this.operadorUrl}/veiculos/${veiculoId}/comprovante`, {
+      responseType: 'blob'
+    }).pipe(
+      tap((blob) => {
+        if (typeof window === 'undefined') {
+          return;
+        }
+        const fileUrl = window.URL.createObjectURL(blob);
+        const printWindow = window.open(fileUrl);
+        if (printWindow) {
+          printWindow.addEventListener('load', () => {
+            printWindow.focus();
+            printWindow.print();
+          });
+        }
+        setTimeout(() => {
+          window.URL.revokeObjectURL(fileUrl);
+          printWindow?.close();
+        }, 5000);
+      }),
+      map(() => void 0)
+    );
+  }
+
+  listarMotivosExcecao(): Observable<GateEnumOption[]> {
+    return this.gateApi.listarMotivosExcecao();
+  }
+
+  listarCanaisEntrada(): Observable<GateEnumOption[]> {
+    return this.gateApi.listarCanaisEntrada();
+  }
+
+  listarTiposOcorrencia(): Observable<GateEnumOption[]> {
+    return this.gateApi.listarTiposOcorrencia();
+  }
+
+  listarNiveisEvento(): Observable<GateEnumOption[]> {
+    return this.gateApi.listarNiveisEvento();
+  }
+
+  ngOnDestroy(): void {
+    this.desconectarEventos();
+    this.painelSubject.complete();
+    this.eventosSubject.complete();
+    this.alertasSubject.complete();
+    this.conexaoStatusSubject.complete();
+  }
+
+  private recarregarPainelComEvento(): void {
+    this.carregarPainel().subscribe({
+      error: (erro) => console.warn('Não foi possível atualizar o painel do Gate.', erro)
+    });
+  }
+
+  private agendarReconexao(): void {
+    if (this.reconexaoTimer) {
+      return;
+    }
+    this.reconexaoTimer = setTimeout(() => {
+      this.reconexaoTimer = null;
+      this.conectarEventos();
+    }, 5000);
+  }
+
+  private deveEmitirAlertaSonoro(nivel: GateNivelEvento): boolean {
+    const nivelNormalizado = (nivel || '').toUpperCase();
+    return nivelNormalizado === 'CRITICA' || nivelNormalizado === 'ALTA' || nivelNormalizado === 'ALERTA';
+  }
+
+  private emitirAlertaSonoro(): void {
+    if (typeof window === 'undefined' || typeof AudioContext === 'undefined') {
+      return;
+    }
+
+    try {
+      const contexto = new AudioContext();
+      const oscilador = contexto.createOscillator();
+      const ganho = contexto.createGain();
+      oscilador.type = 'sine';
+      oscilador.frequency.value = 880;
+      ganho.gain.setValueAtTime(0.0001, contexto.currentTime);
+      ganho.gain.exponentialRampToValueAtTime(0.4, contexto.currentTime + 0.05);
+      ganho.gain.exponentialRampToValueAtTime(0.0001, contexto.currentTime + 0.8);
+      oscilador.connect(ganho);
+      ganho.connect(contexto.destination);
+      oscilador.start();
+      oscilador.stop(contexto.currentTime + 0.8);
+    } catch (erro) {
+      console.warn('Não foi possível reproduzir o alerta sonoro.', erro);
+    }
+  }
+}


### PR DESCRIPTION
## Resumo
- criar modelos, serviço e rotas para o console do operador do gate com atualização em tempo real
- implementar telas de console e eventos com ações operacionais, destaques visuais e contatos rápidos
- ajustar serviço de configuração para carregar motivos, canais e níveis de evento do backend

## Testes
- `npm install` *(falhou: 403 Forbidden ao baixar dependências)*

------
https://chatgpt.com/codex/tasks/task_e_68ed108d66c083278b12670dcf5a541d