### PR TITLE
Ajusta rotas protegidas e navegação do menu

### DIFF
--- a/frontend/cloudport/src/app/app-routing.module.ts
+++ b/frontend/cloudport/src/app/app-routing.module.ts
@@ -10,12 +10,31 @@ import { PrivacidadeComponent } from './componentes/privacidade/privacidade.comp
 import { UsuariosListaComponent } from './componentes/usuarios-lista/usuarios-lista.component';
 
 const homeChildRoutes: Routes = [
-  { path: '', redirectTo: 'role', pathMatch: 'full' },
-  { path: 'role', component: RoleTabelaComponent },
-  { path: 'seguranca', component: SegurancaComponent },
-  { path: 'notificacoes', component: NotificacoesComponent },
-  { path: 'privacidade', component: PrivacidadeComponent },
-  { path: 'lista-de-usuarios', component: UsuariosListaComponent },
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: 'role'
+  },
+  {
+    path: 'role',
+    component: RoleTabelaComponent
+  },
+  {
+    path: 'seguranca',
+    component: SegurancaComponent
+  },
+  {
+    path: 'notificacoes',
+    component: NotificacoesComponent
+  },
+  {
+    path: 'privacidade',
+    component: PrivacidadeComponent
+  },
+  {
+    path: 'lista-de-usuarios',
+    component: UsuariosListaComponent
+  },
   {
     path: 'gate',
     loadChildren: () => import('./componentes/gate/gate.module').then(m => m.GateModule)

--- a/frontend/cloudport/src/app/componentes/home/home.component.ts
+++ b/frontend/cloudport/src/app/componentes/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Router, RouteReuseStrategy, RouterOutlet } from '@angular/router';
 import { AuthenticationService } from '../service/servico-autenticacao/authentication.service';
-import { TabItem, TabService, TAB_REGISTRY, DEFAULT_TAB_ID, normalizeTabId } from '../navbar/TabService';
+import { TabItem, TabService, TAB_REGISTRY, DEFAULT_TAB_ID, normalizeTabId, resolveRouteSegments } from '../navbar/TabService';
 import { CustomReuseStrategy } from '../tab-content/customreusestrategy';
 import { Subscription } from 'rxjs';
 
@@ -110,7 +110,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   private navigateToChild(route: string): void {
-    const commands = ['/home', ...route.split('/')];
+    const commands = ['/home', ...resolveRouteSegments(route)];
     this.router.navigate(commands);
   }
 }

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.css
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.css
@@ -48,14 +48,55 @@
     margin-bottom: 0;
 }
 
-.app-navbar a {
+.app-navbar button {
+    background: none;
+    border: none;
     color: #ffffff;
-    text-decoration: none;
-    margin-right: 15px;
+    cursor: pointer;
+    font: inherit;
+    padding: 0;
 }
 
-.app-navbar a:hover {
+.app-navbar button:focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+}
+
+.submenu-trigger {
+    margin-right: 15px;
+    text-decoration: none;
+}
+
+.submenu-trigger:hover,
+.submenu-item:not(:disabled):hover {
     text-decoration: underline;
+}
+
+.submenu-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+}
+
+.submenu-item:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    text-decoration: none;
+}
+
+.submenu-item.coming-soon {
+    text-decoration: none;
+}
+
+.submenu-badge {
+    background-color: #f5a623;
+    border-radius: 12px;
+    color: #14213d;
+    font-size: 0.65em;
+    font-weight: 600;
+    padding: 2px 8px;
+    text-transform: uppercase;
 }
 
 .title-banner {

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
@@ -1,26 +1,53 @@
 <nav class="app-navbar" *ngIf="mostrarMenu">
   <ul>
     <li *ngIf="configurationTabs.length" (click)="toggleSubmenu($event)">
-      <a href="#">Configurações</a>
+      <button type="button" class="submenu-trigger">Configurações</button>
       <ul>
         <li *ngFor="let tab of configurationTabs">
-          <a (click)="openTab(tab)">{{ tab.label }}</a>
+          <button
+            type="button"
+            class="submenu-item"
+            [class.coming-soon]="tab.disabled"
+            [disabled]="tab.disabled"
+            (click)="handleTabSelection($event, tab)"
+          >
+            <span>{{ tab.label }}</span>
+            <span *ngIf="tab.disabled" class="submenu-badge">{{ tab.comingSoonMessage || 'Em breve' }}</span>
+          </button>
         </li>
       </ul>
     </li>
     <li *ngIf="gateTabs.length" (click)="toggleSubmenu($event)">
-      <a href="#">Gate</a>
+      <button type="button" class="submenu-trigger">Gate</button>
       <ul>
         <li *ngFor="let tab of gateTabs">
-          <a (click)="openTab(tab)">{{ tab.label }}</a>
+          <button
+            type="button"
+            class="submenu-item"
+            [class.coming-soon]="tab.disabled"
+            [disabled]="tab.disabled"
+            (click)="handleTabSelection($event, tab)"
+          >
+            <span>{{ tab.label }}</span>
+            <span *ngIf="tab.disabled" class="submenu-badge">{{ tab.comingSoonMessage || 'Em breve' }}</span>
+          </button>
         </li>
       </ul>
     </li>
     <li *ngIf="userTabs.length" (click)="toggleSubmenu($event)">
-      <a href="#">Usuários</a>
+      <button type="button" class="submenu-trigger">Usuários</button>
       <ul>
         <li *ngFor="let tab of userTabs">
-          <a (click)="openTab(tab)">{{ tab.label }}</a>
+          <button
+            type="button"
+            class="submenu-item"
+            [class.coming-soon]="tab.disabled"
+            [disabled]="tab.disabled"
+            (click)="handleTabSelection($event, tab)"
+          >
+            <span>{{ tab.label }}</span>
+            <span *ngIf="tab.disabled" class="submenu-badge">{{ tab.comingSoonMessage || 'Em breve' }}</span>
+          </button>
         </li>
       </ul>
     </li>


### PR DESCRIPTION
## Resumo
- Expõe somente rotas filhas de funcionalidades reais sob /home e mantém redirecionamento padrão para Role
- Passa a definir rotas explícitas no registro de abas e reutiliza os mesmos segmentos ao navegar
- Atualiza o menu para usar botões com estado "Em breve" quando a funcionalidade não existe e evita navegação indevida

## Testes
- `npm run build` *(falhou: ng não está disponível no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68eebad0ae748327984a61a5fc34a960