### PR TITLE
Define esquema padrão do Flyway para cloudport

### DIFF
--- a/backend/servico-gate/src/main/resources/application.properties
+++ b/backend/servico-gate/src/main/resources/application.properties
@@ -11,6 +11,8 @@ spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+spring.flyway.default-schema=${GATE_FLYWAY_SCHEMA:cloudport}
+spring.flyway.schemas=${GATE_FLYWAY_SCHEMA:cloudport}
 
 spring.rabbitmq.host=${GATE_RABBIT_HOST:localhost}
 spring.rabbitmq.port=${GATE_RABBIT_PORT:5672}

--- a/backend/servico-gate/src/test/resources/application-test.properties
+++ b/backend/servico-gate/src/test/resources/application-test.properties
@@ -11,6 +11,8 @@ spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+spring.flyway.default-schema=${GATE_FLYWAY_SCHEMA:cloudport}
+spring.flyway.schemas=${GATE_FLYWAY_SCHEMA:cloudport}
 
 spring.rabbitmq.host=${GATE_RABBIT_HOST:localhost}
 spring.rabbitmq.port=${GATE_RABBIT_PORT:5672}


### PR DESCRIPTION
## Summary
- configura o Flyway para utilizar o schema cloudport por padrão no serviço de gate
- aplica a mesma configuração para o perfil de testes do serviço

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ef83a89ea4832796ff70918b7df5e5