### PR TITLE
feat: abrir aba padrão automaticamente

### DIFF
--- a/frontend/cloudport/src/app/componentes/home/home.component.ts
+++ b/frontend/cloudport/src/app/componentes/home/home.component.ts
@@ -22,6 +22,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private tabSubscription?: Subscription;
   private readonly defaultChildRoute = DEFAULT_TAB_ID;
   private readonly defaultTab = TAB_REGISTRY[this.defaultChildRoute];
+  private defaultTabOpened = false;
 
   constructor(
     private router: Router,
@@ -42,7 +43,10 @@ export class HomeComponent implements OnInit, OnDestroy {
       this.tabs = tabs;
       if (tabs.length === 0) {
         this.selectedTabId = this.defaultChildRoute;
-        this.openDefaultTab();
+        if (!this.defaultTabOpened) {
+          this.defaultTabOpened = true;
+          this.openDefaultTab();
+        }
         return;
       }
       const lastTab = tabs[tabs.length - 1];
@@ -95,9 +99,13 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   private openDefaultTab(): void {
-    if (this.defaultTab) {
-      this.tabService.openTab(this.defaultTab);
-    }
+    const defaultLabel = this.defaultTab?.label ?? 'Role';
+    this.tabService.openTab(defaultLabel);
+    const initialContent = this.tabService.getTabContent(this.defaultChildRoute) ?? {
+      message: `Conteúdo padrão para a aba ${defaultLabel}`
+    };
+    this.tabService.setTabContent(this.defaultChildRoute, initialContent);
+    this.tabContent[this.defaultChildRoute] = initialContent;
     this.navigateToChild(this.defaultChildRoute);
   }
 

--- a/frontend/cloudport/src/app/componentes/navbar/TabService.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/TabService.ts
@@ -37,11 +37,12 @@ export class TabService {
 
   private tabContents: { [tabId: string]: any } = {};
 
-  openTab(tab: TabItem, content?: any): void {
-    const normalizedId = normalizeTabId(tab.id);
+  openTab(tab: TabItem | string, content?: any): void {
+    const tabToRegister = this.resolveTab(tab);
+    const normalizedId = normalizeTabId(tabToRegister.id);
     const registeredTab = TAB_REGISTRY[normalizedId] ?? {
       id: normalizedId,
-      label: tab.label ?? normalizedId
+      label: tabToRegister.label ?? normalizedId
     };
     const tabToOpen: TabItem = { ...registeredTab };
     const tabs = this.tabsSubject.value;
@@ -70,5 +71,29 @@ export class TabService {
 
   setTabContent(tabId: string, content: any): void {
     this.tabContents[normalizeTabId(tabId)] = content;
+  }
+
+  private resolveTab(tab: TabItem | string): TabItem {
+    if (typeof tab !== 'string') {
+      return tab;
+    }
+
+    const normalizedId = normalizeTabId(tab);
+    const registryById = TAB_REGISTRY[normalizedId];
+    if (registryById) {
+      return registryById;
+    }
+
+    const registryByLabel = Object.values(TAB_REGISTRY).find(
+      registeredTab => registeredTab.label.toLowerCase() === tab.toLowerCase()
+    );
+    if (registryByLabel) {
+      return registryByLabel;
+    }
+
+    return {
+      id: normalizedId,
+      label: tab
+    };
   }
 }


### PR DESCRIPTION
## Summary
- garante que o HomeComponent abra a aba padrão uma única vez quando a lista de abas carregada estiver vazia
- ajusta o TabService para aceitar identificadores de abas informados como texto, preservando o registro oficial
- pré-carrega o conteúdo padrão da aba inicial para evitar navegação sem dados

## Testing
- npm run lint *(falha: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ed760b50088327a175575b6e130ded