### PR TITLE
Ajustar navegação do frontend ao backend do Gate

### DIFF
--- a/frontend/cloudport/src/app/componentes/gate/gate-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/gate/gate-routing.module.ts
@@ -11,7 +11,7 @@ const routes: Routes = [
   { path: '', redirectTo: 'agendamentos', pathMatch: 'full' },
   { path: 'agendamentos', component: GateAgendamentosComponent },
   { path: 'janelas', component: GateJanelasComponent },
-  { path: 'dashboard', redirectTo: 'agendamentos', pathMatch: 'full' },
+  { path: 'dashboard', component: GateDashboardComponent },
   { path: 'relatorios', component: GateRelatoriosComponent },
   {
     path: 'operador',

--- a/frontend/cloudport/src/app/componentes/navbar/TabService.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/TabService.ts
@@ -12,17 +12,81 @@ export interface TabItem {
 export const DEFAULT_TAB_ID = 'role';
 
 export const TAB_REGISTRY: Readonly<Record<string, TabItem>> = {
-  role: { id: 'role', label: 'Role', route: ['role'] },
-  seguranca: { id: 'seguranca', label: 'Segurança', route: ['seguranca'] },
-  notificacoes: { id: 'notificacoes', label: 'Notificações', route: ['notificacoes'] },
-  privacidade: { id: 'privacidade', label: 'Privacidade', route: ['privacidade'] },
-  'lista-de-usuarios': { id: 'lista-de-usuarios', label: 'Lista de usuários', route: ['lista-de-usuarios'] },
-  'gate/agendamentos': { id: 'gate/agendamentos', label: 'Agendamentos do Gate', route: ['gate', 'agendamentos'] },
-  'gate/janelas': { id: 'gate/janelas', label: 'Janelas de Atendimento', route: ['gate', 'janelas'] },
-  'patio/mapa': { id: 'patio/mapa', label: 'Mapa do Pátio', route: ['patio', 'mapa'] },
-  'patio/posicoes': { id: 'patio/posicoes', label: 'Posições do Pátio', route: ['patio', 'posicoes'] },
-  'patio/movimentacoes': { id: 'patio/movimentacoes', label: 'Movimentações do Pátio', route: ['patio', 'movimentacoes'] },
-  'patio/movimentacao': { id: 'patio/movimentacao', label: 'Registrar movimentação', route: ['patio', 'movimentacao'] }
+  role: {
+    id: 'role',
+    label: 'Perfis de Acesso',
+    route: ['role']
+  },
+  seguranca: {
+    id: 'seguranca',
+    label: 'Políticas de Segurança',
+    route: ['seguranca']
+  },
+  notificacoes: {
+    id: 'notificacoes',
+    label: 'Centro de Notificações',
+    route: ['notificacoes']
+  },
+  privacidade: {
+    id: 'privacidade',
+    label: 'Preferências de Privacidade',
+    route: ['privacidade']
+  },
+  'lista-de-usuarios': {
+    id: 'lista-de-usuarios',
+    label: 'Lista de Usuários',
+    route: ['lista-de-usuarios']
+  },
+  'gate/dashboard': {
+    id: 'gate/dashboard',
+    label: 'Painel do Gate',
+    route: ['gate', 'dashboard']
+  },
+  'gate/agendamentos': {
+    id: 'gate/agendamentos',
+    label: 'Agendamentos do Gate',
+    route: ['gate', 'agendamentos']
+  },
+  'gate/janelas': {
+    id: 'gate/janelas',
+    label: 'Janelas de Atendimento',
+    route: ['gate', 'janelas']
+  },
+  'gate/relatorios': {
+    id: 'gate/relatorios',
+    label: 'Relatórios do Gate',
+    route: ['gate', 'relatorios']
+  },
+  'gate/operador/console': {
+    id: 'gate/operador/console',
+    label: 'Console do Operador',
+    route: ['gate', 'operador', 'console']
+  },
+  'gate/operador/eventos': {
+    id: 'gate/operador/eventos',
+    label: 'Eventos do Operador',
+    route: ['gate', 'operador', 'eventos']
+  },
+  'patio/mapa': {
+    id: 'patio/mapa',
+    label: 'Mapa do Pátio',
+    route: ['patio', 'mapa']
+  },
+  'patio/posicoes': {
+    id: 'patio/posicoes',
+    label: 'Posições do Pátio',
+    route: ['patio', 'posicoes']
+  },
+  'patio/movimentacoes': {
+    id: 'patio/movimentacoes',
+    label: 'Movimentações do Pátio',
+    route: ['patio', 'movimentacoes']
+  },
+  'patio/movimentacao': {
+    id: 'patio/movimentacao',
+    label: 'Registrar Movimentação',
+    route: ['patio', 'movimentacao']
+  }
 };
 
 export const VALID_TAB_IDS = new Set<string>(Object.keys(TAB_REGISTRY));

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -15,7 +15,14 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   private readonly configurationTabIds = ['role', 'seguranca', 'notificacoes', 'privacidade'];
   private readonly userTabIds = ['lista-de-usuarios'];
-  private readonly gateTabIds = ['gate/agendamentos', 'gate/janelas'];
+  private readonly gateTabIds = [
+    'gate/dashboard',
+    'gate/agendamentos',
+    'gate/janelas',
+    'gate/relatorios',
+    'gate/operador/console',
+    'gate/operador/eventos'
+  ];
   private readonly yardTabIds = ['patio/mapa', 'patio/posicoes', 'patio/movimentacoes', 'patio/movimentacao'];
 
   private readonly tabRoles: Record<string, string[]> = {
@@ -24,8 +31,12 @@ export class NavbarComponent implements OnInit, OnDestroy {
     notificacoes: ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
     privacidade: ['ROLE_ADMIN_PORTO'],
     'lista-de-usuarios': ['ROLE_ADMIN_PORTO'],
+    'gate/dashboard': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'],
     'gate/agendamentos': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'],
     'gate/janelas': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'],
+    'gate/relatorios': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'],
+    'gate/operador/console': ['ROLE_ADMIN_PORTO', 'ROLE_OPERADOR_GATE', 'ROLE_PLANEJADOR'],
+    'gate/operador/eventos': ['ROLE_ADMIN_PORTO', 'ROLE_OPERADOR_GATE', 'ROLE_PLANEJADOR'],
     'patio/mapa': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
     'patio/posicoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
     'patio/movimentacoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],


### PR DESCRIPTION
## Resumo
- alinhei o registro de abas da navegação com os módulos reais disponíveis no backend, padronizando os rótulos em português
- expus as rotas do painel, relatórios e console do operador do Gate no menu com as permissões corretas
- atualizei a rota de dashboard do Gate para carregar o componente analítico em vez de um redirecionamento

## Testes
- npm install *(falhou: 403 Forbidden para @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68f38df9879483279b9db92c420b4fdd