### PR TITLE
feat: criar telas integradas para gestão do pátio

### DIFF
--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/controlador/MapaPatioControlador.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/controlador/MapaPatioControlador.java
@@ -7,6 +7,9 @@ import br.com.cloudport.servicoyard.patio.dto.EquipamentoPatioRequisicaoDto;
 import br.com.cloudport.servicoyard.patio.dto.FiltrosMapaPatioDto;
 import br.com.cloudport.servicoyard.patio.dto.MapaPatioFiltro;
 import br.com.cloudport.servicoyard.patio.dto.MapaPatioRespostaDto;
+import br.com.cloudport.servicoyard.patio.dto.MovimentoPatioDto;
+import br.com.cloudport.servicoyard.patio.dto.OpcoesCadastroPatioDto;
+import br.com.cloudport.servicoyard.patio.dto.PosicaoPatioDto;
 import br.com.cloudport.servicoyard.patio.servico.MapaPatioServico;
 import java.util.List;
 import javax.validation.Valid;
@@ -43,6 +46,26 @@ public class MapaPatioControlador {
     @GetMapping("/filtros")
     public FiltrosMapaPatioDto consultarFiltros() {
         return mapaPatioServico.consultarFiltros();
+    }
+
+    @GetMapping("/posicoes")
+    public List<PosicaoPatioDto> listarPosicoes() {
+        return mapaPatioServico.listarPosicoes();
+    }
+
+    @GetMapping("/conteineres")
+    public List<ConteinerMapaDto> listarConteineres() {
+        return mapaPatioServico.listarConteineres();
+    }
+
+    @GetMapping("/movimentacoes")
+    public List<MovimentoPatioDto> listarMovimentacoes() {
+        return mapaPatioServico.listarMovimentacoesRecentes();
+    }
+
+    @GetMapping("/opcoes")
+    public OpcoesCadastroPatioDto consultarOpcoesCadastro() {
+        return mapaPatioServico.consultarOpcoesCadastro();
     }
 
     @PostMapping("/conteineres")

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/dto/MovimentoPatioDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/dto/MovimentoPatioDto.java
@@ -1,0 +1,106 @@
+package br.com.cloudport.servicoyard.patio.dto;
+
+import br.com.cloudport.servicoyard.patio.modelo.TipoMovimentoPatio;
+import java.time.LocalDateTime;
+
+public class MovimentoPatioDto {
+
+    private Long id;
+    private String codigoConteiner;
+    private TipoMovimentoPatio tipoMovimento;
+    private String descricao;
+    private String destino;
+    private Integer linha;
+    private Integer coluna;
+    private String camadaOperacional;
+    private LocalDateTime registradoEm;
+
+    public MovimentoPatioDto() {
+    }
+
+    public MovimentoPatioDto(Long id, String codigoConteiner, TipoMovimentoPatio tipoMovimento,
+                              String descricao, String destino, Integer linha, Integer coluna,
+                              String camadaOperacional, LocalDateTime registradoEm) {
+        this.id = id;
+        this.codigoConteiner = codigoConteiner;
+        this.tipoMovimento = tipoMovimento;
+        this.descricao = descricao;
+        this.destino = destino;
+        this.linha = linha;
+        this.coluna = coluna;
+        this.camadaOperacional = camadaOperacional;
+        this.registradoEm = registradoEm;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public TipoMovimentoPatio getTipoMovimento() {
+        return tipoMovimento;
+    }
+
+    public void setTipoMovimento(TipoMovimentoPatio tipoMovimento) {
+        this.tipoMovimento = tipoMovimento;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getDestino() {
+        return destino;
+    }
+
+    public void setDestino(String destino) {
+        this.destino = destino;
+    }
+
+    public Integer getLinha() {
+        return linha;
+    }
+
+    public void setLinha(Integer linha) {
+        this.linha = linha;
+    }
+
+    public Integer getColuna() {
+        return coluna;
+    }
+
+    public void setColuna(Integer coluna) {
+        this.coluna = coluna;
+    }
+
+    public String getCamadaOperacional() {
+        return camadaOperacional;
+    }
+
+    public void setCamadaOperacional(String camadaOperacional) {
+        this.camadaOperacional = camadaOperacional;
+    }
+
+    public LocalDateTime getRegistradoEm() {
+        return registradoEm;
+    }
+
+    public void setRegistradoEm(LocalDateTime registradoEm) {
+        this.registradoEm = registradoEm;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/dto/OpcoesCadastroPatioDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/dto/OpcoesCadastroPatioDto.java
@@ -1,0 +1,44 @@
+package br.com.cloudport.servicoyard.patio.dto;
+
+import java.util.List;
+
+public class OpcoesCadastroPatioDto {
+
+    private List<String> statusConteiner;
+    private List<String> tiposEquipamento;
+    private List<String> statusEquipamento;
+
+    public OpcoesCadastroPatioDto() {
+    }
+
+    public OpcoesCadastroPatioDto(List<String> statusConteiner, List<String> tiposEquipamento,
+                                  List<String> statusEquipamento) {
+        this.statusConteiner = statusConteiner;
+        this.tiposEquipamento = tiposEquipamento;
+        this.statusEquipamento = statusEquipamento;
+    }
+
+    public List<String> getStatusConteiner() {
+        return statusConteiner;
+    }
+
+    public void setStatusConteiner(List<String> statusConteiner) {
+        this.statusConteiner = statusConteiner;
+    }
+
+    public List<String> getTiposEquipamento() {
+        return tiposEquipamento;
+    }
+
+    public void setTiposEquipamento(List<String> tiposEquipamento) {
+        this.tiposEquipamento = tiposEquipamento;
+    }
+
+    public List<String> getStatusEquipamento() {
+        return statusEquipamento;
+    }
+
+    public void setStatusEquipamento(List<String> statusEquipamento) {
+        this.statusEquipamento = statusEquipamento;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/dto/PosicaoPatioDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/dto/PosicaoPatioDto.java
@@ -1,0 +1,84 @@
+package br.com.cloudport.servicoyard.patio.dto;
+
+import br.com.cloudport.servicoyard.patio.modelo.StatusConteiner;
+
+public class PosicaoPatioDto {
+
+    private Long id;
+    private Integer linha;
+    private Integer coluna;
+    private String camadaOperacional;
+    private boolean ocupada;
+    private String codigoConteiner;
+    private StatusConteiner statusConteiner;
+
+    public PosicaoPatioDto() {
+    }
+
+    public PosicaoPatioDto(Long id, Integer linha, Integer coluna, String camadaOperacional,
+                           boolean ocupada, String codigoConteiner, StatusConteiner statusConteiner) {
+        this.id = id;
+        this.linha = linha;
+        this.coluna = coluna;
+        this.camadaOperacional = camadaOperacional;
+        this.ocupada = ocupada;
+        this.codigoConteiner = codigoConteiner;
+        this.statusConteiner = statusConteiner;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getLinha() {
+        return linha;
+    }
+
+    public void setLinha(Integer linha) {
+        this.linha = linha;
+    }
+
+    public Integer getColuna() {
+        return coluna;
+    }
+
+    public void setColuna(Integer coluna) {
+        this.coluna = coluna;
+    }
+
+    public String getCamadaOperacional() {
+        return camadaOperacional;
+    }
+
+    public void setCamadaOperacional(String camadaOperacional) {
+        this.camadaOperacional = camadaOperacional;
+    }
+
+    public boolean isOcupada() {
+        return ocupada;
+    }
+
+    public void setOcupada(boolean ocupada) {
+        this.ocupada = ocupada;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public StatusConteiner getStatusConteiner() {
+        return statusConteiner;
+    }
+
+    public void setStatusConteiner(StatusConteiner statusConteiner) {
+        this.statusConteiner = statusConteiner;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/repositorio/MovimentoPatioRepositorio.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/repositorio/MovimentoPatioRepositorio.java
@@ -1,7 +1,10 @@
 package br.com.cloudport.servicoyard.patio.repositorio;
 
 import br.com.cloudport.servicoyard.patio.modelo.MovimentoPatio;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MovimentoPatioRepositorio extends JpaRepository<MovimentoPatio, Long> {
+
+    List<MovimentoPatio> findTop50ByOrderByRegistradoEmDesc();
 }

--- a/frontend/cloudport/src/app/app-routing.module.ts
+++ b/frontend/cloudport/src/app/app-routing.module.ts
@@ -41,6 +41,8 @@ const homeChildRoutes: Routes = [
   },
   {
     path: 'patio',
+    canActivate: [AuthGuard],
+    canLoad: [AuthGuard],
     loadChildren: () => import('./componentes/patio/patio.module').then(m => m.PatioModule)
   }
 ];
@@ -51,6 +53,7 @@ const routes: Routes = [
     path: 'home',
     component: HomeComponent,
     canActivate: [AuthGuard],
+    canActivateChild: [AuthGuard],
     children: homeChildRoutes
   },
   { path: '', redirectTo: 'home', pathMatch: 'full' }

--- a/frontend/cloudport/src/app/componentes/navbar/TabService.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/TabService.ts
@@ -19,7 +19,10 @@ export const TAB_REGISTRY: Readonly<Record<string, TabItem>> = {
   'lista-de-usuarios': { id: 'lista-de-usuarios', label: 'Lista de usuários', route: ['lista-de-usuarios'] },
   'gate/agendamentos': { id: 'gate/agendamentos', label: 'Agendamentos do Gate', route: ['gate', 'agendamentos'] },
   'gate/janelas': { id: 'gate/janelas', label: 'Janelas de Atendimento', route: ['gate', 'janelas'] },
-  'patio/mapa': { id: 'patio/mapa', label: 'Mapa do Pátio', route: ['patio', 'mapa'] }
+  'patio/mapa': { id: 'patio/mapa', label: 'Mapa do Pátio', route: ['patio', 'mapa'] },
+  'patio/posicoes': { id: 'patio/posicoes', label: 'Posições do Pátio', route: ['patio', 'posicoes'] },
+  'patio/movimentacoes': { id: 'patio/movimentacoes', label: 'Movimentações do Pátio', route: ['patio', 'movimentacoes'] },
+  'patio/movimentacao': { id: 'patio/movimentacao', label: 'Registrar movimentação', route: ['patio', 'movimentacao'] }
 };
 
 export const VALID_TAB_IDS = new Set<string>(Object.keys(TAB_REGISTRY));

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -16,7 +16,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
   private readonly configurationTabIds = ['role', 'seguranca', 'notificacoes', 'privacidade'];
   private readonly userTabIds = ['lista-de-usuarios'];
   private readonly gateTabIds = ['gate/agendamentos', 'gate/janelas'];
-  private readonly yardTabIds = ['patio/mapa'];
+  private readonly yardTabIds = ['patio/mapa', 'patio/posicoes', 'patio/movimentacoes', 'patio/movimentacao'];
 
   private readonly tabRoles: Record<string, string[]> = {
     role: ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
@@ -26,7 +26,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
     'lista-de-usuarios': ['ROLE_ADMIN_PORTO'],
     'gate/agendamentos': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'],
     'gate/janelas': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'],
-    'patio/mapa': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR']
+    'patio/mapa': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
+    'patio/posicoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
+    'patio/movimentacoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
+    'patio/movimentacao': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR']
   };
 
   constructor(

--- a/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.css
+++ b/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.css
@@ -1,0 +1,99 @@
+.formulario-movimentacao {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.formulario-movimentacao header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.formularios {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 900px) {
+  .formularios {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.bloco {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background-color: #fdfdfd;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.campo input,
+.campo select {
+  padding: 8px;
+  border: 1px solid #cbd5e1;
+  border-radius: 4px;
+  font-size: 0.95rem;
+}
+
+.duas-colunas {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.acoes {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.acoes button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background-color: #2563eb;
+  color: #ffffff;
+}
+
+.acoes button.secundario {
+  background-color: #e2e8f0;
+  color: #1e293b;
+}
+
+.acoes button:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+}
+
+.mensagem {
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.mensagem.sucesso {
+  color: #15803d;
+}
+
+.mensagem.erro {
+  color: #b30021;
+}
+
+.estado {
+  font-size: 0.95rem;
+  color: #475569;
+}

--- a/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.html
+++ b/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.html
@@ -1,0 +1,105 @@
+<section class="formulario-movimentacao">
+  <header>
+    <h2>Registrar movimentações</h2>
+    <p>Atualize contêineres e equipamentos com segurança, garantindo dados consistentes.</p>
+  </header>
+
+  <div class="estado" *ngIf="carregandoOpcoes">Carregando opções de cadastro...</div>
+
+  <div class="formularios">
+    <form [formGroup]="formularioConteiner" (ngSubmit)="submeterConteiner()" class="bloco">
+      <h3>Movimentar contêiner</h3>
+      <div class="campo">
+        <label for="conteiner-id">Identificador interno</label>
+        <input id="conteiner-id" type="number" formControlName="id" placeholder="Informe para atualizar um registro existente" />
+      </div>
+      <div class="duas-colunas">
+        <div class="campo">
+          <label for="conteiner-codigo">Código do contêiner</label>
+          <input id="conteiner-codigo" type="text" formControlName="codigo" required />
+        </div>
+        <div class="campo">
+          <label for="conteiner-status">Status operacional</label>
+          <select id="conteiner-status" formControlName="status" required>
+            <option value="" disabled>Selecione</option>
+            <option *ngFor="let status of opcoes?.statusConteiner" [value]="status">{{ formatarRotulo(status) }}</option>
+          </select>
+        </div>
+      </div>
+      <div class="duas-colunas">
+        <div class="campo">
+          <label for="conteiner-linha">Linha</label>
+          <input id="conteiner-linha" type="number" formControlName="linha" min="0" required />
+        </div>
+        <div class="campo">
+          <label for="conteiner-coluna">Coluna</label>
+          <input id="conteiner-coluna" type="number" formControlName="coluna" min="0" required />
+        </div>
+      </div>
+      <div class="duas-colunas">
+        <div class="campo">
+          <label for="conteiner-tipo-carga">Tipo de carga</label>
+          <input id="conteiner-tipo-carga" type="text" formControlName="tipoCarga" required />
+        </div>
+        <div class="campo">
+          <label for="conteiner-destino">Destino</label>
+          <input id="conteiner-destino" type="text" formControlName="destino" required />
+        </div>
+      </div>
+      <div class="campo">
+        <label for="conteiner-camada">Camada operacional</label>
+        <input id="conteiner-camada" type="text" formControlName="camadaOperacional" required />
+      </div>
+      <div class="acoes">
+        <button type="submit" [disabled]="salvandoConteiner">Salvar contêiner</button>
+        <button type="button" class="secundario" (click)="limparFormularioConteiner()">Limpar campos</button>
+      </div>
+      <p class="mensagem sucesso" *ngIf="sucessoConteiner">{{ sucessoConteiner }}</p>
+      <p class="mensagem erro" *ngIf="erroConteiner">{{ erroConteiner }}</p>
+    </form>
+
+    <form [formGroup]="formularioEquipamento" (ngSubmit)="submeterEquipamento()" class="bloco">
+      <h3>Atualizar equipamento</h3>
+      <div class="campo">
+        <label for="equipamento-id">Identificador interno</label>
+        <input id="equipamento-id" type="number" formControlName="id" placeholder="Informe para atualizar um registro existente" />
+      </div>
+      <div class="duas-colunas">
+        <div class="campo">
+          <label for="equipamento-identificador">Identificador</label>
+          <input id="equipamento-identificador" type="text" formControlName="identificador" required />
+        </div>
+        <div class="campo">
+          <label for="equipamento-tipo">Tipo</label>
+          <select id="equipamento-tipo" formControlName="tipoEquipamento" required>
+            <option value="" disabled>Selecione</option>
+            <option *ngFor="let tipo of opcoes?.tiposEquipamento" [value]="tipo">{{ formatarRotulo(tipo) }}</option>
+          </select>
+        </div>
+      </div>
+      <div class="duas-colunas">
+        <div class="campo">
+          <label for="equipamento-linha">Linha</label>
+          <input id="equipamento-linha" type="number" formControlName="linha" min="0" required />
+        </div>
+        <div class="campo">
+          <label for="equipamento-coluna">Coluna</label>
+          <input id="equipamento-coluna" type="number" formControlName="coluna" min="0" required />
+        </div>
+      </div>
+      <div class="campo">
+        <label for="equipamento-status">Status operacional</label>
+        <select id="equipamento-status" formControlName="statusOperacional" required>
+          <option value="" disabled>Selecione</option>
+          <option *ngFor="let status of opcoes?.statusEquipamento" [value]="status">{{ formatarRotulo(status) }}</option>
+        </select>
+      </div>
+      <div class="acoes">
+        <button type="submit" [disabled]="salvandoEquipamento">Salvar equipamento</button>
+        <button type="button" class="secundario" (click)="limparFormularioEquipamento()">Limpar campos</button>
+      </div>
+      <p class="mensagem sucesso" *ngIf="sucessoEquipamento">{{ sucessoEquipamento }}</p>
+      <p class="mensagem erro" *ngIf="erroEquipamento">{{ erroEquipamento }}</p>
+    </form>
+  </div>
+</section>

--- a/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.spec.ts
+++ b/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.spec.ts
@@ -1,0 +1,85 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+import { FormularioMovimentacaoComponent } from './formulario-movimentacao.component';
+import { ServicoPatioService } from '../../service/servico-patio/servico-patio.service';
+import { SanitizadorConteudoService } from '../../service/sanitizacao/sanitizador-conteudo.service';
+
+describe('FormularioMovimentacaoComponent', () => {
+  let component: FormularioMovimentacaoComponent;
+  let fixture: ComponentFixture<FormularioMovimentacaoComponent>;
+  let servicoPatioSpy: jasmine.SpyObj<ServicoPatioService>;
+
+  beforeEach(async () => {
+    servicoPatioSpy = jasmine.createSpyObj('ServicoPatioService', [
+      'obterOpcoesCadastro',
+      'salvarConteiner',
+      'salvarEquipamento'
+    ]);
+
+    servicoPatioSpy.obterOpcoesCadastro.and.returnValue(of({
+      statusConteiner: ['AGUARDANDO_RETIRADA'],
+      tiposEquipamento: ['RTG'],
+      statusEquipamento: ['OPERACIONAL']
+    }));
+
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      declarations: [FormularioMovimentacaoComponent],
+      providers: [
+        SanitizadorConteudoService,
+        { provide: ServicoPatioService, useValue: servicoPatioSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FormularioMovimentacaoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('deve enviar formulário de contêiner com sucesso', () => {
+    servicoPatioSpy.salvarConteiner.and.returnValue(of({ id: 1 } as any));
+
+    component.formularioConteiner.setValue({
+      id: null,
+      codigo: 'CTN123',
+      linha: 1,
+      coluna: 2,
+      status: 'AGUARDANDO_RETIRADA',
+      tipoCarga: 'Granel',
+      destino: 'Santos',
+      camadaOperacional: 'A1'
+    });
+
+    component.submeterConteiner();
+
+    expect(servicoPatioSpy.salvarConteiner).toHaveBeenCalled();
+    expect(component.sucessoConteiner).toBeTruthy();
+  });
+
+  it('não deve enviar contêiner quando formulário é inválido', () => {
+    component.formularioConteiner.patchValue({ codigo: '' });
+
+    component.submeterConteiner();
+
+    expect(servicoPatioSpy.salvarConteiner).not.toHaveBeenCalled();
+  });
+
+  it('deve informar erro ao falhar no envio do equipamento', () => {
+    servicoPatioSpy.salvarEquipamento.and.returnValue(throwError(() => new Error('falha')));
+
+    component.formularioEquipamento.setValue({
+      id: null,
+      identificador: 'EQP',
+      tipoEquipamento: 'RTG',
+      linha: 1,
+      coluna: 1,
+      statusOperacional: 'OPERACIONAL'
+    });
+
+    component.submeterEquipamento();
+
+    expect(servicoPatioSpy.salvarEquipamento).toHaveBeenCalled();
+    expect(component.erroEquipamento).toBeTruthy();
+  });
+});

--- a/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.ts
+++ b/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.ts
@@ -1,0 +1,157 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { finalize } from 'rxjs/operators';
+import { ConteinerMapa, EquipamentoMapa, OpcoesCadastroPatio, ServicoPatioService } from '../../service/servico-patio/servico-patio.service';
+import { SanitizadorConteudoService } from '../../service/sanitizacao/sanitizador-conteudo.service';
+
+@Component({
+  selector: 'app-formulario-movimentacao',
+  templateUrl: './formulario-movimentacao.component.html',
+  styleUrls: ['./formulario-movimentacao.component.css']
+})
+export class FormularioMovimentacaoComponent implements OnInit {
+  formularioConteiner: FormGroup;
+  formularioEquipamento: FormGroup;
+  opcoes?: OpcoesCadastroPatio;
+  carregandoOpcoes = false;
+  salvandoConteiner = false;
+  salvandoEquipamento = false;
+  sucessoConteiner?: string;
+  erroConteiner?: string;
+  sucessoEquipamento?: string;
+  erroEquipamento?: string;
+
+  constructor(
+    private readonly formBuilder: FormBuilder,
+    private readonly servicoPatio: ServicoPatioService,
+    private readonly sanitizador: SanitizadorConteudoService
+  ) {
+    this.formularioConteiner = this.formBuilder.group({
+      id: [null],
+      codigo: ['', [Validators.required, Validators.maxLength(30)]],
+      linha: [0, [Validators.required, Validators.min(0)]],
+      coluna: [0, [Validators.required, Validators.min(0)]],
+      status: ['', Validators.required],
+      tipoCarga: ['', [Validators.required, Validators.maxLength(40)]],
+      destino: ['', [Validators.required, Validators.maxLength(60)]],
+      camadaOperacional: ['', [Validators.required, Validators.maxLength(40)]]
+    });
+
+    this.formularioEquipamento = this.formBuilder.group({
+      id: [null],
+      identificador: ['', [Validators.required, Validators.maxLength(30)]],
+      tipoEquipamento: ['', Validators.required],
+      linha: [0, [Validators.required, Validators.min(0)]],
+      coluna: [0, [Validators.required, Validators.min(0)]],
+      statusOperacional: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.carregarOpcoes();
+  }
+
+  carregarOpcoes(): void {
+    this.carregandoOpcoes = true;
+    this.servicoPatio.obterOpcoesCadastro()
+      .pipe(finalize(() => this.carregandoOpcoes = false))
+      .subscribe({
+        next: (opcoes) => {
+          this.opcoes = opcoes;
+        },
+        error: () => {
+          this.opcoes = undefined;
+        }
+      });
+  }
+
+  submeterConteiner(): void {
+    if (this.formularioConteiner.invalid) {
+      this.formularioConteiner.markAllAsTouched();
+      return;
+    }
+    const valores = this.formularioConteiner.getRawValue();
+    const payload: ConteinerMapa = {
+      id: valores.id ?? undefined,
+      codigo: this.sanitizarTexto(valores.codigo),
+      linha: Number(valores.linha),
+      coluna: Number(valores.coluna),
+      status: valores.status,
+      tipoCarga: this.sanitizarTexto(valores.tipoCarga),
+      destino: this.sanitizarTexto(valores.destino),
+      camadaOperacional: this.sanitizarTexto(valores.camadaOperacional)
+    };
+
+    this.salvandoConteiner = true;
+    this.sucessoConteiner = undefined;
+    this.erroConteiner = undefined;
+    this.servicoPatio.salvarConteiner(payload)
+      .pipe(finalize(() => this.salvandoConteiner = false))
+      .subscribe({
+        next: (resposta) => {
+          this.sucessoConteiner = 'Contêiner atualizado com sucesso.';
+          this.formularioConteiner.patchValue({ id: resposta.id ?? null });
+        },
+        error: () => {
+          this.erroConteiner = 'Não foi possível registrar a movimentação do contêiner. Verifique os dados informados.';
+        }
+      });
+  }
+
+  submeterEquipamento(): void {
+    if (this.formularioEquipamento.invalid) {
+      this.formularioEquipamento.markAllAsTouched();
+      return;
+    }
+    const valores = this.formularioEquipamento.getRawValue();
+    const payload: EquipamentoMapa = {
+      id: valores.id ?? undefined,
+      identificador: this.sanitizarTexto(valores.identificador),
+      tipoEquipamento: valores.tipoEquipamento,
+      linha: Number(valores.linha),
+      coluna: Number(valores.coluna),
+      statusOperacional: valores.statusOperacional
+    };
+
+    this.salvandoEquipamento = true;
+    this.sucessoEquipamento = undefined;
+    this.erroEquipamento = undefined;
+    this.servicoPatio.salvarEquipamento(payload)
+      .pipe(finalize(() => this.salvandoEquipamento = false))
+      .subscribe({
+        next: (resposta) => {
+          this.sucessoEquipamento = 'Equipamento atualizado com sucesso.';
+          this.formularioEquipamento.patchValue({ id: resposta.id ?? null });
+        },
+        error: () => {
+          this.erroEquipamento = 'Não foi possível atualizar as informações do equipamento.';
+        }
+      });
+  }
+
+  limparFormularioConteiner(): void {
+    this.formularioConteiner.reset({ linha: 0, coluna: 0 });
+    this.sucessoConteiner = undefined;
+    this.erroConteiner = undefined;
+  }
+
+  limparFormularioEquipamento(): void {
+    this.formularioEquipamento.reset({ linha: 0, coluna: 0 });
+    this.sucessoEquipamento = undefined;
+    this.erroEquipamento = undefined;
+  }
+
+  formatarRotulo(valor: string): string {
+    const texto = this.sanitizarTexto(valor);
+    return texto
+      .toLowerCase()
+      .split(/[_\s]+/)
+      .filter(parte => parte.length > 0)
+      .map(parte => parte.charAt(0).toUpperCase() + parte.slice(1))
+      .join(' ');
+  }
+
+  private sanitizarTexto(valor: string): string {
+    return this.sanitizador.sanitizar(valor ?? '').trim();
+  }
+}

--- a/frontend/cloudport/src/app/componentes/patio/lista-movimentacoes/lista-movimentacoes.component.css
+++ b/frontend/cloudport/src/app/componentes/patio/lista-movimentacoes/lista-movimentacoes.component.css
@@ -1,0 +1,78 @@
+.lista-movimentacoes {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.lista-movimentacoes header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lista-movimentacoes header button {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border: none;
+  background-color: #0f766e;
+  color: #ffffff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.lista-movimentacoes header button:disabled {
+  background-color: #7ec5bc;
+  cursor: not-allowed;
+}
+
+.lista {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.lista li {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 12px;
+  background-color: #fdfdfd;
+}
+
+.cabecalho {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.cabecalho .tipo {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.cabecalho .horario {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.conteudo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #1e293b;
+}
+
+.estado {
+  font-size: 0.95rem;
+  color: #333333;
+}
+
+.estado.erro {
+  color: #b30021;
+}

--- a/frontend/cloudport/src/app/componentes/patio/lista-movimentacoes/lista-movimentacoes.component.html
+++ b/frontend/cloudport/src/app/componentes/patio/lista-movimentacoes/lista-movimentacoes.component.html
@@ -1,0 +1,32 @@
+<section class="lista-movimentacoes">
+  <header>
+    <h2>Movimentações recentes</h2>
+    <p>Visualize os últimos registros de movimentação e acompanhe a operação em tempo real.</p>
+    <button type="button" (click)="carregarMovimentacoes()" [disabled]="carregando">Atualizar movimentações</button>
+  </header>
+
+  <div class="estado" *ngIf="carregando">Buscando movimentações...</div>
+  <div class="estado erro" *ngIf="erro">{{ erro }}</div>
+
+  <ul class="lista" *ngIf="!carregando && !erro && movimentacoes.length">
+    <li *ngFor="let movimento of movimentacoes; trackBy: identificarMovimento">
+      <div class="cabecalho">
+        <span class="tipo">{{ sanitizar(movimento.tipoMovimento) }}</span>
+        <span class="horario">{{ movimento.registradoEm | date: 'dd/MM/yyyy HH:mm' }}</span>
+      </div>
+      <div class="conteudo">
+        <span class="descricao">{{ sanitizar(movimento.descricao) }}</span>
+        <span class="conteiner" *ngIf="movimento.codigoConteiner">Contêiner: {{ sanitizar(movimento.codigoConteiner) }}</span>
+        <span class="destino" *ngIf="movimento.destino">Destino: {{ sanitizar(movimento.destino) }}</span>
+        <span class="posicao" *ngIf="movimento.linha !== undefined && movimento.coluna !== undefined">
+          Posição: Linha {{ movimento.linha }}, Coluna {{ movimento.coluna }}
+          <span *ngIf="movimento.camadaOperacional">- Camada {{ sanitizar(movimento.camadaOperacional) }}</span>
+        </span>
+      </div>
+    </li>
+  </ul>
+
+  <div class="estado" *ngIf="!carregando && !erro && !movimentacoes.length">
+    Nenhuma movimentação registrada nas últimas execuções.
+  </div>
+</section>

--- a/frontend/cloudport/src/app/componentes/patio/lista-movimentacoes/lista-movimentacoes.component.spec.ts
+++ b/frontend/cloudport/src/app/componentes/patio/lista-movimentacoes/lista-movimentacoes.component.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { ListaMovimentacoesComponent } from './lista-movimentacoes.component';
+import { ServicoPatioService } from '../../service/servico-patio/servico-patio.service';
+import { SanitizadorConteudoService } from '../../service/sanitizacao/sanitizador-conteudo.service';
+
+describe('ListaMovimentacoesComponent', () => {
+  let component: ListaMovimentacoesComponent;
+  let fixture: ComponentFixture<ListaMovimentacoesComponent>;
+  let servicoPatioSpy: jasmine.SpyObj<ServicoPatioService>;
+
+  beforeEach(async () => {
+    servicoPatioSpy = jasmine.createSpyObj('ServicoPatioService', ['listarMovimentacoes']);
+
+    await TestBed.configureTestingModule({
+      declarations: [ListaMovimentacoesComponent],
+      providers: [
+        SanitizadorConteudoService,
+        { provide: ServicoPatioService, useValue: servicoPatioSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ListaMovimentacoesComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('deve carregar movimentações', () => {
+    servicoPatioSpy.listarMovimentacoes.and.returnValue(of([
+      {
+        id: 10,
+        codigoConteiner: 'CTN123',
+        tipoMovimento: 'ALOCACAO',
+        descricao: 'Teste',
+        registradoEm: new Date().toISOString()
+      }
+    ]));
+
+    component.carregarMovimentacoes();
+
+    expect(component.movimentacoes.length).toBe(1);
+    expect(component.erro).toBeUndefined();
+    expect(component.carregando).toBeFalse();
+  });
+
+  it('deve exibir erro quando a busca falha', () => {
+    servicoPatioSpy.listarMovimentacoes.and.returnValue(throwError(() => new Error('falha')));
+
+    component.carregarMovimentacoes();
+
+    expect(component.movimentacoes.length).toBe(0);
+    expect(component.erro).toBeDefined();
+    expect(component.carregando).toBeFalse();
+  });
+});

--- a/frontend/cloudport/src/app/componentes/patio/lista-movimentacoes/lista-movimentacoes.component.ts
+++ b/frontend/cloudport/src/app/componentes/patio/lista-movimentacoes/lista-movimentacoes.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit } from '@angular/core';
+import { MovimentoPatio, ServicoPatioService } from '../../service/servico-patio/servico-patio.service';
+import { SanitizadorConteudoService } from '../../service/sanitizacao/sanitizador-conteudo.service';
+
+@Component({
+  selector: 'app-lista-movimentacoes',
+  templateUrl: './lista-movimentacoes.component.html',
+  styleUrls: ['./lista-movimentacoes.component.css']
+})
+export class ListaMovimentacoesComponent implements OnInit {
+  movimentacoes: MovimentoPatio[] = [];
+  carregando = false;
+  erro?: string;
+
+  constructor(
+    private readonly servicoPatio: ServicoPatioService,
+    private readonly sanitizador: SanitizadorConteudoService
+  ) { }
+
+  ngOnInit(): void {
+    this.carregarMovimentacoes();
+  }
+
+  carregarMovimentacoes(): void {
+    this.carregando = true;
+    this.erro = undefined;
+    this.servicoPatio.listarMovimentacoes().subscribe({
+      next: (movimentacoes) => {
+        this.movimentacoes = movimentacoes;
+        this.carregando = false;
+      },
+      error: () => {
+        this.erro = 'Não foi possível recuperar as movimentações recentes. Tente novamente em instantes.';
+        this.carregando = false;
+      }
+    });
+  }
+
+  sanitizar(valor: string | null | undefined): string {
+    return this.sanitizador.sanitizar(valor ?? '');
+  }
+
+  identificarMovimento(index: number, movimento: MovimentoPatio): number | undefined {
+    return movimento?.id ?? index;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/patio/lista-posicoes/lista-posicoes.component.css
+++ b/frontend/cloudport/src/app/componentes/patio/lista-posicoes/lista-posicoes.component.css
@@ -1,0 +1,65 @@
+.lista-posicoes {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.lista-posicoes header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lista-posicoes header button {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border: none;
+  background-color: #0057b7;
+  color: #ffffff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.lista-posicoes header button:disabled {
+  background-color: #8da7d9;
+  cursor: not-allowed;
+}
+
+.estado {
+  font-size: 0.95rem;
+  color: #333333;
+}
+
+.estado.erro {
+  color: #b30021;
+}
+
+.tabela-posicoes {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tabela-posicoes th,
+.tabela-posicoes td {
+  padding: 8px;
+  border-bottom: 1px solid #e0e0e0;
+  text-align: left;
+}
+
+.tabela-posicoes tbody tr:hover {
+  background-color: #f7f9ff;
+}
+
+.ocupada {
+  color: #b30021;
+  font-weight: 600;
+}
+
+.livre {
+  color: #2f855a;
+  font-weight: 600;
+}

--- a/frontend/cloudport/src/app/componentes/patio/lista-posicoes/lista-posicoes.component.html
+++ b/frontend/cloudport/src/app/componentes/patio/lista-posicoes/lista-posicoes.component.html
@@ -1,0 +1,39 @@
+<section class="lista-posicoes">
+  <header>
+    <h2>Posições do Pátio</h2>
+    <p>Consulte a disponibilidade de cada posição e identifique ocupações críticas.</p>
+    <button type="button" (click)="carregarPosicoes()" [disabled]="carregando">Atualizar posições</button>
+  </header>
+
+  <div class="estado" *ngIf="carregando">Carregando posições do pátio...</div>
+  <div class="estado erro" *ngIf="erro">{{ erro }}</div>
+
+  <table *ngIf="!carregando && !erro && posicoes.length" class="tabela-posicoes">
+    <thead>
+      <tr>
+        <th>Linha</th>
+        <th>Coluna</th>
+        <th>Camada</th>
+        <th>Ocupação</th>
+        <th>Contêiner</th>
+        <th>Status do contêiner</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let posicao of posicoes; trackBy: identificarPosicao">
+        <td>{{ posicao.linha }}</td>
+        <td>{{ posicao.coluna }}</td>
+        <td>{{ sanitizar(posicao.camadaOperacional) }}</td>
+        <td>
+          <span [class.ocupada]="posicao.ocupada" [class.livre]="!posicao.ocupada">{{ descricaoOcupacao(posicao) }}</span>
+        </td>
+        <td>{{ sanitizar(posicao.codigoConteiner) || '—' }}</td>
+        <td>{{ sanitizar(posicao.statusConteiner) || '—' }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="estado" *ngIf="!carregando && !erro && !posicoes.length">
+    Nenhuma posição foi encontrada no momento.
+  </div>
+</section>

--- a/frontend/cloudport/src/app/componentes/patio/lista-posicoes/lista-posicoes.component.spec.ts
+++ b/frontend/cloudport/src/app/componentes/patio/lista-posicoes/lista-posicoes.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { ListaPosicoesComponent } from './lista-posicoes.component';
+import { ServicoPatioService } from '../../service/servico-patio/servico-patio.service';
+import { SanitizadorConteudoService } from '../../service/sanitizacao/sanitizador-conteudo.service';
+
+describe('ListaPosicoesComponent', () => {
+  let component: ListaPosicoesComponent;
+  let fixture: ComponentFixture<ListaPosicoesComponent>;
+  let servicoPatioSpy: jasmine.SpyObj<ServicoPatioService>;
+
+  beforeEach(async () => {
+    servicoPatioSpy = jasmine.createSpyObj('ServicoPatioService', ['listarPosicoes']);
+
+    await TestBed.configureTestingModule({
+      declarations: [ListaPosicoesComponent],
+      providers: [
+        SanitizadorConteudoService,
+        { provide: ServicoPatioService, useValue: servicoPatioSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ListaPosicoesComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('deve carregar posições com sucesso', () => {
+    servicoPatioSpy.listarPosicoes.and.returnValue(of([
+      { id: 1, linha: 1, coluna: 2, camadaOperacional: 'A', ocupada: true, codigoConteiner: 'CTN001', statusConteiner: 'RETIDO' }
+    ]));
+
+    component.carregarPosicoes();
+
+    expect(component.posicoes.length).toBe(1);
+    expect(component.carregando).toBeFalse();
+    expect(component.erro).toBeUndefined();
+  });
+
+  it('deve informar erro ao falhar no carregamento', () => {
+    servicoPatioSpy.listarPosicoes.and.returnValue(throwError(() => new Error('falha')));
+
+    component.carregarPosicoes();
+
+    expect(component.posicoes.length).toBe(0);
+    expect(component.carregando).toBeFalse();
+    expect(component.erro).toBeDefined();
+  });
+});

--- a/frontend/cloudport/src/app/componentes/patio/lista-posicoes/lista-posicoes.component.ts
+++ b/frontend/cloudport/src/app/componentes/patio/lista-posicoes/lista-posicoes.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core';
+import { PosicaoPatio, ServicoPatioService } from '../../service/servico-patio/servico-patio.service';
+import { SanitizadorConteudoService } from '../../service/sanitizacao/sanitizador-conteudo.service';
+
+@Component({
+  selector: 'app-lista-posicoes',
+  templateUrl: './lista-posicoes.component.html',
+  styleUrls: ['./lista-posicoes.component.css']
+})
+export class ListaPosicoesComponent implements OnInit {
+  posicoes: PosicaoPatio[] = [];
+  carregando = false;
+  erro?: string;
+
+  constructor(
+    private readonly servicoPatio: ServicoPatioService,
+    private readonly sanitizador: SanitizadorConteudoService
+  ) { }
+
+  ngOnInit(): void {
+    this.carregarPosicoes();
+  }
+
+  carregarPosicoes(): void {
+    this.carregando = true;
+    this.erro = undefined;
+    this.servicoPatio.listarPosicoes().subscribe({
+      next: (posicoes) => {
+        this.posicoes = posicoes;
+        this.carregando = false;
+      },
+      error: () => {
+        this.erro = 'Não foi possível carregar as posições do pátio. Tente novamente em instantes.';
+        this.carregando = false;
+      }
+    });
+  }
+
+  descricaoOcupacao(posicao: PosicaoPatio): string {
+    return posicao.ocupada ? 'Ocupada' : 'Livre';
+  }
+
+  sanitizar(valor: string | null | undefined): string {
+    return this.sanitizador.sanitizar(valor ?? '');
+  }
+
+  identificarPosicao(index: number, posicao: PosicaoPatio): number | undefined {
+    return posicao?.id ?? index;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/patio/mapa-patio/mapa-patio.component.html
+++ b/frontend/cloudport/src/app/componentes/patio/mapa-patio/mapa-patio.component.html
@@ -13,31 +13,31 @@
     <div class="filtro-grupo">
       <label for="filtro-status">Status dos contêineres</label>
       <select id="filtro-status" multiple formControlName="status">
-        <option *ngFor="let status of filtrosDisponiveis.statusDisponiveis" [value]="status">{{ status }}</option>
+        <option *ngFor="let status of filtrosDisponiveis.statusDisponiveis" [value]="status">{{ sanitizarTexto(status) }}</option>
       </select>
     </div>
     <div class="filtro-grupo">
       <label for="filtro-tipo-carga">Tipo de carga</label>
       <select id="filtro-tipo-carga" multiple formControlName="tiposCarga">
-        <option *ngFor="let tipo of filtrosDisponiveis.tiposCargaDisponiveis" [value]="tipo">{{ tipo }}</option>
+        <option *ngFor="let tipo of filtrosDisponiveis.tiposCargaDisponiveis" [value]="tipo">{{ sanitizarTexto(tipo) }}</option>
       </select>
     </div>
     <div class="filtro-grupo">
       <label for="filtro-destino">Destino</label>
       <select id="filtro-destino" multiple formControlName="destinos">
-        <option *ngFor="let destino of filtrosDisponiveis.destinosDisponiveis" [value]="destino">{{ destino }}</option>
+        <option *ngFor="let destino of filtrosDisponiveis.destinosDisponiveis" [value]="destino">{{ sanitizarTexto(destino) }}</option>
       </select>
     </div>
     <div class="filtro-grupo">
       <label for="filtro-camada">Camada operacional</label>
       <select id="filtro-camada" multiple formControlName="camadas">
-        <option *ngFor="let camada of filtrosDisponiveis.camadasOperacionaisDisponiveis" [value]="camada">{{ camada }}</option>
+        <option *ngFor="let camada of filtrosDisponiveis.camadasOperacionaisDisponiveis" [value]="camada">{{ sanitizarTexto(camada) }}</option>
       </select>
     </div>
     <div class="filtro-grupo">
       <label for="filtro-equipamento">Tipos de equipamento</label>
       <select id="filtro-equipamento" multiple formControlName="tiposEquipamento">
-        <option *ngFor="let tipoEquipamento of filtrosDisponiveis.tiposEquipamentoDisponiveis" [value]="tipoEquipamento">{{ tipoEquipamento }}</option>
+        <option *ngFor="let tipoEquipamento of filtrosDisponiveis.tiposEquipamentoDisponiveis" [value]="tipoEquipamento">{{ sanitizarTexto(tipoEquipamento) }}</option>
       </select>
     </div>
   </section>
@@ -56,17 +56,17 @@
            [ngClass]="obterClasseStatus(conteiner.status)"
            aria-label="Contêiner {{ conteiner.codigo }}"
            role="button">
-        <span class="conteiner-codigo">{{ conteiner.codigo }}</span>
-        <span class="conteiner-detalhe">{{ conteiner.tipoCarga }}</span>
-        <span class="conteiner-detalhe">{{ conteiner.destino }}</span>
+        <span class="conteiner-codigo">{{ sanitizarTexto(conteiner.codigo) }}</span>
+        <span class="conteiner-detalhe">{{ sanitizarTexto(conteiner.tipoCarga) }}</span>
+        <span class="conteiner-detalhe">{{ sanitizarTexto(conteiner.destino) }}</span>
       </div>
       <div class="mapa-equipamento" *ngFor="let equipamento of mapaFiltrado.equipamentos"
            [style.gridRow]="(equipamento.linha + 1)"
            [style.gridColumn]="(equipamento.coluna + 1)"
            aria-label="Equipamento {{ equipamento.identificador }}"
            role="button">
-        <span class="equipamento-identificador">{{ equipamento.identificador }}</span>
-        <span class="equipamento-tipo">{{ equipamento.tipoEquipamento }}</span>
+        <span class="equipamento-identificador">{{ sanitizarTexto(equipamento.identificador) }}</span>
+        <span class="equipamento-tipo">{{ sanitizarTexto(equipamento.tipoEquipamento) }}</span>
       </div>
     </div>
   </section>

--- a/frontend/cloudport/src/app/componentes/patio/mapa-patio/mapa-patio.component.ts
+++ b/frontend/cloudport/src/app/componentes/patio/mapa-patio/mapa-patio.component.ts
@@ -7,6 +7,7 @@ import {
   MapaPatioResposta,
   ServicoPatioService
 } from '../../service/servico-patio/servico-patio.service';
+import { SanitizadorConteudoService } from '../../service/sanitizacao/sanitizador-conteudo.service';
 
 interface FiltroFormulario {
   status: FormControl<string[]>;
@@ -32,7 +33,11 @@ export class MapaPatioComponent implements OnInit, OnDestroy {
   inscricaoTempoReal?: Subscription;
   inscricaoFormulario?: Subscription;
 
-  constructor(private readonly servicoPatio: ServicoPatioService, private readonly formBuilder: FormBuilder) {
+  constructor(
+    private readonly servicoPatio: ServicoPatioService,
+    private readonly formBuilder: FormBuilder,
+    private readonly sanitizador: SanitizadorConteudoService
+  ) {
     this.formularioFiltros = this.formBuilder.group({
       status: this.formBuilder.control<string[]>([]),
       tiposCarga: this.formBuilder.control<string[]>([]),
@@ -101,6 +106,10 @@ export class MapaPatioComponent implements OnInit, OnDestroy {
   obterTemplateLinhas(): string {
     const linhas = this.mapaFiltrado?.totalLinhas ?? 0;
     return `repeat(${linhas}, minmax(70px, 1fr))`;
+  }
+
+  sanitizarTexto(texto: string | null | undefined): string {
+    return this.sanitizador.sanitizar(texto ?? '');
   }
 
   private carregarFiltros(): void {

--- a/frontend/cloudport/src/app/componentes/patio/patio-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/patio/patio-routing.module.ts
@@ -1,11 +1,26 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { MapaPatioComponent } from './mapa-patio/mapa-patio.component';
+import { ListaPosicoesComponent } from './lista-posicoes/lista-posicoes.component';
+import { ListaMovimentacoesComponent } from './lista-movimentacoes/lista-movimentacoes.component';
+import { FormularioMovimentacaoComponent } from './formulario-movimentacao/formulario-movimentacao.component';
 
 const routes: Routes = [
   {
     path: 'mapa',
     component: MapaPatioComponent
+  },
+  {
+    path: 'posicoes',
+    component: ListaPosicoesComponent
+  },
+  {
+    path: 'movimentacoes',
+    component: ListaMovimentacoesComponent
+  },
+  {
+    path: 'movimentacao',
+    component: FormularioMovimentacaoComponent
   },
   {
     path: '',

--- a/frontend/cloudport/src/app/componentes/patio/patio.module.ts
+++ b/frontend/cloudport/src/app/componentes/patio/patio.module.ts
@@ -2,10 +2,18 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MapaPatioComponent } from './mapa-patio/mapa-patio.component';
+import { ListaPosicoesComponent } from './lista-posicoes/lista-posicoes.component';
+import { ListaMovimentacoesComponent } from './lista-movimentacoes/lista-movimentacoes.component';
+import { FormularioMovimentacaoComponent } from './formulario-movimentacao/formulario-movimentacao.component';
 import { PatioRoutingModule } from './patio-routing.module';
 
 @NgModule({
-  declarations: [MapaPatioComponent],
+  declarations: [
+    MapaPatioComponent,
+    ListaPosicoesComponent,
+    ListaMovimentacoesComponent,
+    FormularioMovimentacaoComponent
+  ],
   imports: [CommonModule, ReactiveFormsModule, PatioRoutingModule]
 })
 export class PatioModule { }

--- a/frontend/cloudport/src/app/componentes/service/endpoint.ts
+++ b/frontend/cloudport/src/app/componentes/service/endpoint.ts
@@ -26,6 +26,10 @@ export const environment = {
     patio: {
         mapa: `${baseLink}/yard/patio/mapa`,
         filtros: `${baseLink}/yard/patio/filtros`,
+        posicoes: `${baseLink}/yard/patio/posicoes`,
+        listaConteineres: `${baseLink}/yard/patio/conteineres`,
+        movimentacoes: `${baseLink}/yard/patio/movimentacoes`,
+        opcoes: `${baseLink}/yard/patio/opcoes`,
         conteineres: `${baseLink}/yard/patio/conteineres`,
         equipamentos: `${baseLink}/yard/patio/equipamentos`,
         websocket: `${baseLink.replace('http', 'ws')}/ws/patio`

--- a/frontend/cloudport/src/app/componentes/service/servico-autenticacao/auth.guard.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-autenticacao/auth.guard.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
-import { Router, CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Router, CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, CanActivateChild, CanLoad, Route, UrlSegment } from '@angular/router';
 
 import { ServicoAutenticacao } from './servico-autenticacao.service';
 
 @Injectable({ providedIn: 'root' })
-export class AuthGuard implements CanActivate {
+export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
     constructor(
         private router: Router,
         private servicoAutenticacao: ServicoAutenticacao
@@ -19,6 +19,20 @@ export class AuthGuard implements CanActivate {
 
         // not logged in so redirect to login page with the return url
         this.router.navigate(['/login'], { queryParams: { returnUrl: state.url } });
+        return false;
+    }
+
+    canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+        return this.canActivate(childRoute, state);
+    }
+
+    canLoad(route: Route, segments: UrlSegment[]): boolean {
+        const currentUser = this.servicoAutenticacao.obterUsuarioAtual();
+        if (currentUser) {
+            return true;
+        }
+        const returnUrl = '/' + segments.map(segment => segment.path).join('/');
+        this.router.navigate(['/login'], { queryParams: { returnUrl } });
         return false;
     }
 }

--- a/frontend/cloudport/src/app/componentes/service/servico-patio/servico-patio.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-patio/servico-patio.service.ts
@@ -5,7 +5,7 @@ import { environment } from '../../service/endpoint';
 import { ClienteStompBasico, ManipuladorErro, ManipuladorMensagem } from './cliente-stomp-basico';
 
 export interface ConteinerMapa {
-  id: number;
+  id?: number;
   codigo: string;
   linha: number;
   coluna: number;
@@ -16,12 +16,40 @@ export interface ConteinerMapa {
 }
 
 export interface EquipamentoMapa {
-  id: number;
+  id?: number;
   identificador: string;
   tipoEquipamento: string;
   linha: number;
   coluna: number;
   statusOperacional: string;
+}
+
+export interface PosicaoPatio {
+  id: number;
+  linha: number;
+  coluna: number;
+  camadaOperacional: string;
+  ocupada: boolean;
+  codigoConteiner?: string;
+  statusConteiner?: string;
+}
+
+export interface MovimentoPatio {
+  id: number;
+  codigoConteiner?: string;
+  tipoMovimento: string;
+  descricao: string;
+  destino?: string;
+  linha?: number;
+  coluna?: number;
+  camadaOperacional?: string;
+  registradoEm: string;
+}
+
+export interface OpcoesCadastroPatio {
+  statusConteiner: string[];
+  tiposEquipamento: string[];
+  statusEquipamento: string[];
 }
 
 export interface MapaPatioResposta {
@@ -70,6 +98,22 @@ export class ServicoPatioService implements OnDestroy {
 
   obterFiltros(): Observable<FiltrosMapaPatio> {
     return this.http.get<FiltrosMapaPatio>(environment.patio.filtros);
+  }
+
+  listarPosicoes(): Observable<PosicaoPatio[]> {
+    return this.http.get<PosicaoPatio[]>(environment.patio.posicoes);
+  }
+
+  listarConteineres(): Observable<ConteinerMapa[]> {
+    return this.http.get<ConteinerMapa[]>(environment.patio.listaConteineres);
+  }
+
+  listarMovimentacoes(): Observable<MovimentoPatio[]> {
+    return this.http.get<MovimentoPatio[]>(environment.patio.movimentacoes);
+  }
+
+  obterOpcoesCadastro(): Observable<OpcoesCadastroPatio> {
+    return this.http.get<OpcoesCadastroPatio>(environment.patio.opcoes);
   }
 
   salvarConteiner(payload: ConteinerMapa): Observable<ConteinerMapa> {


### PR DESCRIPTION
## Resumo
- adicionar DTOs e endpoints REST no serviço de pátio para listar posições, contêineres, movimentações e opções de cadastro com sanitização
- estender o módulo Angular do pátio com novos serviços, rotas protegidas e componentes para mapa 2D, listagens e formulários de movimentação
- atualizar navegação, guarda de rotas e integração em tempo real garantindo textos e feedbacks em português do Brasil

## Testes
- mvn -f backend/servico-yard/pom.xml test *(falha: repositório Maven retorna 403 Forbidden)*
- npm install *(falha: registry.npmjs.org retornou 403 Forbidden ao baixar @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68f3737ac8ec8327b73e2614d0d6c0c2