### PR TITLE
Integra privacidade com backend real e sanitização de conteúdo

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/ConfiguracaoPrivacidade.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/ConfiguracaoPrivacidade.java
@@ -1,0 +1,48 @@
+package br.com.cloudport.servicoautenticacao.app.privacidade;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "configuracoes_privacidade")
+public class ConfiguracaoPrivacidade {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Column(name = "descricao", nullable = false, length = 255)
+    private String descricao;
+
+    @Column(name = "ativo", nullable = false)
+    private boolean ativo;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public boolean isAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(boolean ativo) {
+        this.ativo = ativo;
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/ConfiguracaoPrivacidadeRepositorio.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/ConfiguracaoPrivacidadeRepositorio.java
@@ -1,0 +1,7 @@
+package br.com.cloudport.servicoautenticacao.app.privacidade;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConfiguracaoPrivacidadeRepositorio extends JpaRepository<ConfiguracaoPrivacidade, UUID> {
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/PrivacidadeConsultaServico.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/PrivacidadeConsultaServico.java
@@ -1,0 +1,31 @@
+package br.com.cloudport.servicoautenticacao.app.privacidade;
+
+import br.com.cloudport.servicoautenticacao.app.privacidade.dto.OpcaoPrivacidadeRespostaDTO;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PrivacidadeConsultaServico {
+
+    private final ConfiguracaoPrivacidadeRepositorio configuracaoPrivacidadeRepositorio;
+    private final SanitizadorConteudoPrivacidade sanitizadorConteudoPrivacidade;
+
+    public PrivacidadeConsultaServico(
+            ConfiguracaoPrivacidadeRepositorio configuracaoPrivacidadeRepositorio,
+            SanitizadorConteudoPrivacidade sanitizadorConteudoPrivacidade
+    ) {
+        this.configuracaoPrivacidadeRepositorio = configuracaoPrivacidadeRepositorio;
+        this.sanitizadorConteudoPrivacidade = sanitizadorConteudoPrivacidade;
+    }
+
+    public List<OpcaoPrivacidadeRespostaDTO> listarOpcoes() {
+        return configuracaoPrivacidadeRepositorio.findAll()
+                .stream()
+                .map(opcao -> OpcaoPrivacidadeRespostaDTO.fromModelo(
+                        opcao,
+                        sanitizadorConteudoPrivacidade.sanitizarDescricao(opcao.getDescricao())
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/PrivacidadeController.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/PrivacidadeController.java
@@ -1,0 +1,26 @@
+package br.com.cloudport.servicoautenticacao.app.privacidade;
+
+import br.com.cloudport.servicoautenticacao.app.privacidade.dto.OpcaoPrivacidadeRespostaDTO;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/configuracoes/privacidade")
+public class PrivacidadeController {
+
+    private final PrivacidadeConsultaServico privacidadeConsultaServico;
+
+    public PrivacidadeController(PrivacidadeConsultaServico privacidadeConsultaServico) {
+        this.privacidadeConsultaServico = privacidadeConsultaServico;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE')")
+    public ResponseEntity<List<OpcaoPrivacidadeRespostaDTO>> listarOpcoes() {
+        return ResponseEntity.ok(privacidadeConsultaServico.listarOpcoes());
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/SanitizadorConteudoPrivacidade.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/SanitizadorConteudoPrivacidade.java
@@ -1,0 +1,20 @@
+package br.com.cloudport.servicoautenticacao.app.privacidade;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SanitizadorConteudoPrivacidade {
+
+    public String sanitizarDescricao(String descricao) {
+        if (descricao == null) {
+            return "";
+        }
+        String semScripts = descricao.replaceAll("(?i)<script.*?>.*?</script>", "");
+        String semTags = semScripts.replaceAll("<[^>]+>", "");
+        return semTags
+                .replace("\"", "")
+                .replace("'", "")
+                .replace("`", "")
+                .trim();
+    }
+}

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/dto/OpcaoPrivacidadeRespostaDTO.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/app/privacidade/dto/OpcaoPrivacidadeRespostaDTO.java
@@ -1,0 +1,52 @@
+package br.com.cloudport.servicoautenticacao.app.privacidade.dto;
+
+import br.com.cloudport.servicoautenticacao.app.privacidade.ConfiguracaoPrivacidade;
+import java.util.UUID;
+
+public class OpcaoPrivacidadeRespostaDTO {
+
+    private UUID id;
+    private String descricao;
+    private boolean ativo;
+
+    public OpcaoPrivacidadeRespostaDTO() {
+    }
+
+    public OpcaoPrivacidadeRespostaDTO(UUID id, String descricao, boolean ativo) {
+        this.id = id;
+        this.descricao = descricao;
+        this.ativo = ativo;
+    }
+
+    public static OpcaoPrivacidadeRespostaDTO fromModelo(ConfiguracaoPrivacidade configuracao, String descricaoSanitizada) {
+        return new OpcaoPrivacidadeRespostaDTO(
+                configuracao.getId(),
+                descricaoSanitizada,
+                configuracao.isAtivo()
+        );
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public boolean isAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(boolean ativo) {
+        this.ativo = ativo;
+    }
+}

--- a/backend/servico-autenticacao/src/main/resources/db/migration/V4__create_tabela_configuracoes_privacidade.sql
+++ b/backend/servico-autenticacao/src/main/resources/db/migration/V4__create_tabela_configuracoes_privacidade.sql
@@ -1,0 +1,15 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS configuracoes_privacidade (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    descricao VARCHAR(255) NOT NULL,
+    ativo BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT uk_configuracoes_privacidade_descricao UNIQUE (descricao)
+);
+
+INSERT INTO configuracoes_privacidade (descricao, ativo)
+VALUES
+    ('Permitir compartilhamento de dados com parceiros', FALSE),
+    ('Mostrar minha atividade para outros usuários', FALSE),
+    ('Receber relatórios de auditoria mensais', TRUE)
+ON CONFLICT (descricao) DO NOTHING;

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/app/privacidade/PrivacidadeConsultaServicoTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/app/privacidade/PrivacidadeConsultaServicoTest.java
@@ -1,0 +1,50 @@
+package br.com.cloudport.servicoautenticacao.app.privacidade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import br.com.cloudport.servicoautenticacao.app.privacidade.dto.OpcaoPrivacidadeRespostaDTO;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PrivacidadeConsultaServicoTest {
+
+    @Mock
+    private ConfiguracaoPrivacidadeRepositorio configuracaoPrivacidadeRepositorio;
+
+    @Mock
+    private SanitizadorConteudoPrivacidade sanitizadorConteudoPrivacidade;
+
+    @InjectMocks
+    private PrivacidadeConsultaServico privacidadeConsultaServico;
+
+    @BeforeEach
+    void configurar() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void deveSanitizarDescricoesAntesDeRetornarOpcoes() {
+        ConfiguracaoPrivacidade configuracao = new ConfiguracaoPrivacidade();
+        configuracao.setId(UUID.randomUUID());
+        configuracao.setDescricao("<script>alert('xss')</script><b>Texto Seguro</b>");
+        configuracao.setAtivo(true);
+
+        when(configuracaoPrivacidadeRepositorio.findAll()).thenReturn(List.of(configuracao));
+        when(sanitizadorConteudoPrivacidade.sanitizarDescricao(configuracao.getDescricao())).thenReturn("Texto Seguro");
+
+        List<OpcaoPrivacidadeRespostaDTO> resposta = privacidadeConsultaServico.listarOpcoes();
+
+        assertThat(resposta)
+                .hasSize(1)
+                .allSatisfy(opcao -> {
+                    assertThat(opcao.getDescricao()).isEqualTo("Texto Seguro");
+                    assertThat(opcao.isAtivo()).isTrue();
+                });
+    }
+}

--- a/frontend/cloudport/src/app/app.module.ts
+++ b/frontend/cloudport/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { PrivacidadeComponent } from './componentes/privacidade/privacidade.comp
 import { UsuariosListaComponent } from './componentes/usuarios-lista/usuarios-lista.component';
 import { DynamicTableModule } from './componentes/dynamic-table/dynamic-table.module';
 import { ConfirmacaoModalComponent } from './componentes/modal/confirmacao-modal/confirmacao-modal.component';
+import { TextoSeguroPipe } from './componentes/pipes/texto-seguro.pipe';
 
 @NgModule({
   declarations: [
@@ -45,6 +46,7 @@ import { ConfirmacaoModalComponent } from './componentes/modal/confirmacao-modal
     NotificacoesComponent,
     PrivacidadeComponent,
     UsuariosListaComponent,
+    TextoSeguroPipe,
 
   ],
   imports: [

--- a/frontend/cloudport/src/app/componentes/pipes/texto-seguro.pipe.spec.ts
+++ b/frontend/cloudport/src/app/componentes/pipes/texto-seguro.pipe.spec.ts
@@ -1,0 +1,13 @@
+import { TextoSeguroPipe } from './texto-seguro.pipe';
+import { SanitizadorConteudoService } from '../service/sanitizacao/sanitizador-conteudo.service';
+
+describe('TextoSeguroPipe', () => {
+  it('deve remover scripts e escapar caracteres perigosos', () => {
+    const sanitizador = new SanitizadorConteudoService();
+    const pipe = new TextoSeguroPipe(sanitizador);
+
+    const resultado = pipe.transform("<script>alert('xss')</script><b>Texto</b>");
+
+    expect(resultado).toBe('Texto');
+  });
+});

--- a/frontend/cloudport/src/app/componentes/pipes/texto-seguro.pipe.ts
+++ b/frontend/cloudport/src/app/componentes/pipes/texto-seguro.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { SanitizadorConteudoService } from '../service/sanitizacao/sanitizador-conteudo.service';
+
+@Pipe({
+  name: 'textoSeguro'
+})
+export class TextoSeguroPipe implements PipeTransform {
+  constructor(private readonly sanitizadorConteudo: SanitizadorConteudoService) {}
+
+  transform(valor: string | null | undefined): string {
+    return this.sanitizadorConteudo.sanitizar(valor);
+  }
+}

--- a/frontend/cloudport/src/app/componentes/privacidade/privacidade.component.html
+++ b/frontend/cloudport/src/app/componentes/privacidade/privacidade.component.html
@@ -1,12 +1,21 @@
 <section class="privacidade">
   <h2>Centro de Privacidade</h2>
   <p>Ajuste como seus dados são utilizados dentro da plataforma.</p>
-  <ul>
+  <div *ngIf="carregando" class="estado-carregamento" aria-live="polite">
+    Carregando opções de privacidade...
+  </div>
+
+  <div *ngIf="!carregando && mensagemErro" class="estado-erro" role="alert">
+    <p>{{ mensagemErro }}</p>
+    <button type="button" class="btn primario" (click)="recarregar()">Tentar novamente</button>
+  </div>
+
+  <ul *ngIf="!carregando && !mensagemErro">
     <li *ngFor="let opcao of opcoes">
       <span class="status" [class.ativo]="opcao.ativo" [class.inativo]="!opcao.ativo">
         {{ opcao.ativo ? 'Ativo' : 'Inativo' }}
       </span>
-      {{ opcao.descricao }}
+      {{ opcao.descricao | textoSeguro }}
     </li>
   </ul>
 </section>

--- a/frontend/cloudport/src/app/componentes/privacidade/privacidade.component.ts
+++ b/frontend/cloudport/src/app/componentes/privacidade/privacidade.component.ts
@@ -1,14 +1,52 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject, of } from 'rxjs';
+import { catchError, finalize, takeUntil } from 'rxjs/operators';
+import { OpcaoPrivacidade, PrivacidadeService } from '../service/privacidade/privacidade.service';
 
 @Component({
   selector: 'app-privacidade',
   templateUrl: './privacidade.component.html',
   styleUrls: ['./privacidade.component.css']
 })
-export class PrivacidadeComponent {
-  opcoes: { descricao: string; ativo: boolean }[] = [
-    { descricao: 'Permitir compartilhamento de dados com parceiros', ativo: false },
-    { descricao: 'Mostrar minha atividade para outros usuários', ativo: false },
-    { descricao: 'Receber relatórios de auditoria mensais', ativo: true }
-  ];
+export class PrivacidadeComponent implements OnInit, OnDestroy {
+  opcoes: OpcaoPrivacidade[] = [];
+  carregando = false;
+  mensagemErro: string | null = null;
+
+  private readonly destruir$ = new Subject<void>();
+
+  constructor(private readonly privacidadeService: PrivacidadeService) {}
+
+  ngOnInit(): void {
+    this.carregarOpcoes();
+  }
+
+  ngOnDestroy(): void {
+    this.destruir$.next();
+    this.destruir$.complete();
+  }
+
+  recarregar(): void {
+    this.carregarOpcoes();
+  }
+
+  private carregarOpcoes(): void {
+    this.carregando = true;
+    this.mensagemErro = null;
+    this.privacidadeService
+      .listarOpcoes()
+      .pipe(
+        takeUntil(this.destruir$),
+        catchError(() => {
+          this.mensagemErro = 'Não foi possível carregar as opções de privacidade. Tente novamente.';
+          return of([]);
+        }),
+        finalize(() => {
+          this.carregando = false;
+        })
+      )
+      .subscribe((opcoes) => {
+        this.opcoes = opcoes;
+      });
+  }
 }

--- a/frontend/cloudport/src/app/componentes/service/endpoint.ts
+++ b/frontend/cloudport/src/app/componentes/service/endpoint.ts
@@ -7,6 +7,9 @@ export const environment = {
         login: `${baseLink}/auth/login`,
         logout: `${baseLink}/auth/logout`
     },
+    configuracoes: {
+        privacidade: `${baseLink}/api/configuracoes/privacidade`
+    },
     users: {
         getAll: `${baseLink}/api/usuarios`,
         getByLogin: (login: string) => `${baseLink}/auth/usuarios/${login}`,

--- a/frontend/cloudport/src/app/componentes/service/privacidade/privacidade.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/privacidade/privacidade.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as endpointConfig } from '../endpoint';
+
+export interface OpcaoPrivacidade {
+  id: string;
+  descricao: string;
+  ativo: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PrivacidadeService {
+  constructor(private readonly http: HttpClient) {}
+
+  listarOpcoes(): Observable<OpcaoPrivacidade[]> {
+    return this.http.get<OpcaoPrivacidade[]>(endpointConfig.configuracoes.privacidade);
+  }
+}

--- a/frontend/cloudport/src/app/componentes/service/sanitizacao/sanitizador-conteudo.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/sanitizacao/sanitizador-conteudo.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SanitizadorConteudoService {
+  sanitizar(texto: string | null | undefined): string {
+    if (!texto) {
+      return '';
+    }
+    const semScripts = texto.replace(/<script.*?>.*?<\/script>/gis, '');
+    const semTags = semScripts.replace(/<[^>]+>/g, '');
+    return semTags.replace(/["'`]/g, '').trim();
+  }
+}


### PR DESCRIPTION
## Resumo
- cria a funcionalidade de configurações de privacidade no backend com entidade, repositório, serviço, controlador e migração de dados reais
- adiciona sanitização de descrições de privacidade tanto no backend quanto no frontend com testes automatizados
- consome o endpoint recém-criado na tela de privacidade do frontend exibindo estados de carregamento e erro em português

## Testes
- mvn -q test *(falhou: acesso proibido ao repositório Maven central durante a resolução do parent POM)*
- npm install *(falhou: acesso proibido ao pacote @playwright/test no registro npm)*

------
https://chatgpt.com/codex/tasks/task_e_68f2f3a8b784832789593b2cef7e7b27