### PR TITLE
Ensure admin initializer persists user roles with user reference

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java
@@ -32,16 +32,13 @@ public class UserInitializer implements CommandLineRunner {
         ensureRoleExists("ROLE_OPERADOR_GATE");
         ensureRoleExists("ROLE_TRANSPORTADORA");
 
-        Set<UserRole> roles = new HashSet<>();
-        roles.add(new UserRole(adminRole));
-
         if (!userRepository.findByLogin(adminLogin).isPresent()) {
             User adminUser = new User(adminLogin, adminPassword, "Administrador CloudPort",
-                    null, null, roles);
+                    null, null, new HashSet<>());
 
-            for (UserRole userRole : roles) {
-                userRole.setUser(adminUser);
-            }
+            Set<UserRole> roles = adminUser.getRoles();
+            UserRole adminUserRole = new UserRole(adminUser, adminRole);
+            roles.add(adminUserRole);
 
             userRepository.save(adminUser);
         }


### PR DESCRIPTION
## Summary
- ensure the admin user created on startup assigns user references to its roles before persistence

## Testing
- mvn test *(fails: unable to download Maven dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed26436f748327b0aeeca3f3fbc3bb