### PR TITLE
Ajusta extração de token no interceptor JWT

### DIFF
--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/jwt.interceptor.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/jwt.interceptor.ts
@@ -4,23 +4,41 @@ import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/c
 import { Observable } from 'rxjs';
 
 import { AuthenticationService } from './authentication.service';
+import { User } from '../../model/user.model';
 
 @Injectable()
 export class JwtInterceptor implements HttpInterceptor {
     constructor(private authenticationService: AuthenticationService) { }
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        const currentUser = this.authenticationService.currentUserValue;
+        const token = this.resolveToken();
 
-        if (currentUser?.token) {
-
+        if (token) {
             request = request.clone({
                 setHeaders: {
-                    Authorization: `Bearer ${currentUser.token}`
+                    Authorization: `Bearer ${token}`
                 }
             });
         }
 
         return next.handle(request);
+    }
+
+    private resolveToken(): string | null {
+        const currentUser = this.authenticationService.currentUserValue as (User & { [key: string]: any }) | null;
+
+        if (!currentUser) {
+            return null;
+        }
+
+        if (currentUser.token) {
+            return currentUser.token;
+        }
+
+        const dynamicToken = currentUser['data']?.token
+            ?? currentUser['accessToken']
+            ?? currentUser['jwt'];
+
+        return dynamicToken ?? null;
     }
 }


### PR DESCRIPTION
## Summary
- ajusta o interceptor JWT para extrair o token diretamente do usuário atual ou de campos alternativos retornados pela API
- mantém o registro do interceptor para anexar o header Authorization às chamadas autenticadas

## Testing
- não executado (não há testes automatizados configurados para este cenário)


------
https://chatgpt.com/codex/tasks/task_e_68ed6d87f3d883278930f86d979408c2