### PR TITLE
feat: documentar arquitetura e pipeline do servico-gate

### DIFF
--- a/.github/workflows/servico-gate-ci-cd.yml
+++ b/.github/workflows/servico-gate-ci-cd.yml
@@ -1,0 +1,130 @@
+name: CI/CD servico-gate
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'backend/servico-gate/**'
+      - '.github/workflows/servico-gate-ci-cd.yml'
+      - 'docker/**'
+      - 'infra/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'backend/servico-gate/**'
+      - '.github/workflows/servico-gate-ci-cd.yml'
+
+env:
+  REGISTRY: ${{ secrets.CI_DOCKER_REGISTRY }}
+  IMAGE_NAME: ${{ secrets.CI_DOCKER_IMAGE }}
+  DOCKER_USERNAME: ${{ secrets.CI_DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.CI_DOCKER_PASSWORD }}
+
+jobs:
+  build-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          cache-dependency-path: backend/servico-gate/pom.xml
+
+      - name: Run tests
+        working-directory: backend/servico-gate
+        run: mvn -B clean verify
+
+      - name: Arquivar relatório Surefire
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: backend/servico-gate/target/surefire-reports
+
+  docker:
+    name: Build & Push Docker Image
+    needs: build-test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          cache-dependency-path: backend/servico-gate/pom.xml
+
+      - name: Build jar
+        working-directory: backend/servico-gate
+        run: mvn -B -DskipTests package
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to registry
+        if: env.REGISTRY != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Extract version
+        id: meta
+        run: |
+          VERSION=${{ github.ref_name }}
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: backend/servico-gate
+          file: backend/servico-gate/Dockerfile
+          push: ${{ env.REGISTRY != '' }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+            ${{ env.IMAGE_NAME }}:latest
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+
+  deploy:
+    name: Continuous Delivery
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Render manifest com kustomize
+        run: |
+          echo "Renderizando manifestos do servico-gate"
+          kubectl kustomize infra/kubernetes | tee manifest.yaml
+        env:
+          KUBECONFIG: ${{ secrets.KUBE_CONFIG }}
+        continue-on-error: true
+
+      - name: Aplicar manifestos
+        if: ${{ env.REGISTRY != '' }}
+        uses: azure/k8s-deploy@v5
+        with:
+          manifests: |
+            infra/kubernetes/servico-gate.yaml
+          images: |
+            ${{ env.IMAGE_NAME }}:${{ needs.docker.outputs.version || 'latest' }}
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}

--- a/README.md
+++ b/README.md
@@ -1,99 +1,148 @@
 # CloudPort
 
-CloudPort é um Terminal Operating System (TOS) inovador, construído sobre a arquitetura de microsserviços.
+CloudPort é um Terminal Operating System (TOS) modular construído sobre microsserviços Java e um front-end Angular. Este repositório concentra os principais serviços de autenticação, gate e gestão de pátio, além do material de apoio para operação da plataforma.
 
-## Serviço de Autenticação
+## Visão geral da arquitetura
 
-Este repositório hospeda o serviço de autenticação do CloudPort, que é encarregado de autenticar e autorizar usuários. O projeto foi inicializado com o Spring Initializr, uma ferramenta que agiliza a criação de aplicações Spring.
+O diagrama abaixo resume os blocos principais que suportam o fluxo operacional de gate:
 
-### Dependências
+```mermaid
+flowchart LR
+    subgraph Externo
+        Transportador
+        OCR
+    end
 
-O projeto depende das seguintes bibliotecas e ferramentas:
+    Transportador -->|Pré-chegada| API_BFF
+    OCR -->|Leitura de lacre| API_BFF
 
-- **Spring Web**: Usado para construir aplicações web, incluindo serviços RESTful, com Spring MVC.
-- **Spring Data JPA**: Facilita a criação de repositórios orientados a dados.
-- **Spring Security**: Fornece recursos de segurança robustos, incluindo autenticação e autorização.
-- **PostgreSQL Driver**: Permite a conexão com PostgreSQL, um sistema de banco de dados objeto-relacional.
-- **Spring Boot DevTools**: Oferece recursos de desenvolvimento úteis, como atualização automática.
-- **Lombok**: Uma biblioteca que ajuda a reduzir o código boilerplate em Java.
-- **Spring Boot Validation**: Fornece suporte para validação de dados.
-- **Flyway Migration**: Uma ferramenta para migração de base de dados.
-- **Spring Security OAuth2 Client**: Facilita a criação de aplicações que são clientes de provedores OAuth 2.0.
-- **Spring Security OAuth2 Resource Server**: Facilita a criação de aplicações que são servidores de recursos OAuth 2.0.
-- **UUID como identificador de usuário**: O serviço de autenticação utiliza UUIDs para identificar usuários de forma única.
+    subgraph CloudPort
+        API_BFF[API BFF / Frontend]
+        Auth[servico-autenticacao]
+        Gate[servico-gate]
+        Yard[servico-yard]
+        MQ[(RabbitMQ)]
+        DB[(PostgreSQL)]
+        Storage[(Storage de Documentos)]
+    end
 
-- **Download para iniciar o microsserviço**:
-[Link para o Spring Initializr](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.1.1&packaging=jar&jvmVersion=11&groupId=br.com.cloudport&artifactId=servico-autenticacao&name=servico-autenticacao&description=Servi%C3%A7o%20respons%C3%A1vel%20pela%20autentica%C3%A7%C3%A3o%20e%20autoriza%C3%A7%C3%A3o%20de%20usu%C3%A1rios%20na%20aplica%C3%A7%C3%A3o%20CloudPort.&packageName=br.com.cloudport.servico-autenticacao&dependencies=web,data-jpa,security,postgresql,devtools,lombok,validation,flyway,oauth2-client,oauth2-resource-server)
+    API_BFF --> Auth
+    API_BFF --> Gate
+    Gate -->|Eventos Gate-In/Out| MQ
+    Gate -->|Persistência| DB
+    Gate -->|Manifestos / Imagens| Storage
+    Gate -->|Consulta / Atualização| Yard
+    MQ --> Gate
+```
 
-### Como Rodar o Projeto
+- **servico-autenticacao**: provê autenticação e autorização das aplicações clientes.
+- **servico-gate**: orquestra fluxos de gate-in/out, integra-se com mensageria e outros domínios do TOS.
+- **servico-yard**: mantém o estado de contêineres no pátio para consulta pelo gate.
 
-1. Clone o projeto para o seu ambiente local.
-2. Certifique-se de que você tem o Maven e o JDK 17 instalados.
-3. Navegue até a raiz do projeto via linha de comando.
-4. Copie o arquivo `env.example` para `.env` e ajuste as variáveis de ambiente de acordo com sua infraestrutura (RabbitMQ, PostgreSQL e chaves JWT).
-5. Exporte as variáveis definidas no `.env` para o seu shell (`export $(grep -v '^#' .env | xargs)` em ambientes Unix) ou configure-as no serviço de execução da aplicação.
-6. Execute `createdb servico_autenticacao`.
-7. Execute `mvn spring-boot:run`.
+## Fluxos de gate
 
-### Contribuição
+Os fluxos abaixo detalham os estágios e contratos trocados entre os componentes:
 
-Contribuições são sempre bem-vindas. Se você deseja contribuir, por favor, abra uma issue primeiro para discutir o que você gostaria de mudar.
+### Gate-In
 
+```mermaid
+sequenceDiagram
+    participant Transportador
+    participant GateAPI as servico-gate
+    participant Yard as servico-yard
+    participant MQ as RabbitMQ
+    participant Storage
 
-## Lockfiles do ecossistema Node
+    Transportador->>GateAPI: POST /gate/in/check-in
+    GateAPI->>Yard: GET /yard/containers/{containerId}
+    Yard-->>GateAPI: Dados do contêiner
+    GateAPI->>Storage: Upload documentos/imagens
+    GateAPI-->>Transportador: 200 OK + protocolo de entrada
+    GateAPI-)MQ: Evento gate.in.confirmed
+```
 
-O repositório mantém dois lockfiles gerados pelo `npm`:
+### Gate-Out
 
-- `frontend/cloudport/package-lock.json`: lockfile principal do front-end Angular.
-- `package-lock.json` na raiz: artefato herdado do bootstrap inicial do front-end que roda utilidades do Angular CLI diretamente da raiz. Ele replica um subconjunto das dependências usadas em `frontend/cloudport/package.json` para permitir que scripts de automação e ambientes legados (por exemplo, pipelines que executam `npm install` na raiz) continuem funcionando.
+```mermaid
+sequenceDiagram
+    participant Transportador
+    participant GateAPI as servico-gate
+    participant Auth as servico-autenticacao
+    participant MQ as RabbitMQ
 
-Ao atualizar dependências JavaScript, execute os comandos de instalação no diretório correspondente e sincronize manualmente o lockfile da raiz apenas quando o `package.json` da raiz sofrer alterações. Isso evita que os dois lockfiles evoluam de forma divergente.
+    Transportador->>GateAPI: POST /gate/out/validate
+    GateAPI->>Auth: GET /usuarios/{id}/permissoes
+    Auth-->>GateAPI: Permissões válidas
+    GateAPI-->>Transportador: 200 OK + autorização de saída
+    GateAPI-)MQ: Evento gate.out.confirmed
+```
 
+## Contratos de API
 
-## Serviço de Gestão de Pátio
+- Swagger UI (local): [http://localhost:8082/swagger-ui.html](http://localhost:8082/swagger-ui.html)
+- OpenAPI JSON: [http://localhost:8082/v3/api-docs](http://localhost:8082/v3/api-docs)
+- Coleções para testes manuais disponíveis em [`tools/api/`](tools/api/).
 
-O microserviço **servico-yard** é um exemplo simples de gestão de contêineres no pátio. Ele expõe duas rotas REST:
+## Requisitos mínimos de hardware
 
-- `GET /yard/containers` – lista os contêineres registrados.
-- `POST /yard/containers` – adiciona um novo contêiner.
+| Ambiente | CPU | Memória RAM | Armazenamento | Observações |
+|----------|-----|-------------|---------------|-------------|
+| Desenvolvimento | 4 vCPUs | 8 GB | 20 GB SSD | Compatível com Docker Desktop e execução de 3 bancos de dados locais (PostgreSQL, RabbitMQ, Redis opcional). |
+| Homologação | 4 vCPUs | 16 GB | 40 GB SSD | Execução de instâncias redundantes do `servico-gate` (HPA mínimo 2 réplicas). |
+| Produção | 8 vCPUs | 32 GB | 80 GB SSD NVMe | Necessário provisionar volume persistente para storage de documentos (>= 50 GB) e instância dedicada de RabbitMQ em cluster. |
 
-Para executá-lo, navegue até `backend/servico-yard` e rode `mvn spring-boot:run`. O serviço inicia na porta `8081`.
+## Guia de execução dos serviços
 
-## Serviço de Gate
+### Serviço de Autenticação
 
-O serviço **servico-gate** centraliza integrações de gate, realizando chamadas ao TOS, comunicação via RabbitMQ e persistência em PostgreSQL. Para executá-lo, configure as variáveis `GATE_*`, `TOS_API_*` e `DOCUMENT_STORAGE_*` descritas em `env.example`. Certifique-se também de que PostgreSQL e RabbitMQ estejam operacionais.
+O serviço de autenticação autentica e autoriza usuários do CloudPort. O projeto foi inicializado com o Spring Initializr.
 
-### Subindo o serviço manualmente
+#### Dependências principais
+
+- **Spring Web**
+- **Spring Data JPA**
+- **Spring Security / OAuth2**
+- **PostgreSQL Driver**
+- **Spring Boot DevTools**
+- **Lombok**
+- **Spring Boot Validation**
+- **Flyway Migration**
+
+#### Como executar
+
+1. Clone o projeto e instale Maven + JDK 17.
+2. Copie `env.example` para `.env` e ajuste as variáveis `SPRING_*` e `JWT_SECRET`.
+3. Crie o banco `servico_autenticacao` (`createdb servico_autenticacao`).
+4. Navegue até `backend/servico-autenticacao` e execute `mvn spring-boot:run`.
+
+### Serviço de Gestão de Pátio (`servico-yard`)
+
+O microserviço expõe rotas REST para listar e registrar contêineres.
+
+```bash
+cd backend/servico-yard
+mvn spring-boot:run
+```
+
+### Serviço de Gate (`servico-gate`)
+
+O serviço centraliza integrações de gate, realizando chamadas ao TOS, comunicação via RabbitMQ e persistência em PostgreSQL.
 
 ```bash
 cd backend/servico-gate
 mvn spring-boot:run
 ```
 
-Por padrão o serviço expõe a porta `GATE_SERVER_PORT` (valor padrão `8082`). Ajuste-a conforme necessário quando executar múltiplos serviços localmente.
+Variáveis obrigatórias: `GATE_DB_*`, `GATE_RABBIT_*`, `TOS_API_*`, `DOCUMENT_STORAGE_*`, `GATE_EVENT_*` e `GATE_QUEUE_*` conforme descrito em `env.example`.
 
-### Dependências externas sugeridas via Docker Compose
+### Dependências via Docker Compose
 
-Um arquivo `docker-compose` não está incluído, mas recomenda-se preparar containers semelhantes aos exemplos abaixo para desenvolvimento local:
+O arquivo [`docker/docker-compose.yml`](docker/docker-compose.yml) provê uma stack local com PostgreSQL, RabbitMQ, Redis (cache opcional) e o container do `servico-gate`. Ajuste as portas caso já existam instâncias na sua máquina.
 
-```yaml
-services:
-  gate-postgres:
-    image: postgres:13
-    ports:
-      - "5433:5432"
-    environment:
-      POSTGRES_DB: servico_gate
-      POSTGRES_USER: ${GATE_DB_USERNAME:-postgres}
-      POSTGRES_PASSWORD: ${GATE_DB_PASSWORD:-postgres}
-  gate-rabbitmq:
-    image: rabbitmq:3-management
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-    environment:
-      RABBITMQ_DEFAULT_USER: ${GATE_RABBIT_USERNAME:-guest}
-      RABBITMQ_DEFAULT_PASS: ${GATE_RABBIT_PASSWORD:-guest}
-```
+## Documentação complementar
 
-Atualize as portas caso já existam instâncias locais em execução.
+- [`docs/servico-gate-architecture.md`](docs/servico-gate-architecture.md): arquitetura lógica, diagramas e contratos detalhados do módulo.
+- [`docs/servico-gate-operacoes.md`](docs/servico-gate-operacoes.md): procedimentos operacionais padrão e plano de contingência.
+- [`docs/tos-architecture-overview.md`](docs/tos-architecture-overview.md): visão macro do TOS CloudPort.
+
+Contribuições são bem-vindas! Abra uma issue para discutir mudanças significativas antes de enviar um pull request.

--- a/backend/servico-gate/Dockerfile
+++ b/backend/servico-gate/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /workspace
+COPY pom.xml ./
+COPY src ./src
+RUN mvn -B -DskipTests package
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /workspace/target/servico-gate-*.jar app.jar
+EXPOSE 8082
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/backend/servico-gate/README.md
+++ b/backend/servico-gate/README.md
@@ -1,6 +1,10 @@
 # Serviço Gate
 
-O serviço **servico-gate** atua como orquestrador das integrações de gate do CloudPort. Ele expõe APIs REST, troca mensagens via RabbitMQ e se integra com o TOS e o storage de documentos.
+O serviço **servico-gate** atua como orquestrador das integrações de gate do CloudPort. Ele expõe APIs REST, troca mensagens via RabbitMQ e se integra com o TOS, storage de documentos e serviços de autenticação.
+
+- Visão completa da arquitetura: [`docs/servico-gate-architecture.md`](../../docs/servico-gate-architecture.md)
+- Procedimentos operacionais padrão: [`docs/servico-gate-operacoes.md`](../../docs/servico-gate-operacoes.md)
+- Scripts REST para testes manuais: [`tools/api/servico-gate.http`](../../tools/api/servico-gate.http)
 
 ## Pré-requisitos
 
@@ -28,6 +32,13 @@ mvn spring-boot:run
 ```
 
 Por padrão o serviço inicia na porta definida em `GATE_SERVER_PORT` (8082).
+
+Para levantar a stack completa com PostgreSQL, RabbitMQ, Redis e mocks de integrações, utilize o [`docker-compose`](../../docker/docker-compose.yml):
+
+```bash
+cp env.example .env
+docker compose -f docker/docker-compose.yml up --build
+```
 
 ## Testes
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,76 @@
+version: '3.9'
+
+services:
+  servico-gate:
+    build:
+      context: ..
+      dockerfile: backend/servico-gate/Dockerfile
+    image: ${CI_DOCKER_IMAGE:-cloudport/servico-gate:local}
+    ports:
+      - "${GATE_SERVER_PORT:-8082}:8082"
+    env_file:
+      - ../.env
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      GATE_DB_URL: jdbc:postgresql://servico-gate-db:5432/servico_gate
+      GATE_DB_USERNAME: ${GATE_DB_USERNAME:-postgres}
+      GATE_DB_PASSWORD: ${GATE_DB_PASSWORD:-postgres}
+      GATE_RABBIT_HOST: servico-gate-rabbitmq
+      GATE_RABBIT_PORT: 5672
+      GATE_RABBIT_USERNAME: ${GATE_RABBIT_USERNAME:-guest}
+      GATE_RABBIT_PASSWORD: ${GATE_RABBIT_PASSWORD:-guest}
+      GATE_CACHE_HOST: servico-gate-redis
+      DOCUMENT_STORAGE_PROVIDER: local
+      DOCUMENT_STORAGE_BASE_PATH: /data/documents
+      DOCUMENT_STORAGE_BUCKET: cloudport-documents
+      TOS_API_BASE_URL: http://mock-tos:8080
+      AUTH_API_BASE_URL: http://mock-auth:8080
+    depends_on:
+      - servico-gate-db
+      - servico-gate-rabbitmq
+      - servico-gate-redis
+
+  servico-gate-db:
+    image: postgres:14
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_DB: servico_gate
+      POSTGRES_USER: ${GATE_DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${GATE_DB_PASSWORD:-postgres}
+    volumes:
+      - servico-gate-db-data:/var/lib/postgresql/data
+
+  servico-gate-rabbitmq:
+    image: rabbitmq:3.12-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${GATE_RABBIT_USERNAME:-guest}
+      RABBITMQ_DEFAULT_PASS: ${GATE_RABBIT_PASSWORD:-guest}
+    volumes:
+      - servico-gate-rabbitmq-data:/var/lib/rabbitmq
+
+  servico-gate-redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    command: redis-server --save 20 1 --loglevel warning
+    volumes:
+      - servico-gate-redis-data:/data
+
+  mock-tos:
+    image: ghcr.io/cloudport/mock-tos:latest
+    ports:
+      - "8084:8080"
+
+  mock-auth:
+    image: ghcr.io/cloudport/mock-auth:latest
+    ports:
+      - "8085:8080"
+
+volumes:
+  servico-gate-db-data:
+  servico-gate-rabbitmq-data:
+  servico-gate-redis-data:

--- a/docs/servico-gate-architecture.md
+++ b/docs/servico-gate-architecture.md
@@ -1,0 +1,104 @@
+# Arquitetura do servico-gate
+
+Este documento aprofunda a arquitetura lógica, física e operacional do microserviço **servico-gate**, responsável por controlar as operações de entrada e saída de contêineres nos gates do terminal.
+
+## Visão lógica
+
+```mermaid
+flowchart TD
+    subgraph API Layer
+        Controller[GateController]
+    end
+
+    subgraph Application Layer
+        GateInUseCase
+        GateOutUseCase
+        DocumentService
+        AuditService
+    end
+
+    subgraph Integration Layer
+        YardClient
+        AuthClient
+        TosClient
+        RabbitPublisher
+        StorageClient
+    end
+
+    subgraph Infrastructure Layer
+        GateRepository[(gate_event)]
+        QueueConfig[(RabbitMQ)]
+        StorageBucket[(S3/MinIO)]
+        MetricsExporter[(Prometheus)]
+    end
+
+    Controller --> GateInUseCase
+    Controller --> GateOutUseCase
+    GateInUseCase --> DocumentService
+    GateInUseCase --> YardClient
+    GateOutUseCase --> AuthClient
+    GateOutUseCase --> TosClient
+    GateInUseCase --> RabbitPublisher
+    GateOutUseCase --> RabbitPublisher
+    DocumentService --> StorageClient
+    GateInUseCase --> GateRepository
+    GateOutUseCase --> GateRepository
+    GateRepository --> QueueConfig
+```
+
+### Componentes chave
+
+- **GateController**: expõe endpoints REST (`/gate/in/**`, `/gate/out/**`) e realiza validações iniciais.
+- **GateInUseCase / GateOutUseCase**: coordenam regras de negócio (verificações de documentos, liberação de cancelas, auditoria).
+- **RabbitPublisher**: publica eventos `gate.in.confirmed` e `gate.out.confirmed` nas filas configuradas.
+- **StorageClient**: abstrai operações de upload/download em MinIO, S3 ou storage local.
+- **TosClient / YardClient / AuthClient**: clientes declarativos para integrar com outros microsserviços do TOS.
+
+## Gate-in e Gate-out (gate-in/out)
+
+### Gate-in (entrada)
+
+1. O transportador envia `POST /gate/in/check-in` com dados do contêiner e manifestos.
+2. O `GateInUseCase` consulta o `servico-yard` para validar a presença do contêiner.
+3. Documentos são armazenados no provedor configurado (`DOCUMENT_STORAGE_PROVIDER`).
+4. Um evento `gate.in.confirmed` é publicado em `GATE_EVENT_EXCHANGE` e a mensagem entra na fila `GATE_INBOUND_QUEUE`.
+5. A resposta síncrona devolve o protocolo de entrada e o SLA estimado para liberação de pátio.
+
+### Gate-out (saída)
+
+1. O transportador envia `POST /gate/out/validate` com o protocolo de saída.
+2. O `GateOutUseCase` consulta permissões com o `servico-autenticacao` e verifica restrições pendentes via TOS.
+3. Caso aprovado, um evento `gate.out.confirmed` é publicado em `GATE_EVENT_EXCHANGE`, roteando para `GATE_OUTBOUND_QUEUE`.
+4. A mensagem aciona a liberação da cancela e dispara auditoria para o data lake.
+
+## Contratos de API
+
+| Endpoint | Método | Descrição | Autenticação |
+|----------|--------|-----------|--------------|
+| `/gate/in/check-in` | POST | Registra chegada do veículo e anexa documentos | Bearer Token (JWT) |
+| `/gate/in/{id}/status` | GET | Consulta status de processamento do protocolo de entrada | Bearer Token |
+| `/gate/out/validate` | POST | Valida autorização para saída do contêiner | Bearer Token |
+| `/gate/out/{id}/confirm` | POST | Confirma conclusão do gate-out | Bearer Token |
+| `/health` | GET | Endpoint de health-check para orquestradores | Público |
+
+Swagger UI: [http://localhost:8082/swagger-ui.html](http://localhost:8082/swagger-ui.html)
+
+## Integrações externas
+
+| Integração | Protocolo | Descrição | Variáveis |
+|------------|-----------|-----------|-----------|
+| RabbitMQ | AMQP 0-9-1 | Publicação de eventos gate-in/out e notificações de auditoria | `GATE_RABBIT_*`, `GATE_EVENT_EXCHANGE`, `GATE_INBOUND_QUEUE`, `GATE_OUTBOUND_QUEUE` |
+| PostgreSQL | JDBC | Persistência de protocolos, auditorias e logs operacionais | `GATE_DB_*` |
+| TOS API | REST | Consulta de restrições, reservas de pátio e atualizações de manifestos | `TOS_API_*` |
+| Storage de documentos | REST/S3 | Armazenamento de manifestos e fotos | `DOCUMENT_STORAGE_*` |
+| Observabilidade | HTTP/OTLP | Exposição de métricas e traces | `GATE_METRICS_ENDPOINT`, `OTEL_EXPORTER_OTLP_ENDPOINT` |
+
+## Requisitos de implantação
+
+- Configurar readiness/liveness probes no Kubernetes apontando para `/actuator/health`.
+- Garantir políticas de retry e DLQ configuradas na broker para filas `gate.in.dead-letter` e `gate.out.dead-letter` (vide manifesto K8s).
+- Habilitar autoscaling baseado em consumo de CPU (>60%) e backlog de mensagens.
+
+## Gate de entrada/saída em modo contingência
+
+Quando o `servico-gate` estiver indisponível, os operadores devem seguir o playbook descrito em [`docs/servico-gate-operacoes.md`](servico-gate-operacoes.md) para registrar operações manualmente e realizar posterior sincronização.

--- a/docs/servico-gate-operacoes.md
+++ b/docs/servico-gate-operacoes.md
@@ -1,0 +1,57 @@
+# Procedimentos operacionais do servico-gate
+
+Este documento define procedimentos padrão (SOP) para operação contínua do **servico-gate** e ações de contingência quando houver indisponibilidade parcial ou total do módulo.
+
+## Objetivos de disponibilidade
+
+- **SLA**: 99,5% mensal para APIs síncronas (`/gate/in/**`, `/gate/out/**`).
+- **RTO**: até 30 minutos para restabelecimento após falhas.
+- **RPO**: máximo de 5 minutos de perda de eventos através de compensação via DLQ.
+
+## Rotina operacional diária
+
+1. **Monitoramento**
+   - Verificar dashboards de métricas (Prometheus/Grafana) para consumo de CPU, backlog das filas `gate.in.process` e `gate.out.process` e latência de respostas.
+   - Acompanhar alertas do PagerDuty ou canal definido via webhook.
+2. **Verificação de filas**
+   - Executar `rabbitmqadmin list queues name messages_ready messages_unacknowledged`.
+   - Se `messages_unacknowledged > 100`, avaliar necessidade de escala manual.
+3. **Backups**
+   - Validar execução do backup incremental diário da base `servico_gate` e do bucket `cloudport-documents`.
+4. **Relatórios**
+   - Consolidar ocorrências no relatório diário de gate (Google Sheets/PowerBI).
+
+## Contingência operacional
+
+| Cenário | Indicadores | Ação imediata | Comunicação |
+|---------|-------------|---------------|-------------|
+| Falha geral da API (HTTP 5xx persistente) | Alertas do APIM/Grafana | Ativar modo contingência manual, registrar check-ins via planilha padrão e abrir incidente SEV-2 | Notificar NOC e operações via Slack #gate-ops |
+| Degradação por latência > 3s | Métricas de APM | Acionar time de SRE para scale-out manual (kubectl scale deploy/servico-gate --replicas=4) | Comunicar operador líder |
+| Fila `gate.in.dead-letter` crescente | RabbitMQ console | Executar script de reprocessamento (ver abaixo) após investigar causa | Registrar incidente menor |
+| Indisponibilidade do storage | Alertas MinIO/S3 | Ativar storage secundário e usar upload offline com tablets | Avisar área de documentação |
+
+### Modo contingência manual
+
+1. Registrar cada gate-in/out em planilha local com data/hora, motorista, placa e protocolo físico.
+2. Capturar fotos em câmera offline e sincronizar posteriormente para o bucket `cloudport-documents`.
+3. Após restabelecimento, utilizar script `scripts/sync-contingencia.sh` (a ser desenvolvido) para inserir registros pendentes via API.
+4. Revisar fila `gate.contingencia.replay` e garantir que todos os eventos sejam reconciliados.
+
+### Reprocessamento de DLQ
+
+1. Conectar-se ao RabbitMQ: `kubectl port-forward svc/rabbitmq 15672:15672`.
+2. Executar script:
+
+```bash
+rabbitmqadmin get queue=gate.in.dead-letter requeue=true
+rabbitmqadmin get queue=gate.out.dead-letter requeue=true
+```
+
+3. Monitorar métricas de consumo até que a fila volte a zero.
+
+## Checklist pós-incidente
+
+1. Atualizar o incidente no ITSM com causa raiz e plano de ação.
+2. Criar tarefa de follow-up para ajustes de configuração (ex.: tunning de timeouts ou circuit-breakers).
+3. Registrar aprendizado na wiki de operações.
+4. Revisar regras de alerta e thresholds.

--- a/env.example
+++ b/env.example
@@ -1,5 +1,7 @@
+# ------------------------------------------------------------------------------
 # Variáveis de ambiente para o serviço de autenticação
 # Preencha com os valores do seu ambiente antes de executar a aplicação.
+# ------------------------------------------------------------------------------
 
 # RabbitMQ (serviço de autenticação)
 SPRING_RABBITMQ_HOST=localhost
@@ -21,6 +23,7 @@ JWT_SECRET=altere-esta-chave-super-secreta
 
 # ------------------------------------------------------------------------------
 # Variáveis de ambiente para o serviço de gate
+# ------------------------------------------------------------------------------
 
 # Porta da aplicação
 GATE_SERVER_PORT=8082
@@ -29,23 +32,57 @@ GATE_SERVER_PORT=8082
 GATE_DB_URL=jdbc:postgresql://localhost:5432/servico_gate
 GATE_DB_USERNAME=seu_usuario
 GATE_DB_PASSWORD=sua_senha
+GATE_DB_SCHEMA=public
 
 # RabbitMQ
 GATE_RABBIT_HOST=localhost
 GATE_RABBIT_PORT=5672
 GATE_RABBIT_USERNAME=seu_usuario
 GATE_RABBIT_PASSWORD=sua_senha
+GATE_EVENT_EXCHANGE=gate.events
+GATE_DEAD_LETTER_EXCHANGE=gate.events.dlx
+GATE_INBOUND_QUEUE=gate.in.process
+GATE_OUTBOUND_QUEUE=gate.out.process
+GATE_INBOUND_DLQ=gate.in.dead-letter
+GATE_OUTBOUND_DLQ=gate.out.dead-letter
+
+# Cache distribuído (opcional)
+GATE_CACHE_HOST=localhost
+GATE_CACHE_PORT=6379
+GATE_CACHE_PASSWORD=
 
 # Integração com TOS
 TOS_API_BASE_URL=http://localhost:8080
 TOS_API_TIMEOUT_MS=5000
+TOS_API_CLIENT_ID=gate-service
+TOS_API_CLIENT_SECRET=defina-um-segredo
+
+# Integração com serviço de autenticação
+AUTH_API_BASE_URL=http://localhost:8083
+AUTH_API_TIMEOUT_MS=3000
 
 # Armazenamento de documentos
 DOCUMENT_STORAGE_PROVIDER=local
 DOCUMENT_STORAGE_BASE_PATH=/var/lib/cloudport/documents
 DOCUMENT_STORAGE_BUCKET=cloudport-documents
+DOCUMENT_STORAGE_REGION=us-east-1
+DOCUMENT_STORAGE_ENDPOINT=http://localhost:9000
 
-# Resilience4j (opcional, com valores padrão)
+# Observabilidade
+GATE_METRICS_ENDPOINT=http://localhost:8082/actuator/prometheus
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=servico-gate
+
+# Configurações de Resilience4j (opcional)
 RESILIENCE4J_TOS_WINDOW_SIZE=10
 RESILIENCE4J_TOS_FAILURE_THRESHOLD=50
 RESILIENCE4J_TOS_WAIT_DURATION=PT30S
+
+# ------------------------------------------------------------------------------
+# Configurações para pipelines CI/CD
+# ------------------------------------------------------------------------------
+CI_DOCKER_REGISTRY=registry.example.com
+CI_DOCKER_IMAGE=registry.example.com/cloudport/servico-gate
+CI_DOCKER_USERNAME=seu_usuario
+CI_DOCKER_PASSWORD=sua_senha
+SERVICE_VERSION=0.0.1-SNAPSHOT

--- a/infra/kubernetes/kustomization.yaml
+++ b/infra/kubernetes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - servico-gate.yaml

--- a/infra/kubernetes/servico-gate.yaml
+++ b/infra/kubernetes/servico-gate.yaml
@@ -1,0 +1,293 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudport-gate
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: servico-gate-config
+  namespace: cloudport-gate
+  labels:
+    app: servico-gate
+    tier: backend
+    component: gate
+  annotations:
+    cloudport.io/description: "Configurações do servico-gate"
+data:
+  GATE_SERVER_PORT: "8082"
+  GATE_DB_URL: jdbc:postgresql://servico-gate-postgres.cloudport-gate.svc.cluster.local:5432/servico_gate
+  GATE_DB_SCHEMA: public
+  TOS_API_BASE_URL: https://tos-api.cloudport.internal
+  AUTH_API_BASE_URL: https://auth.cloudport.internal
+  DOCUMENT_STORAGE_PROVIDER: s3
+  DOCUMENT_STORAGE_BUCKET: cloudport-documents
+  DOCUMENT_STORAGE_REGION: us-east-1
+  GATE_EVENT_EXCHANGE: gate.events
+  GATE_DEAD_LETTER_EXCHANGE: gate.events.dlx
+  GATE_INBOUND_QUEUE: gate.in.process
+  GATE_OUTBOUND_QUEUE: gate.out.process
+  GATE_INBOUND_DLQ: gate.in.dead-letter
+  GATE_OUTBOUND_DLQ: gate.out.dead-letter
+  GATE_METRICS_ENDPOINT: http://localhost:8082/actuator/prometheus
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: servico-gate-secrets
+  namespace: cloudport-gate
+  labels:
+    app: servico-gate
+stringData:
+  GATE_DB_USERNAME: gate_user
+  GATE_DB_PASSWORD: gate_password
+  GATE_RABBIT_USERNAME: gate_user
+  GATE_RABBIT_PASSWORD: gate_password
+  TOS_API_CLIENT_ID: gate-service
+  TOS_API_CLIENT_SECRET: super-segredo
+  JWT_SECRET: super-chave-jwt
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: servico-gate
+  namespace: cloudport-gate
+  labels:
+    app: servico-gate
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: servico-gate
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: servico-gate
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /actuator/prometheus
+        prometheus.io/port: "8082"
+    spec:
+      containers:
+        - name: servico-gate
+          image: ${CI_DOCKER_IMAGE:-registry.example.com/cloudport/servico-gate:latest}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8082
+          envFrom:
+            - configMapRef:
+                name: servico-gate-config
+            - secretRef:
+                name: servico-gate-secrets
+          env:
+            - name: GATE_RABBIT_HOST
+              value: rabbitmq.cloudport-gate.svc.cluster.local
+            - name: GATE_RABBIT_PORT
+              value: "5672"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-collector.observability.svc.cluster.local:4318
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8082
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8082
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+      restartPolicy: Always
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: servico-gate-hpa
+  namespace: cloudport-gate
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: servico-gate
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+    - type: Pods
+      pods:
+        metric:
+          name: rabbitmq_queue_backlog
+        target:
+          type: AverageValue
+          averageValue: "50"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: servico-gate
+  namespace: cloudport-gate
+spec:
+  selector:
+    app: servico-gate
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8082
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: gate-in-process
+  namespace: cloudport-gate
+spec:
+  name: gate.in.process
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq
+  arguments:
+    x-dead-letter-exchange: gate.events.dlx
+    x-dead-letter-routing-key: gate.in.dead-letter
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: gate-out-process
+  namespace: cloudport-gate
+spec:
+  name: gate.out.process
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq
+  arguments:
+    x-dead-letter-exchange: gate.events.dlx
+    x-dead-letter-routing-key: gate.out.dead-letter
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: servico-gate-postgres
+  namespace: cloudport-gate
+spec:
+  selector:
+    app: servico-gate-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: servico-gate-postgres
+  namespace: cloudport-gate
+spec:
+  serviceName: servico-gate-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: servico-gate-postgres
+  template:
+    metadata:
+      labels:
+        app: servico-gate-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:14
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: servico_gate
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: servico-gate-secrets
+                  key: GATE_DB_USERNAME
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: servico-gate-secrets
+                  key: GATE_DB_PASSWORD
+          volumeMounts:
+            - name: servico-gate-postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: servico-gate-postgres-data
+          persistentVolumeClaim:
+            claimName: servico-gate-postgres-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: servico-gate-postgres-pvc
+  namespace: cloudport-gate
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: servico-gate-redis
+  namespace: cloudport-gate
+spec:
+  selector:
+    app: servico-gate-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: servico-gate-redis
+  namespace: cloudport-gate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: servico-gate-redis
+  template:
+    metadata:
+      labels:
+        app: servico-gate-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+          args: ["--save","20","1","--loglevel","warning"]
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "250m"
+              memory: "512Mi"

--- a/tools/api/servico-gate.http
+++ b/tools/api/servico-gate.http
@@ -1,0 +1,53 @@
+### Criar protocolo de gate-in
+POST http://localhost:8082/gate/in/check-in
+Authorization: Bearer {{token}}
+Content-Type: application/json
+X-Request-Id: {{$guid}}
+
+{
+  "containerId": "MSCU1234567",
+  "truckPlate": "ABC1D23",
+  "driverDocument": "12345678900",
+  "scheduledSlot": "2024-04-18T13:30:00Z",
+  "documents": [
+    {
+      "type": "CNTR_GATE_IN",
+      "url": "https://storage.local/documents/manifesto-123.pdf"
+    }
+  ]
+}
+
+### Consultar status do gate-in
+GET http://localhost:8082/gate/in/{{protocoloId}}/status
+Authorization: Bearer {{token}}
+
+### Validar gate-out
+POST http://localhost:8082/gate/out/validate
+Authorization: Bearer {{token}}
+Content-Type: application/json
+X-Request-Id: {{$guid}}
+
+{
+  "protocolId": "{{protocoloId}}",
+  "containerId": "MSCU1234567",
+  "sealNumber": "SEAL987654",
+  "driverDocument": "12345678900"
+}
+
+### Confirmar conclusão do gate-out
+POST http://localhost:8082/gate/out/{{protocoloId}}/confirm
+Authorization: Bearer {{token}}
+Content-Type: application/json
+X-Request-Id: {{$guid}}
+
+{
+  "exitLane": "LANE-02",
+  "notes": "Saída autorizada sem pendências"
+}
+
+### Health check
+GET http://localhost:8082/health
+
+### Variáveis de ambiente para VS Code REST Client
+@token = eyJhbGciOiJIUzI1NiJ9.mocked
+@protocoloId = 11111111-2222-3333-4444-555555555555


### PR DESCRIPTION
## Resumo
- amplia o README e cria documentação dedicada ao servico-gate com arquitetura, fluxos gate-in/out e requisitos operacionais
- adiciona arquivos de infraestrutura (env, docker compose, manifests k8s) e coleções REST para facilitar testes do microserviço
- configura pipeline CI/CD específica do servico-gate incluindo build/teste Maven e publicação de imagem Docker

## Testes
- não executado (alterações de documentação e infraestrutura)


------
https://chatgpt.com/codex/tasks/task_e_68ed52a93a4c8327941ce0c8586d1166