### PR TITLE
Remover padrões sensíveis do serviço de autenticação

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ O projeto depende das seguintes bibliotecas e ferramentas:
 2. Certifique-se de que você tem o Maven e o JDK 17 instalados.
 3. Navegue até a raiz do projeto via linha de comando.
 4. Copie o arquivo `env.example` para `.env` e ajuste as variáveis de ambiente de acordo com sua infraestrutura (RabbitMQ, PostgreSQL e chaves JWT).
+   - As credenciais e segredos não possuem mais valores padrão no `application.properties`; a aplicação só inicia quando `SPRING_RABBITMQ_USERNAME`, `SPRING_RABBITMQ_PASSWORD`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`, `SPRING_SECURITY_USER_NAME`, `SPRING_SECURITY_USER_PASSWORD` (opcional) e `JWT_SECRET` estiverem definidos.
 5. Exporte as variáveis definidas no `.env` para o seu shell (`export $(grep -v '^#' .env | xargs)` em ambientes Unix) ou configure-as no serviço de execução da aplicação.
 6. Execute `createdb servico_autenticacao`.
 7. Execute `mvn spring-boot:run`.

--- a/backend/servico-autenticacao/src/main/resources/application.properties
+++ b/backend/servico-autenticacao/src/main/resources/application.properties
@@ -1,13 +1,13 @@
 # RabbitMQ Configuration
 spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:localhost}
 spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
-spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:change-me}
-spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD:change-me}
+spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME}
+spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD}
 
 # PostgreSQL Configuration
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/servico_autenticacao}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME:change-me}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:change-me}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Hibernate Configuration
@@ -15,11 +15,11 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialec
 spring.jpa.hibernate.ddl-auto = update
 
 # Spring Security Configuration
-spring.security.user.name=${SPRING_SECURITY_USER_NAME:change-me}
-spring.security.user.password=${SPRING_SECURITY_USER_PASSWORD:change-me}
-jwt.secret=${JWT_SECRET:change-me}
+spring.security.user.name=${SPRING_SECURITY_USER_NAME}
+spring.security.user.password=${SPRING_SECURITY_USER_PASSWORD}
+jwt.secret=${JWT_SECRET}
 
-api.security.token.secret=${JWT_SECRET:change-me}
+api.security.token.secret=${JWT_SECRET}
 api.security.self-registration.allowed-roles=${API_SECURITY_SELF_REGISTRATION_ALLOWED_ROLES:USER}
 app.security.cors.allowed-origins=${APP_SECURITY_CORS_ALLOWED_ORIGINS:http://localhost:3000}
 

--- a/env.example
+++ b/env.example
@@ -2,22 +2,24 @@
 # Preencha com os valores do seu ambiente antes de executar a aplicação.
 
 # RabbitMQ (serviço de autenticação)
+# Obrigatório: defina usuário e senha válidos para a instância utilizada
 SPRING_RABBITMQ_HOST=localhost
 SPRING_RABBITMQ_PORT=5672
-SPRING_RABBITMQ_USERNAME=seu_usuario
-SPRING_RABBITMQ_PASSWORD=sua_senha
+SPRING_RABBITMQ_USERNAME=<USUARIO_RABBITMQ>
+SPRING_RABBITMQ_PASSWORD=<SENHA_RABBITMQ>
 
 # PostgreSQL (serviço de autenticação)
+# Obrigatório: defina credenciais do banco utilizado pelo serviço
 SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/servico_autenticacao
-SPRING_DATASOURCE_USERNAME=seu_usuario
-SPRING_DATASOURCE_PASSWORD=sua_senha
+SPRING_DATASOURCE_USERNAME=<USUARIO_POSTGRES>
+SPRING_DATASOURCE_PASSWORD=<SENHA_POSTGRES>
 
 # Usuário padrão do Spring Security (opcional)
-SPRING_SECURITY_USER_NAME=usuario_admin
-SPRING_SECURITY_USER_PASSWORD=senha_admin
+SPRING_SECURITY_USER_NAME=<USUARIO_ADMIN>
+SPRING_SECURITY_USER_PASSWORD=<SENHA_ADMIN>
 
-# Segredo JWT compartilhado entre os serviços
-JWT_SECRET=altere-esta-chave-super-secreta
+# Segredo JWT compartilhado entre os serviços (obrigatório)
+JWT_SECRET=<SEGREDO_JWT>
 
 # ------------------------------------------------------------------------------
 # Variáveis de ambiente para o serviço de gate


### PR DESCRIPTION
## Summary
- remove valores padrão sensíveis do `application.properties` do serviço de autenticação e força leitura via variáveis de ambiente
- orienta configuração das novas variáveis obrigatórias no `env.example` e na documentação principal

## Testing
- `mvn -f backend/servico-autenticacao/pom.xml test` *(falhou: Maven sem acesso ao repositório central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ed52b94b388327a9ddcad757a0c429