### PR TITLE
Garantir atribuição correta do token do usuário

### DIFF
--- a/frontend/cloudport/src/app/componentes/model/user.model.spec.ts
+++ b/frontend/cloudport/src/app/componentes/model/user.model.spec.ts
@@ -24,4 +24,10 @@ describe('User model', () => {
     expect(user.perfil).toBe('');
     expect(user.roles).toEqual([]);
   });
+
+  it('deve garantir que o token seja atribuído mesmo quando não informado', () => {
+    const user = new User('2', 'Maria', undefined as unknown as string);
+
+    expect(user.token).toBe('');
+  });
 });

--- a/frontend/cloudport/src/app/componentes/model/user.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/user.model.ts
@@ -12,7 +12,7 @@ export class User {
     ) {
       this.id = id;
       this.nome = nome;
-      this.token = token;
+      this.token = token ?? '';
       this.email = email;
       this.senha = senha;
       this.perfil = perfil;

--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/authentication.service.ts
@@ -99,7 +99,11 @@ export class AuthenticationService {
         }
 
         const source = data.data ?? data;
-        const token = source.token ?? data.token ?? '';
+        const token = source.token
+            ?? data.token
+            ?? source.accessToken
+            ?? data.accessToken
+            ?? '';
         const decoded = this.decodeToken(token);
         const responseRoles = Array.isArray(source.roles)
             ? source.roles


### PR DESCRIPTION
## Resumo
- Ajusta o construtor do modelo `User` para garantir que o token seja atribuído mesmo quando valores indefinidos sejam recebidos
- Atualiza o mapeamento da `AuthenticationService` para propagar tokens retornados em diferentes campos da resposta
- Adiciona teste unitário que cobre a atribuição do token no construtor do modelo

## Testes
- `npm run test -- --watch=false --browsers=ChromeHeadless --include=**/user.model.spec.ts` *(falhou: ng não disponível por dependências não instaladas)*

------
https://chatgpt.com/codex/tasks/task_e_68ed75fcee948327908596c84f67aa4f