### PR TITLE
Integra lista de usuários com backend real

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/UserController.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/UserController.java
@@ -1,0 +1,30 @@
+package br.com.cloudport.servicoautenticacao.controllers;
+
+import br.com.cloudport.servicoautenticacao.dto.UserSummaryDTO;
+import br.com.cloudport.servicoautenticacao.services.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/usuarios")
+public class UserController {
+
+    private final UserService userService;
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN_PORTO')")
+    public ResponseEntity<List<UserSummaryDTO>> listarUsuarios() {
+        return ResponseEntity.ok(userService.listarUsuariosResumo());
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/UserSummaryDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/dto/UserSummaryDTO.java
@@ -1,0 +1,44 @@
+package br.com.cloudport.servicoautenticacao.dto;
+
+import br.com.cloudport.servicoautenticacao.model.User;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserSummaryDTO {
+    private final UUID id;
+    private final String nome;
+    private final String email;
+    private final String status;
+
+    public UserSummaryDTO(UUID id, String nome, String email, String status) {
+        this.id = id;
+        this.nome = nome;
+        this.email = email;
+        this.status = status;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public static UserSummaryDTO fromUser(User user) {
+        String nome = user.getNome() != null && !user.getNome().isBlank() ? user.getNome() : user.getLogin();
+        String email = user.getLogin();
+        String status = user.isEnabled() ? "Ativo" : "Inativo";
+        return new UserSummaryDTO(user.getId(), nome, email, status);
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/services/UserService.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/services/UserService.java
@@ -1,0 +1,27 @@
+package br.com.cloudport.servicoautenticacao.services;
+
+import br.com.cloudport.servicoautenticacao.dto.UserSummaryDTO;
+import br.com.cloudport.servicoautenticacao.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<UserSummaryDTO> listarUsuariosResumo() {
+        return userRepository.findAll()
+                .stream()
+                .map(UserSummaryDTO::fromUser)
+                .collect(Collectors.toList());
+    }
+}

--- a/frontend/cloudport/src/app/componentes/service/endpoint.ts
+++ b/frontend/cloudport/src/app/componentes/service/endpoint.ts
@@ -8,10 +8,10 @@ export const environment = {
         logout: `${baseLink}/auth/logout`
     },
     users: {
-        getAll: `${baseLink}/users/all`,
-        getById: (id: number) => `${baseLink}/users/${id}`,
-        update: `${baseLink}/users/update`,
-        delete: `${baseLink}/users/delete`
+        getAll: `${baseLink}/api/usuarios`,
+        getByLogin: (login: string) => `${baseLink}/auth/usuarios/${login}`,
+        update: `${baseLink}/auth/usuarios`,
+        delete: `${baseLink}/auth/usuarios`
     },
     role: {
         create: `${baseLink}/api/roles`,

--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/usuarios.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/usuarios.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+
+import { environment as endpointConfig } from '../../service/endpoint';
+
+export interface UsuarioResumo {
+  id: string;
+  nome: string;
+  email: string;
+  status: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UsuariosService {
+  constructor(private http: HttpClient) {}
+
+  listarUsuarios(): Observable<UsuarioResumo[]> {
+    return this.http.get<UsuarioResumo[]>(endpointConfig.users.getAll).pipe(
+      map((usuarios) =>
+        (usuarios ?? []).map((usuario) => ({
+          ...usuario,
+          status: usuario.status ?? 'Ativo'
+        }))
+        .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR', { sensitivity: 'base' }))
+      )
+    );
+  }
+}

--- a/frontend/cloudport/src/app/componentes/usuarios-lista/usuarios-lista.component.css
+++ b/frontend/cloudport/src/app/componentes/usuarios-lista/usuarios-lista.component.css
@@ -20,3 +20,20 @@
 .usuarios-lista .inativo {
   color: #c53030;
 }
+
+.usuarios-lista .estado {
+  margin: 1rem 0;
+  font-weight: 500;
+}
+
+.usuarios-lista .estado-carregamento {
+  color: #2f80ed;
+}
+
+.usuarios-lista .estado-erro {
+  color: #c53030;
+}
+
+.usuarios-lista .estado-vazio {
+  color: #4a5568;
+}

--- a/frontend/cloudport/src/app/componentes/usuarios-lista/usuarios-lista.component.html
+++ b/frontend/cloudport/src/app/componentes/usuarios-lista/usuarios-lista.component.html
@@ -1,7 +1,13 @@
 <section class="usuarios-lista">
   <h2>Lista de Usuários</h2>
   <p>Resumo dos usuários cadastrados no sistema.</p>
-  <table>
+  <div *ngIf="estaCarregando" class="estado estado-carregamento">Carregando usuários...</div>
+  <div *ngIf="!estaCarregando && erroCarregamento" class="estado estado-erro">{{ erroCarregamento }}</div>
+  <p *ngIf="!estaCarregando && !erroCarregamento && usuarios.length === 0" class="estado estado-vazio">
+    Nenhum usuário cadastrado até o momento.
+  </p>
+
+  <table *ngIf="!estaCarregando && !erroCarregamento && usuarios.length > 0">
     <thead>
       <tr>
         <th>Nome</th>


### PR DESCRIPTION
## Summary
- criar DTO, serviço e controller para disponibilizar resumo de usuários a partir do banco via /api/usuarios
- ajustar frontend para consumir o endpoint real, removendo mocks e exibindo estados de carregamento/erro
- alinhar mapeamento de endpoints do frontend com as rotas efetivas do backend

## Testing
- mvn -f backend/servico-autenticacao/pom.xml test *(falha: repositório Maven central bloqueado no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68eed03ad6b48327ae387bf6c600ee4f