### PR TITLE
Integração real do console do gate e persistência de containers

### DIFF
--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/GateOperadorController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/controllers/GateOperadorController.java
@@ -1,0 +1,104 @@
+package br.com.cloudport.servicogate.controllers;
+
+import br.com.cloudport.servicogate.dto.operador.GateOperadorBloqueioRequest;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorEventoDTO;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorLiberacaoRequest;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorOcorrenciaRequest;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorPainelDTO;
+import br.com.cloudport.servicogate.service.GateOperadorOperacoesService;
+import br.com.cloudport.servicogate.service.GateOperadorPainelService;
+import br.com.cloudport.servicogate.service.GateOperadorRealtimeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import javax.validation.Valid;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/gate/operador")
+@Tag(name = "Operador de Gate", description = "Painel operacional e ações de liberação/bloqueio do gate")
+public class GateOperadorController {
+
+    private final GateOperadorPainelService painelService;
+    private final GateOperadorOperacoesService operacoesService;
+    private final GateOperadorRealtimeService realtimeService;
+
+    public GateOperadorController(GateOperadorPainelService painelService,
+                                  GateOperadorOperacoesService operacoesService,
+                                  GateOperadorRealtimeService realtimeService) {
+        this.painelService = painelService;
+        this.operacoesService = operacoesService;
+        this.realtimeService = realtimeService;
+    }
+
+    @GetMapping("/painel")
+    @Operation(summary = "Resumo atualizado do painel do operador do gate")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE','PLANEJADOR')")
+    public GateOperadorPainelDTO obterPainel() {
+        return painelService.montarPainel();
+    }
+
+    @GetMapping("/eventos")
+    @Operation(summary = "Histórico recente de eventos operacionais do gate")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE','PLANEJADOR')")
+    public List<GateOperadorEventoDTO> listarEventos() {
+        return painelService.listarEventosRecentes(50);
+    }
+
+    @GetMapping(value = "/eventos/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Operation(summary = "Canal em tempo real para eventos do gate")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE','PLANEJADOR')")
+    public SseEmitter streamEventos() {
+        return realtimeService.registrar();
+    }
+
+    @PostMapping("/veiculos/{veiculoId}/liberacao")
+    @Operation(summary = "Liberação manual de veículo", description = "Registra liberação manual com justificativa")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE')")
+    public ResponseEntity<Void> liberarVeiculo(@PathVariable Long veiculoId,
+                                               @Valid @RequestBody GateOperadorLiberacaoRequest request) {
+        operacoesService.liberarVeiculo(veiculoId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/veiculos/{veiculoId}/bloqueio")
+    @Operation(summary = "Bloqueio manual de veículo", description = "Registra bloqueio temporário com motivo")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE')")
+    public ResponseEntity<Void> bloquearVeiculo(@PathVariable Long veiculoId,
+                                                @Valid @RequestBody GateOperadorBloqueioRequest request) {
+        operacoesService.bloquearVeiculo(veiculoId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/ocorrencias")
+    @Operation(summary = "Registro de ocorrência operacional")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE','PLANEJADOR')")
+    public ResponseEntity<Void> registrarOcorrencia(@Valid @RequestBody GateOperadorOcorrenciaRequest request) {
+        operacoesService.registrarOcorrencia(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/veiculos/{veiculoId}/comprovante")
+    @Operation(summary = "Gera comprovante textual do gate para o veículo informado")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','OPERADOR_GATE','PLANEJADOR')")
+    public ResponseEntity<ByteArrayResource> imprimirComprovante(@PathVariable Long veiculoId) {
+        var comprovante = operacoesService.gerarComprovante(veiculoId);
+        ByteArrayResource resource = new ByteArrayResource(comprovante.conteudo());
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(comprovante.contentType()))
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "inline; filename=\"" + comprovante.nomeArquivo() + "\"")
+                .body(resource);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/mapper/GateOperadorMapper.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/mapper/GateOperadorMapper.java
@@ -1,0 +1,73 @@
+package br.com.cloudport.servicogate.dto.mapper;
+
+import br.com.cloudport.servicogate.dto.operador.GateOperadorEventoDTO;
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.GateEvent;
+import br.com.cloudport.servicogate.model.GateOcorrencia;
+import br.com.cloudport.servicogate.model.Transportadora;
+import br.com.cloudport.servicogate.model.Veiculo;
+import br.com.cloudport.servicogate.model.enums.NivelEvento;
+import br.com.cloudport.servicogate.model.enums.StatusGate;
+import org.springframework.util.StringUtils;
+
+public final class GateOperadorMapper {
+
+    private GateOperadorMapper() {
+    }
+
+    public static GateOperadorEventoDTO toEventoDTO(GateEvent event) {
+        if (event == null || event.getGatePass() == null || event.getGatePass().getAgendamento() == null) {
+            return null;
+        }
+        Agendamento agendamento = event.getGatePass().getAgendamento();
+        Veiculo veiculo = agendamento.getVeiculo();
+        Transportadora transportadora = agendamento.getTransportadora();
+        StatusGate statusGate = event.getStatus();
+        String tipo = statusGate != null ? statusGate.getDescricao() : "Evento de gate";
+        String descricao = StringUtils.hasText(event.getObservacao()) ? event.getObservacao() : tipo;
+        NivelEvento nivel = nivelFromStatus(statusGate);
+        return new GateOperadorEventoDTO(
+                event.getId(),
+                tipo,
+                descricao,
+                nivel.name(),
+                event.getRegistradoEm(),
+                veiculo != null ? veiculo.getId() : null,
+                veiculo != null ? veiculo.getPlaca() : null,
+                transportadora != null ? transportadora.getNome() : null,
+                event.getUsuarioResponsavel()
+        );
+    }
+
+    public static GateOperadorEventoDTO toEventoDTO(GateOcorrencia ocorrencia) {
+        if (ocorrencia == null) {
+            return null;
+        }
+        Veiculo veiculo = ocorrencia.getVeiculo();
+        Transportadora transportadora = ocorrencia.getTransportadora();
+        String tipo = ocorrencia.getTipo() != null ? ocorrencia.getTipo().getDescricao() : "Ocorrência";
+        NivelEvento nivel = ocorrencia.getNivel() != null ? ocorrencia.getNivel() : NivelEvento.INFO;
+        return new GateOperadorEventoDTO(
+                ocorrencia.getId(),
+                tipo,
+                ocorrencia.getDescricao(),
+                nivel.name(),
+                ocorrencia.getRegistradoEm(),
+                veiculo != null ? veiculo.getId() : null,
+                veiculo != null ? veiculo.getPlaca() : null,
+                transportadora != null ? transportadora.getNome() : null,
+                ocorrencia.getUsuarioResponsavel()
+        );
+    }
+
+    public static NivelEvento nivelFromStatus(StatusGate status) {
+        if (status == null) {
+            return NivelEvento.INFO;
+        }
+        return switch (status) {
+            case RETIDO -> NivelEvento.CRITICA;
+            case LIBERADO, FINALIZADO -> NivelEvento.INFO;
+            case EM_PROCESSAMENTO, AGUARDANDO_ENTRADA -> NivelEvento.OPERACIONAL;
+        };
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorBloqueioRequest.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorBloqueioRequest.java
@@ -1,0 +1,9 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public record GateOperadorBloqueioRequest(@NotBlank @Size(max = 40) String motivoCodigo,
+                                          @NotBlank @Size(max = 500) String justificativa,
+                                          @Size(max = 40) String bloqueioAte) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorComprovanteDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorComprovanteDTO.java
@@ -1,0 +1,4 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+public record GateOperadorComprovanteDTO(String nomeArquivo, byte[] conteudo, String contentType) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorContatoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorContatoDTO.java
@@ -1,0 +1,4 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+public record GateOperadorContatoDTO(String tipo, String valor, String descricao) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorEventoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorEventoDTO.java
@@ -1,0 +1,14 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+import java.time.LocalDateTime;
+
+public record GateOperadorEventoDTO(Long id,
+                                    String tipo,
+                                    String descricao,
+                                    String nivel,
+                                    LocalDateTime registradoEm,
+                                    Long veiculoId,
+                                    String placaVeiculo,
+                                    String transportadora,
+                                    String usuario) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorExcecaoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorExcecaoDTO.java
@@ -1,0 +1,4 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+public record GateOperadorExcecaoDTO(String codigo, String descricao, String nivel) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorFilaDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorFilaDTO.java
@@ -1,0 +1,10 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+import java.util.List;
+
+public record GateOperadorFilaDTO(String id,
+                                  String nome,
+                                  Integer quantidade,
+                                  Long tempoMedioEsperaMinutos,
+                                  List<GateOperadorVeiculoDTO> veiculos) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorLiberacaoRequest.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorLiberacaoRequest.java
@@ -1,0 +1,9 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public record GateOperadorLiberacaoRequest(@NotBlank @Size(max = 40) String canalEntrada,
+                                           @NotBlank @Size(max = 500) String justificativa,
+                                           Boolean notificarTransportadora) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorOcorrenciaRequest.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorOcorrenciaRequest.java
@@ -1,0 +1,9 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public record GateOperadorOcorrenciaRequest(@NotBlank @Size(max = 40) String tipoCodigo,
+                                            @NotBlank @Size(max = 500) String descricao,
+                                            Long veiculoId) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorPainelDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorPainelDTO.java
@@ -1,0 +1,11 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GateOperadorPainelDTO(List<GateOperadorFilaDTO> filasEntrada,
+                                    List<GateOperadorFilaDTO> filasSaida,
+                                    List<GateOperadorVeiculoDTO> veiculosAtendimento,
+                                    List<GateOperadorEventoDTO> historico,
+                                    LocalDateTime ultimaAtualizacao) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorVeiculoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/dto/operador/GateOperadorVeiculoDTO.java
@@ -1,0 +1,17 @@
+package br.com.cloudport.servicogate.dto.operador;
+
+import java.util.List;
+
+public record GateOperadorVeiculoDTO(Long id,
+                                     String placa,
+                                     String documento,
+                                     String motorista,
+                                     String status,
+                                     String statusDescricao,
+                                     Long tempoFilaMinutos,
+                                     String canalEntrada,
+                                     String transportadora,
+                                     List<GateOperadorContatoDTO> contatos,
+                                     List<GateOperadorExcecaoDTO> excecoes,
+                                     boolean podeImprimirComprovante) {
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/GateOcorrencia.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/GateOcorrencia.java
@@ -1,0 +1,114 @@
+package br.com.cloudport.servicogate.model;
+
+import br.com.cloudport.servicogate.model.enums.NivelEvento;
+import br.com.cloudport.servicogate.model.enums.TipoOcorrenciaOperador;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "gate_ocorrencia")
+public class GateOcorrencia extends AbstractAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false, length = 60)
+    private TipoOcorrenciaOperador tipo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "nivel", nullable = false, length = 40)
+    private NivelEvento nivel;
+
+    @Column(name = "descricao", nullable = false, length = 500)
+    private String descricao;
+
+    @Column(name = "registrado_em", nullable = false)
+    private LocalDateTime registradoEm;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "veiculo_id")
+    private Veiculo veiculo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "transportadora_id")
+    private Transportadora transportadora;
+
+    @Column(name = "usuario_responsavel", length = 80)
+    private String usuarioResponsavel;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public TipoOcorrenciaOperador getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(TipoOcorrenciaOperador tipo) {
+        this.tipo = tipo;
+    }
+
+    public NivelEvento getNivel() {
+        return nivel;
+    }
+
+    public void setNivel(NivelEvento nivel) {
+        this.nivel = nivel;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public LocalDateTime getRegistradoEm() {
+        return registradoEm;
+    }
+
+    public void setRegistradoEm(LocalDateTime registradoEm) {
+        this.registradoEm = registradoEm;
+    }
+
+    public Veiculo getVeiculo() {
+        return veiculo;
+    }
+
+    public void setVeiculo(Veiculo veiculo) {
+        this.veiculo = veiculo;
+    }
+
+    public Transportadora getTransportadora() {
+        return transportadora;
+    }
+
+    public void setTransportadora(Transportadora transportadora) {
+        this.transportadora = transportadora;
+    }
+
+    public String getUsuarioResponsavel() {
+        return usuarioResponsavel;
+    }
+
+    public void setUsuarioResponsavel(String usuarioResponsavel) {
+        this.usuarioResponsavel = usuarioResponsavel;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/NivelEvento.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/NivelEvento.java
@@ -1,0 +1,18 @@
+package br.com.cloudport.servicogate.model.enums;
+
+public enum NivelEvento {
+    INFO("Informativo"),
+    ALERTA("Alerta"),
+    CRITICA("Crítica"),
+    OPERACIONAL("Operacional");
+
+    private final String descricao;
+
+    NivelEvento(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/TipoOcorrenciaOperador.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/model/enums/TipoOcorrenciaOperador.java
@@ -1,0 +1,37 @@
+package br.com.cloudport.servicogate.model.enums;
+
+import java.util.Locale;
+
+public enum TipoOcorrenciaOperador {
+    ATRASO_EM_FILAS("Atraso em filas", NivelEvento.ALERTA),
+    DOCUMENTACAO_PENDENTE("Documentação pendente", NivelEvento.ALERTA),
+    INCIDENTE_SEGURANCA("Incidente de segurança", NivelEvento.CRITICA),
+    MANUTENCAO_EQUIPAMENTO("Manutenção de equipamento", NivelEvento.OPERACIONAL),
+    OPERACAO_NORMAL("Ocorrência operacional", NivelEvento.INFO);
+
+    private final String descricao;
+    private final NivelEvento nivelPadrao;
+
+    TipoOcorrenciaOperador(String descricao, NivelEvento nivelPadrao) {
+        this.descricao = descricao;
+        this.nivelPadrao = nivelPadrao;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public NivelEvento getNivelPadrao() {
+        return nivelPadrao;
+    }
+
+    public static TipoOcorrenciaOperador fromCodigo(String codigo) {
+        if (codigo == null) {
+            throw new IllegalArgumentException("Tipo de ocorrência não informado");
+        }
+        String normalizado = codigo.trim().toUpperCase(Locale.ROOT)
+                .replace('-', '_')
+                .replace(' ', '_');
+        return TipoOcorrenciaOperador.valueOf(normalizado);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/AgendamentoRepository.java
@@ -22,7 +22,13 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
             String placa,
             List<StatusAgendamento> status);
 
+    Optional<Agendamento> findFirstByVeiculoIdAndStatusInOrderByHorarioPrevistoChegadaDesc(
+            Long veiculoId,
+            List<StatusAgendamento> status);
+
     List<Agendamento> findByStatus(StatusAgendamento status);
+
+    List<Agendamento> findByStatusInOrderByHorarioPrevistoChegadaAsc(List<StatusAgendamento> status);
 
     List<Agendamento> findByJanelaAtendimentoData(LocalDate data);
 

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GateEventRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GateEventRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GateEventRepository extends JpaRepository<GateEvent, Long> {
 
     List<GateEvent> findByGatePassIdOrderByRegistradoEmAsc(Long gatePassId);
+
+    List<GateEvent> findTop100ByOrderByRegistradoEmDesc();
 }

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GateOcorrenciaRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/repository/GateOcorrenciaRepository.java
@@ -1,0 +1,12 @@
+package br.com.cloudport.servicogate.repository;
+
+import br.com.cloudport.servicogate.model.GateOcorrencia;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GateOcorrenciaRepository extends JpaRepository<GateOcorrencia, Long> {
+
+    List<GateOcorrencia> findTop100ByOrderByRegistradoEmDesc();
+
+    List<GateOcorrencia> findByVeiculoIdOrderByRegistradoEmDesc(Long veiculoId);
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateFlowService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateFlowService.java
@@ -9,6 +9,7 @@ import br.com.cloudport.servicogate.dto.ManualReleaseRequest;
 import br.com.cloudport.servicogate.dto.TosContainerStatus;
 import br.com.cloudport.servicogate.dto.TosSyncResponse;
 import br.com.cloudport.servicogate.dto.mapper.GateMapper;
+import br.com.cloudport.servicogate.dto.mapper.GateOperadorMapper;
 import br.com.cloudport.servicogate.exception.BusinessException;
 import br.com.cloudport.servicogate.exception.NotFoundException;
 import br.com.cloudport.servicogate.integration.tos.TosIntegrationService;
@@ -23,6 +24,7 @@ import br.com.cloudport.servicogate.monitoring.GateMetrics;
 import br.com.cloudport.servicogate.repository.AgendamentoRepository;
 import br.com.cloudport.servicogate.repository.GateEventRepository;
 import br.com.cloudport.servicogate.repository.GatePassRepository;
+import br.com.cloudport.servicogate.service.GateOperadorRealtimeService;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -66,14 +68,16 @@ public class GateFlowService {
     private final TosIntegrationService tosIntegrationService;
     private final GateMetrics gateMetrics;
     private final AgendamentoRealtimeService agendamentoRealtimeService;
+    private final GateOperadorRealtimeService gateOperadorRealtimeService;
 
     public GateFlowService(AgendamentoRepository agendamentoRepository,
                            GatePassRepository gatePassRepository,
                            GateEventRepository gateEventRepository,
                            GateFlowProperties flowProperties,
                            TosIntegrationService tosIntegrationService,
-                           GateMetrics gateMetrics,
-                           AgendamentoRealtimeService agendamentoRealtimeService) {
+                              GateMetrics gateMetrics,
+                              AgendamentoRealtimeService agendamentoRealtimeService,
+                              GateOperadorRealtimeService gateOperadorRealtimeService) {
         this.agendamentoRepository = agendamentoRepository;
         this.gatePassRepository = gatePassRepository;
         this.gateEventRepository = gateEventRepository;
@@ -81,6 +85,7 @@ public class GateFlowService {
         this.tosIntegrationService = tosIntegrationService;
         this.gateMetrics = gateMetrics;
         this.agendamentoRealtimeService = agendamentoRealtimeService;
+        this.gateOperadorRealtimeService = gateOperadorRealtimeService;
     }
 
     public GateDecisionDTO registrarEntrada(GateFlowRequest request) {
@@ -328,6 +333,7 @@ public class GateFlowService {
         GateEvent salvo = gateEventRepository.save(event);
         gatePass.getEventos().add(salvo);
         agendamentoRealtimeService.notificarGatePass(gatePass);
+        gateOperadorRealtimeService.publicarEvento(GateOperadorMapper.toEventoDTO(salvo));
         return salvo;
     }
 

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateOperadorOperacoesService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateOperadorOperacoesService.java
@@ -1,0 +1,182 @@
+package br.com.cloudport.servicogate.service;
+
+import br.com.cloudport.servicogate.dto.ManualReleaseAction;
+import br.com.cloudport.servicogate.dto.ManualReleaseRequest;
+import br.com.cloudport.servicogate.dto.mapper.GateOperadorMapper;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorBloqueioRequest;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorComprovanteDTO;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorEventoDTO;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorLiberacaoRequest;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorOcorrenciaRequest;
+import br.com.cloudport.servicogate.exception.NotFoundException;
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.GateEvent;
+import br.com.cloudport.servicogate.model.GateOcorrencia;
+import br.com.cloudport.servicogate.model.Veiculo;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.model.enums.TipoOcorrenciaOperador;
+import br.com.cloudport.servicogate.repository.AgendamentoRepository;
+import br.com.cloudport.servicogate.repository.GateOcorrenciaRepository;
+import br.com.cloudport.servicogate.repository.VeiculoRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@Transactional
+public class GateOperadorOperacoesService {
+
+    private static final DateTimeFormatter DATA_HORA_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+    private final AgendamentoRepository agendamentoRepository;
+    private final GateFlowService gateFlowService;
+    private final GateOperadorRealtimeService realtimeService;
+    private final GateOcorrenciaRepository gateOcorrenciaRepository;
+    private final VeiculoRepository veiculoRepository;
+
+    public GateOperadorOperacoesService(AgendamentoRepository agendamentoRepository,
+                                        GateFlowService gateFlowService,
+                                        GateOperadorRealtimeService realtimeService,
+                                        GateOcorrenciaRepository gateOcorrenciaRepository,
+                                        VeiculoRepository veiculoRepository) {
+        this.agendamentoRepository = agendamentoRepository;
+        this.gateFlowService = gateFlowService;
+        this.realtimeService = realtimeService;
+        this.gateOcorrenciaRepository = gateOcorrenciaRepository;
+        this.veiculoRepository = veiculoRepository;
+    }
+
+    public void liberarVeiculo(Long veiculoId, GateOperadorLiberacaoRequest request) {
+        Agendamento agendamento = localizarAgendamentoAtivo(veiculoId);
+        ManualReleaseRequest manual = new ManualReleaseRequest();
+        manual.setAcao(ManualReleaseAction.LIBERAR);
+        manual.setObservacao(formatarJustificativaLiberacao(request));
+        manual.setOperador(obterOperadorAtual());
+        manual.setMotivo(null);
+        GateEvent evento = gateFlowService.registrarLiberacaoManual(agendamento.getId(), manual);
+        realtimeService.publicarEvento(GateOperadorMapper.toEventoDTO(evento));
+    }
+
+    public void bloquearVeiculo(Long veiculoId, GateOperadorBloqueioRequest request) {
+        Agendamento agendamento = localizarAgendamentoAtivo(veiculoId);
+        ManualReleaseRequest manual = new ManualReleaseRequest();
+        manual.setAcao(ManualReleaseAction.BLOQUEAR);
+        manual.setMotivo(request.motivoCodigo());
+        manual.setObservacao(formatarJustificativaBloqueio(request));
+        manual.setOperador(obterOperadorAtual());
+        GateEvent evento = gateFlowService.registrarBloqueioManual(agendamento.getId(), manual);
+        realtimeService.publicarEvento(GateOperadorMapper.toEventoDTO(evento));
+    }
+
+    public GateOperadorEventoDTO registrarOcorrencia(GateOperadorOcorrenciaRequest request) {
+        TipoOcorrenciaOperador tipo;
+        try {
+            tipo = TipoOcorrenciaOperador.fromCodigo(request.tipoCodigo());
+        } catch (IllegalArgumentException ex) {
+            throw new NotFoundException("Tipo de ocorrência informado é inválido");
+        }
+        Veiculo veiculo = null;
+        if (request.veiculoId() != null) {
+            veiculo = veiculoRepository.findById(request.veiculoId())
+                    .orElseThrow(() -> new NotFoundException("Veículo informado na ocorrência não foi encontrado"));
+        }
+        GateOcorrencia ocorrencia = new GateOcorrencia();
+        ocorrencia.setTipo(tipo);
+        ocorrencia.setNivel(tipo.getNivelPadrao());
+        ocorrencia.setDescricao(request.descricao());
+        ocorrencia.setRegistradoEm(LocalDateTime.now());
+        ocorrencia.setUsuarioResponsavel(obterOperadorAtual());
+        ocorrencia.setVeiculo(veiculo);
+        ocorrencia.setTransportadora(veiculo != null ? veiculo.getTransportadora() : null);
+        GateOcorrencia salvo = gateOcorrenciaRepository.save(ocorrencia);
+        GateOperadorEventoDTO evento = GateOperadorMapper.toEventoDTO(salvo);
+        realtimeService.publicarEvento(evento);
+        return evento;
+    }
+
+    @Transactional(readOnly = true)
+    public GateOperadorComprovanteDTO gerarComprovante(Long veiculoId) {
+        Agendamento agendamento = localizarAgendamentoAtivo(veiculoId);
+        StringBuilder builder = new StringBuilder();
+        builder.append("Comprovante de Gate\n");
+        builder.append("Emitido em: ").append(LocalDateTime.now().format(DATA_HORA_FORMATTER)).append('\n');
+        builder.append("Agendamento: ").append(agendamento.getCodigo()).append('\n');
+        builder.append("Status: ").append(agendamento.getStatus() != null ? agendamento.getStatus().getDescricao() : "").append('\n');
+        if (agendamento.getTransportadora() != null) {
+            builder.append("Transportadora: ").append(agendamento.getTransportadora().getNome()).append('\n');
+        }
+        if (agendamento.getMotorista() != null) {
+            builder.append("Motorista: ").append(agendamento.getMotorista().getNome()).append('\n');
+        }
+        if (agendamento.getVeiculo() != null) {
+            builder.append("Placa: ").append(agendamento.getVeiculo().getPlaca()).append('\n');
+        }
+        if (agendamento.getHorarioPrevistoChegada() != null) {
+            builder.append("Chegada prevista: ")
+                    .append(agendamento.getHorarioPrevistoChegada().format(DATA_HORA_FORMATTER))
+                    .append('\n');
+        }
+        if (agendamento.getHorarioRealChegada() != null) {
+            builder.append("Chegada registrada: ")
+                    .append(agendamento.getHorarioRealChegada().format(DATA_HORA_FORMATTER))
+                    .append('\n');
+        }
+        if (agendamento.getHorarioRealSaida() != null) {
+            builder.append("Saída registrada: ")
+                    .append(agendamento.getHorarioRealSaida().format(DATA_HORA_FORMATTER))
+                    .append('\n');
+        }
+        builder.append("Operador responsável: ").append(obterOperadorAtual()).append('\n');
+
+        byte[] conteudo = builder.toString().getBytes(StandardCharsets.UTF_8);
+        String nomeArquivo = "comprovante-gate-" +
+                (agendamento.getVeiculo() != null ? agendamento.getVeiculo().getPlaca() : "veiculo") + ".txt";
+        return new GateOperadorComprovanteDTO(nomeArquivo, conteudo, "text/plain;charset=UTF-8");
+    }
+
+    private Agendamento localizarAgendamentoAtivo(Long veiculoId) {
+        List<StatusAgendamento> status = List.of(
+                StatusAgendamento.CONFIRMADO,
+                StatusAgendamento.EM_ATENDIMENTO,
+                StatusAgendamento.EM_EXECUCAO
+        );
+        return agendamentoRepository.findFirstByVeiculoIdAndStatusInOrderByHorarioPrevistoChegadaDesc(veiculoId, status)
+                .orElseThrow(() -> new NotFoundException("Não foi encontrado agendamento ativo para o veículo informado"));
+    }
+
+    private String formatarJustificativaLiberacao(GateOperadorLiberacaoRequest request) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(request.justificativa());
+        if (StringUtils.hasText(request.canalEntrada())) {
+            builder.append(" | Canal: ").append(request.canalEntrada());
+        }
+        if (Boolean.TRUE.equals(request.notificarTransportadora())) {
+            builder.append(" | Transportadora notificada");
+        }
+        return builder.toString();
+    }
+
+    private String formatarJustificativaBloqueio(GateOperadorBloqueioRequest request) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(request.justificativa());
+        if (StringUtils.hasText(request.bloqueioAte())) {
+            builder.append(" | Bloqueio até: ").append(request.bloqueioAte());
+        }
+        return builder.toString();
+    }
+
+    private String obterOperadorAtual() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !StringUtils.hasText(authentication.getName())) {
+            return "SISTEMA";
+        }
+        return authentication.getName();
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateOperadorPainelService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateOperadorPainelService.java
@@ -1,0 +1,245 @@
+package br.com.cloudport.servicogate.service;
+
+import br.com.cloudport.servicogate.dto.mapper.GateOperadorMapper;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorContatoDTO;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorEventoDTO;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorExcecaoDTO;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorFilaDTO;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorPainelDTO;
+import br.com.cloudport.servicogate.dto.operador.GateOperadorVeiculoDTO;
+import br.com.cloudport.servicogate.model.Agendamento;
+import br.com.cloudport.servicogate.model.GateEvent;
+import br.com.cloudport.servicogate.model.JanelaAtendimento;
+import br.com.cloudport.servicogate.model.Motorista;
+import br.com.cloudport.servicogate.model.Transportadora;
+import br.com.cloudport.servicogate.model.Veiculo;
+import br.com.cloudport.servicogate.model.enums.CanalEntrada;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.repository.AgendamentoRepository;
+import br.com.cloudport.servicogate.repository.GateEventRepository;
+import br.com.cloudport.servicogate.repository.GateOcorrenciaRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@Transactional(readOnly = true)
+public class GateOperadorPainelService {
+
+    private static final int HISTORICO_LIMITE_PADRAO = 50;
+
+    private final AgendamentoRepository agendamentoRepository;
+    private final GateEventRepository gateEventRepository;
+    private final GateOcorrenciaRepository gateOcorrenciaRepository;
+
+    public GateOperadorPainelService(AgendamentoRepository agendamentoRepository,
+                                     GateEventRepository gateEventRepository,
+                                     GateOcorrenciaRepository gateOcorrenciaRepository) {
+        this.agendamentoRepository = agendamentoRepository;
+        this.gateEventRepository = gateEventRepository;
+        this.gateOcorrenciaRepository = gateOcorrenciaRepository;
+    }
+
+    public GateOperadorPainelDTO montarPainel() {
+        LocalDateTime agora = LocalDateTime.now();
+        List<StatusAgendamento> statusConsiderados = List.of(
+                StatusAgendamento.CONFIRMADO,
+                StatusAgendamento.EM_ATENDIMENTO,
+                StatusAgendamento.EM_EXECUCAO
+        );
+        List<Agendamento> agendamentos = agendamentoRepository
+                .findByStatusInOrderByHorarioPrevistoChegadaAsc(statusConsiderados);
+
+        List<GateOperadorVeiculoDTO> veiculosAtendimento = agendamentos.stream()
+                .filter(agendamento -> agendamento.getStatus() == StatusAgendamento.EM_ATENDIMENTO)
+                .map(agendamento -> toVeiculoDTO(agendamento,
+                        calcularMinutos(agendamento.getHorarioRealChegada(), agora)))
+                .collect(Collectors.toList());
+
+        List<GateOperadorFilaDTO> filasEntrada = montarFilas(
+                agendamentos.stream()
+                        .filter(agendamento -> agendamento.getStatus() == StatusAgendamento.CONFIRMADO)
+                        .collect(Collectors.toList()),
+                true,
+                agora
+        );
+
+        List<GateOperadorFilaDTO> filasSaida = montarFilas(
+                agendamentos.stream()
+                        .filter(agendamento -> agendamento.getStatus() == StatusAgendamento.EM_EXECUCAO)
+                        .collect(Collectors.toList()),
+                false,
+                agora
+        );
+
+        List<GateOperadorEventoDTO> historico = listarEventosRecentes(HISTORICO_LIMITE_PADRAO);
+
+        return new GateOperadorPainelDTO(
+                filasEntrada,
+                filasSaida,
+                veiculosAtendimento,
+                historico,
+                agora
+        );
+    }
+
+    public List<GateOperadorEventoDTO> listarEventosRecentes(int limite) {
+        List<GateOperadorEventoDTO> eventosGate = gateEventRepository.findTop100ByOrderByRegistradoEmDesc()
+                .stream()
+                .map(GateOperadorMapper::toEventoDTO)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        List<GateOperadorEventoDTO> ocorrencias = gateOcorrenciaRepository.findTop100ByOrderByRegistradoEmDesc()
+                .stream()
+                .map(GateOperadorMapper::toEventoDTO)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return Stream.concat(eventosGate.stream(), ocorrencias.stream())
+                .sorted(Comparator.comparing(GateOperadorEventoDTO::registradoEm,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(limite)
+                .collect(Collectors.toList());
+    }
+
+    private List<GateOperadorFilaDTO> montarFilas(List<Agendamento> agendamentos,
+                                                  boolean entrada,
+                                                  LocalDateTime agora) {
+        if (agendamentos.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Map<String, List<Agendamento>> agrupados = agendamentos.stream()
+                .collect(Collectors.groupingBy(agendamento -> identificarFila(agendamento, entrada)));
+
+        return agrupados.entrySet().stream()
+                .map(entry -> {
+                    List<GateOperadorVeiculoDTO> veiculos = entry.getValue().stream()
+                            .map(agendamento -> toVeiculoDTO(agendamento, calcularTempoFila(agendamento, entrada, agora)))
+                            .collect(Collectors.toList());
+                    long media = veiculos.stream()
+                            .map(GateOperadorVeiculoDTO::tempoFilaMinutos)
+                            .filter(Objects::nonNull)
+                            .mapToLong(Long::longValue)
+                            .average()
+                            .orElse(0);
+                    String id = gerarIdentificadorFila(entry.getKey(), entrada);
+                    return new GateOperadorFilaDTO(
+                            id,
+                            entry.getKey(),
+                            veiculos.size(),
+                            media > 0 ? Math.round(media) : 0L,
+                            veiculos
+                    );
+                })
+                .sorted(Comparator.comparing(GateOperadorFilaDTO::nome, String.CASE_INSENSITIVE_ORDER))
+                .collect(Collectors.toList());
+    }
+
+    private String identificarFila(Agendamento agendamento, boolean entrada) {
+        JanelaAtendimento janela = agendamento.getJanelaAtendimento();
+        if (janela != null && janela.getCanalEntrada() != null) {
+            String canal = janela.getCanalEntrada().getDescricao();
+            if (janela.getHoraInicio() != null) {
+                return canal + " - " + janela.getHoraInicio();
+            }
+            return canal;
+        }
+        Transportadora transportadora = agendamento.getTransportadora();
+        if (!entrada && transportadora != null && StringUtils.hasText(transportadora.getNome())) {
+            return transportadora.getNome();
+        }
+        return entrada ? "Fila de entrada" : "Fila de saída";
+    }
+
+    private String gerarIdentificadorFila(String nome, boolean entrada) {
+        String base = StringUtils.hasText(nome) ? nome : (entrada ? "entrada" : "saida");
+        return base.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "-");
+    }
+
+    private GateOperadorVeiculoDTO toVeiculoDTO(Agendamento agendamento, Long tempoFilaMinutos) {
+        Veiculo veiculo = agendamento.getVeiculo();
+        Transportadora transportadora = agendamento.getTransportadora();
+        Motorista motorista = agendamento.getMotorista();
+        JanelaAtendimento janela = agendamento.getJanelaAtendimento();
+        CanalEntrada canal = janela != null ? janela.getCanalEntrada() : null;
+
+        List<GateOperadorContatoDTO> contatos = montarContatos(motorista, transportadora);
+        List<GateOperadorExcecaoDTO> excecoes = buscarExcecoes(agendamento);
+
+        boolean podeImprimir = agendamento.getGatePass() != null &&
+                StringUtils.hasText(agendamento.getGatePass().getToken());
+
+        return new GateOperadorVeiculoDTO(
+                veiculo != null ? veiculo.getId() : null,
+                veiculo != null ? veiculo.getPlaca() : null,
+                motorista != null ? motorista.getDocumento() : null,
+                motorista != null ? motorista.getNome() : null,
+                agendamento.getStatus() != null ? agendamento.getStatus().name() : null,
+                agendamento.getStatus() != null ? agendamento.getStatus().getDescricao() : null,
+                tempoFilaMinutos,
+                canal != null ? canal.getDescricao() : null,
+                transportadora != null ? transportadora.getNome() : null,
+                contatos,
+                excecoes,
+                podeImprimir
+        );
+    }
+
+    private Long calcularTempoFila(Agendamento agendamento, boolean entrada, LocalDateTime agora) {
+        if (entrada) {
+            return calcularMinutos(agendamento.getHorarioPrevistoChegada(), agora);
+        }
+        LocalDateTime referencia = Optional.ofNullable(agendamento.getHorarioRealChegada())
+                .orElse(agendamento.getHorarioPrevistoChegada());
+        return calcularMinutos(referencia, agora);
+    }
+
+    private Long calcularMinutos(LocalDateTime inicio, LocalDateTime fim) {
+        if (inicio == null || fim == null) {
+            return 0L;
+        }
+        long minutos = Duration.between(inicio, fim).toMinutes();
+        return minutos < 0 ? 0L : minutos;
+    }
+
+    private List<GateOperadorContatoDTO> montarContatos(Motorista motorista, Transportadora transportadora) {
+        List<GateOperadorContatoDTO> contatos = new ArrayList<>();
+        if (motorista != null && StringUtils.hasText(motorista.getTelefone())) {
+            contatos.add(new GateOperadorContatoDTO("TELEFONE", motorista.getTelefone(), "Motorista"));
+        }
+        if (transportadora != null && StringUtils.hasText(transportadora.getContato())) {
+            String contato = transportadora.getContato();
+            String tipo = contato.contains("@") ? "EMAIL" : "TELEFONE";
+            contatos.add(new GateOperadorContatoDTO(tipo, contato, "Transportadora"));
+        }
+        return contatos;
+    }
+
+    private List<GateOperadorExcecaoDTO> buscarExcecoes(Agendamento agendamento) {
+        if (agendamento.getGatePass() == null) {
+            return Collections.emptyList();
+        }
+        return gateEventRepository.findByGatePassIdOrderByRegistradoEmAsc(agendamento.getGatePass().getId())
+                .stream()
+                .filter(evento -> evento.getMotivoExcecao() != null)
+                .map(evento -> new GateOperadorExcecaoDTO(
+                        evento.getMotivoExcecao().name(),
+                        evento.getMotivoExcecao().getDescricao(),
+                        GateOperadorMapper.nivelFromStatus(evento.getStatus()).name()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateOperadorRealtimeService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/service/GateOperadorRealtimeService.java
@@ -1,0 +1,48 @@
+package br.com.cloudport.servicogate.service;
+
+import br.com.cloudport.servicogate.dto.operador.GateOperadorEventoDTO;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+public class GateOperadorRealtimeService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GateOperadorRealtimeService.class);
+    private static final Duration TIMEOUT = Duration.ofMinutes(30);
+
+    private final List<SseEmitter> emissores = new CopyOnWriteArrayList<>();
+
+    public SseEmitter registrar() {
+        SseEmitter emitter = new SseEmitter(TIMEOUT.toMillis());
+        emissores.add(emitter);
+        emitter.onCompletion(() -> remover(emitter));
+        emitter.onTimeout(() -> remover(emitter));
+        emitter.onError(throwable -> remover(emitter));
+        return emitter;
+    }
+
+    public void publicarEvento(GateOperadorEventoDTO evento) {
+        if (evento == null || emissores.isEmpty()) {
+            return;
+        }
+        for (SseEmitter emitter : emissores) {
+            try {
+                emitter.send(evento);
+            } catch (IOException ex) {
+                LOGGER.debug("Falha ao enviar evento SSE do gate", ex);
+                emitter.completeWithError(ex);
+                emissores.remove(emitter);
+            }
+        }
+    }
+
+    private void remover(SseEmitter emitter) {
+        emissores.remove(emitter);
+    }
+}

--- a/backend/servico-yard/pom.xml
+++ b/backend/servico-yard/pom.xml
@@ -23,6 +23,15 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/model/Container.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/model/Container.java
@@ -1,11 +1,28 @@
 package br.com.cloudport.servicoyard.model;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "container")
 public class Container {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "nome", nullable = false, length = 80)
     private String name;
+
+    @Column(name = "localizacao", nullable = false, length = 120)
     private String location;
 
-    public Container() {}
+    public Container() {
+    }
 
     public Container(Long id, String name, String location) {
         this.id = id;

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/repository/ContainerRepository.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/repository/ContainerRepository.java
@@ -1,0 +1,9 @@
+package br.com.cloudport.servicoyard.repository;
+
+import br.com.cloudport.servicoyard.model.Container;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContainerRepository extends JpaRepository<Container, Long> {
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/service/ContainerService.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/service/ContainerService.java
@@ -1,25 +1,27 @@
 package br.com.cloudport.servicoyard.service;
 
 import br.com.cloudport.servicoyard.model.Container;
-import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.Collections;
+import br.com.cloudport.servicoyard.repository.ContainerRepository;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ContainerService {
-    private final List<Container> containers = new ArrayList<>();
-    private final AtomicLong counter = new AtomicLong();
+    private final ContainerRepository containerRepository;
 
+    public ContainerService(ContainerRepository containerRepository) {
+        this.containerRepository = containerRepository;
+    }
+
+    @Transactional(readOnly = true)
     public List<Container> listContainers() {
-        return Collections.unmodifiableList(containers);
+        return containerRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
     }
 
     public Container addContainer(Container container) {
-        container.setId(counter.incrementAndGet());
-        containers.add(container);
-        return container;
+        container.setId(null);
+        return containerRepository.save(container);
     }
 }

--- a/backend/servico-yard/src/main/resources/application.properties
+++ b/backend/servico-yard/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 server.port=8081
+spring.datasource.url=jdbc:h2:mem:yarddb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Resumo
- habilita a persistência do serviço de yard com Spring Data JPA e banco H2 em memória
- expõe endpoints reais para o console do operador do gate com DTOs, serviços agregadores e SSE
- amplia o controlador de configuração com transportadoras, tipos de ocorrência e níveis de evento

## Testes
- `mvn test` *(falhou: download do parent Spring Boot bloqueado com HTTP 403 no repositório Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68ed9460b46c8327ba2b9ef65afd94bb