### PR TITLE
Ajusta tratamento de erros no registro de usuários

### DIFF
--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
@@ -133,7 +133,8 @@ class AuthenticationControllerTest {
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Login informado já está em uso."));
     }
 
     @Test
@@ -202,6 +203,6 @@ class AuthenticationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("Role UNKNOWN not found"));
+                .andExpect(jsonPath("$.message").value("Role 'UNKNOWN' não encontrada."));
     }
 }


### PR DESCRIPTION
## Summary
- retornar erro 400 com mensagem clara quando o login já estiver em uso
- alinhar mensagens e status para roles inválidas ou inexistentes no registro
- atualizar testes do AuthenticationController para cobrir mensagens esperadas

## Testing
- ./mvnw test *(falha: ambiente sem acesso à rede para baixar dependências)*

------
https://chatgpt.com/codex/tasks/task_e_68ed4981acf48327a71e477db1e0341b