### PR TITLE
Aprimora validações e testes de autenticação

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/RegisterDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/RegisterDTO.java
@@ -19,10 +19,13 @@ public class RegisterDTO {
     @NotEmpty(message = "Informe ao menos uma role.")
     private Set<@NotBlank(message = "A role não pode ser vazia.") String> roles;
 
+    @Size(max = 255, message = "O nome deve ter no máximo 255 caracteres.")
     private String nome;
 
+    @Size(max = 30, message = "O documento da transportadora deve ter no máximo 30 caracteres.")
     private String transportadoraDocumento;
 
+    @Size(max = 255, message = "O nome da transportadora deve ter no máximo 255 caracteres.")
     private String transportadoraNome;
 
     public RegisterDTO() {}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/GlobalExceptionHandler.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/exception/GlobalExceptionHandler.java
@@ -7,13 +7,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@ControllerAdvice
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);


### PR DESCRIPTION
## Summary
- adiciona validações de tamanho aos campos opcionais do RegisterDTO
- garante que o tratamento global de exceções retorne respostas JSON com @RestControllerAdvice
- amplia os testes do AuthenticationController para cobrir payloads inválidos e roles em branco

## Testing
- ./mvnw test *(falha: Network is unreachable durante download do Maven Wrapper)*
- mvn test *(falha: acesso 403 ao repositório Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68ed432230808327ac200a080a11ba6c