### PR TITLE
Atualiza emissão de tokens para jjwt 0.11.5

### DIFF
--- a/backend/servico-autenticacao/pom.xml
+++ b/backend/servico-autenticacao/pom.xml
@@ -86,9 +86,21 @@
                         <artifactId>spring-boot-starter-log4j2</artifactId>
                 </dependency>
                 <dependency>
-                        <groupId>com.auth0</groupId>
-                        <artifactId>java-jwt</artifactId>
-                        <version>3.18.1</version>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                        <version>0.11.5</version>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <version>0.11.5</version>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <version>0.11.5</version>
+                        <scope>runtime</scope>
                 </dependency>
                 <dependency>
                         <groupId>org.hibernate.validator</groupId>


### PR DESCRIPTION
## Summary
- substitui a dependência java-jwt do serviço de autenticação pelo conjunto jjwt 0.11.5 adequado para a assinatura HS256
- reimplementa o TokenService com jjwt centralizando a montagem de claims e a validação do segredo mínimo

## Testing
- mvn -q test *(falha: impossibilidade de resolver spring-boot-starter-parent sem acesso ao Maven Central nesta sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ed675fa48c8327a5f7016c7f775ae2