### PR TITLE
Reorganiza funcionalidade de roles no serviço de autenticação

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/role/PapelControlador.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/role/PapelControlador.java
@@ -1,7 +1,6 @@
-package br.com.cloudport.servicoautenticacao.controllers;
+package br.com.cloudport.servicoautenticacao.app.role;
 
-import br.com.cloudport.servicoautenticacao.app.administracao.dto.PapelDTO;
-import br.com.cloudport.servicoautenticacao.services.PapelService;
+import br.com.cloudport.servicoautenticacao.app.role.dto.PapelDTO;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,41 +14,41 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/roles")
-public class PapelController {
+public class PapelControlador {
 
-    private final PapelService papelService;
+    private final PapelServico papelServico;
 
-    public PapelController(PapelService papelService) {
-        this.papelService = papelService;
+    public PapelControlador(PapelServico papelServico) {
+        this.papelServico = papelServico;
     }
 
     @PostMapping
     public ResponseEntity<PapelDTO> criarPapel(@RequestBody PapelDTO papelDTO) {
-        PapelDTO papelSalvo = papelService.salvarPapel(papelDTO);
+        PapelDTO papelSalvo = papelServico.salvarPapel(papelDTO);
         return ResponseEntity.ok(papelSalvo);
     }
 
     @GetMapping("/{nome}")
     public ResponseEntity<PapelDTO> buscarPapel(@PathVariable String nome) {
-        PapelDTO papel = papelService.buscarPorNome(nome);
+        PapelDTO papel = papelServico.buscarPorNome(nome);
         return ResponseEntity.ok(papel);
     }
 
     @GetMapping
     public ResponseEntity<List<PapelDTO>> listarPapeis() {
-        List<PapelDTO> papeis = papelService.listarTodos();
+        List<PapelDTO> papeis = papelServico.listarTodos();
         return ResponseEntity.ok(papeis);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<PapelDTO> atualizarPapel(@PathVariable Long id, @RequestBody PapelDTO papelDTO) {
-        PapelDTO papelAtualizado = papelService.atualizar(id, papelDTO);
+        PapelDTO papelAtualizado = papelServico.atualizar(id, papelDTO);
         return ResponseEntity.ok(papelAtualizado);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> removerPapel(@PathVariable Long id) {
-        papelService.remover(id);
+        papelServico.remover(id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/role/PapelServico.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/role/PapelServico.java
@@ -1,6 +1,6 @@
-package br.com.cloudport.servicoautenticacao.services;
+package br.com.cloudport.servicoautenticacao.app.role;
 
-import br.com.cloudport.servicoautenticacao.app.administracao.dto.PapelDTO;
+import br.com.cloudport.servicoautenticacao.app.role.dto.PapelDTO;
 import br.com.cloudport.servicoautenticacao.exception.PapelNaoEncontradoException;
 import br.com.cloudport.servicoautenticacao.model.Papel;
 import br.com.cloudport.servicoautenticacao.repositories.PapelRepositorio;
@@ -12,12 +12,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class PapelService {
+public class PapelServico {
 
     private final PapelRepositorio papelRepositorio;
     private final UsuarioPapelRepositorio usuarioPapelRepositorio;
 
-    public PapelService(PapelRepositorio papelRepositorio, UsuarioPapelRepositorio usuarioPapelRepositorio) {
+    public PapelServico(PapelRepositorio papelRepositorio, UsuarioPapelRepositorio usuarioPapelRepositorio) {
         this.papelRepositorio = papelRepositorio;
         this.usuarioPapelRepositorio = usuarioPapelRepositorio;
     }

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/role/dto/PapelDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/role/dto/PapelDTO.java
@@ -1,4 +1,4 @@
-package br.com.cloudport.servicoautenticacao.app.administracao.dto;
+package br.com.cloudport.servicoautenticacao.app.role.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/app/role/PapelServicoTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/app/role/PapelServicoTest.java
@@ -1,6 +1,6 @@
-package br.com.cloudport.servicoautenticacao.services;
+package br.com.cloudport.servicoautenticacao.app.role;
 
-import br.com.cloudport.servicoautenticacao.app.administracao.dto.PapelDTO;
+import br.com.cloudport.servicoautenticacao.app.role.dto.PapelDTO;
 import br.com.cloudport.servicoautenticacao.model.Papel;
 import br.com.cloudport.servicoautenticacao.repositories.PapelRepositorio;
 import br.com.cloudport.servicoautenticacao.repositories.UsuarioPapelRepositorio;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-class PapelServiceTest {
+class PapelServicoTest {
 
     @Mock
     private PapelRepositorio papelRepositorio;
@@ -24,7 +24,7 @@ class PapelServiceTest {
     private UsuarioPapelRepositorio usuarioPapelRepositorio;
 
     @InjectMocks
-    private PapelService papelService;
+    private PapelServico papelServico;
 
     @BeforeEach
     void setUp() {
@@ -43,7 +43,7 @@ class PapelServiceTest {
             return papel;
         });
 
-        PapelDTO resultado = papelService.salvarPapel(dto);
+        PapelDTO resultado = papelServico.salvarPapel(dto);
 
         assertNotNull(resultado.getId());
         assertEquals("ADMIN", resultado.getNome());
@@ -57,7 +57,7 @@ class PapelServiceTest {
 
         when(papelRepositorio.findByNome("ADMIN")).thenReturn(Optional.of(new Papel("ADMIN")));
 
-        assertThrows(IllegalArgumentException.class, () -> papelService.salvarPapel(dto));
+        assertThrows(IllegalArgumentException.class, () -> papelServico.salvarPapel(dto));
         verify(papelRepositorio, never()).save(any());
     }
 }

--- a/docs/relatorios/reorganizacao-role.txt
+++ b/docs/relatorios/reorganizacao-role.txt
@@ -1,0 +1,16 @@
+Relatório Técnico - Funcionalidade Role
+
+Classes movidas:
+- app/role/PapelControlador.java (anteriormente em controllers/PapelController.java)
+- app/role/PapelServico.java (anteriormente em services/PapelService.java)
+- app/role/dto/PapelDTO.java (anteriormente em app/administracao/dto/PapelDTO.java)
+- teste app/role/PapelServicoTest.java (anteriormente em services/PapelServiceTest.java)
+
+Entidades renomeadas:
+- Serviço: PapelService -> PapelServico
+- Controlador: PapelController -> PapelControlador
+
+Mocks ou dados simulados removidos: não aplicável (nenhum mock residual identificado além dos usados em testes unitários).
+
+Imports ajustados:
+- Atualização dos imports para refletir o novo pacote br.com.cloudport.servicoautenticacao.app.role e o subpacote dto.


### PR DESCRIPTION
## Resumo
- organiza a funcionalidade de roles em um pacote dedicado `app.role`, alinhado ao módulo do frontend
- renomeia controlador e serviço para nomenclatura em português e ajusta o DTO correspondente
- atualiza testes e adiciona relatório técnico com os arquivos movidos e ajustes realizados

## Testes
- mvnw test *(falha por falta de acesso à rede ao baixar dependências)*

------
https://chatgpt.com/codex/tasks/task_e_68ef8032009083278c713e7c42521948