### PR TITLE
Centralizar visão de agendamentos e migrar tela para cards móveis

### DIFF
--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/CentralAcaoAgendamentoController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/CentralAcaoAgendamentoController.java
@@ -1,0 +1,44 @@
+package br.com.cloudport.servicogate.app.cidadao.centralacao;
+
+import br.com.cloudport.servicogate.app.cidadao.centralacao.dto.CentralAcaoAgendamentoRespostaDTO;
+import br.com.cloudport.servicogate.app.cidadao.centralacao.dto.VisaoCompletaAgendamentoDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/gate/agendamentos")
+@Validated
+@Tag(name = "Central de Ação", description = "Visão consolidada dos agendamentos para atuação rápida")
+public class CentralAcaoAgendamentoController {
+
+    private final CentralAcaoAgendamentoService centralAcaoAgendamentoService;
+
+    public CentralAcaoAgendamentoController(CentralAcaoAgendamentoService centralAcaoAgendamentoService) {
+        this.centralAcaoAgendamentoService = centralAcaoAgendamentoService;
+    }
+
+    @GetMapping("/visao-completa")
+    @Operation(summary = "Lista cartões de ação dos agendamentos com dados consolidados")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE','TRANSPORTADORA')")
+    public CentralAcaoAgendamentoRespostaDTO listarVisaoCompleta(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader) {
+        return centralAcaoAgendamentoService.montarVisaoCompleta(authorizationHeader);
+    }
+
+    @GetMapping("/{id}/visao-completa")
+    @Operation(summary = "Detalha um agendamento com visão consolidada para ação imediata")
+    @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE','TRANSPORTADORA')")
+    public VisaoCompletaAgendamentoDTO buscarPorId(
+            @PathVariable Long id,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader) {
+        return centralAcaoAgendamentoService.montarVisaoPorId(id, authorizationHeader);
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/CentralAcaoAgendamentoService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/CentralAcaoAgendamentoService.java
@@ -1,0 +1,270 @@
+package br.com.cloudport.servicogate.app.cidadao.centralacao;
+
+import br.com.cloudport.servicogate.app.cidadao.AgendamentoService;
+import br.com.cloudport.servicogate.app.cidadao.centralacao.dto.AcaoAgendamentoDTO;
+import br.com.cloudport.servicogate.app.cidadao.centralacao.dto.CentralAcaoAgendamentoRespostaDTO;
+import br.com.cloudport.servicogate.app.cidadao.centralacao.dto.DocumentoPendenteDTO;
+import br.com.cloudport.servicogate.app.cidadao.centralacao.dto.SituacaoPatioDTO;
+import br.com.cloudport.servicogate.app.cidadao.centralacao.dto.UsuarioCentralAcaoDTO;
+import br.com.cloudport.servicogate.app.cidadao.centralacao.dto.VisaoCompletaAgendamentoDTO;
+import br.com.cloudport.servicogate.app.cidadao.dto.AgendamentoDTO;
+import br.com.cloudport.servicogate.app.cidadao.dto.DocumentoAgendamentoDTO;
+import br.com.cloudport.servicogate.integration.yard.ClienteStatusPatio;
+import br.com.cloudport.servicogate.integration.yard.dto.StatusPatioResposta;
+import br.com.cloudport.servicogate.model.enums.StatusAgendamento;
+import br.com.cloudport.servicogate.security.AutenticacaoClient;
+import br.com.cloudport.servicogate.security.UserInfoResponse;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
+
+@Service
+public class CentralAcaoAgendamentoService {
+
+    private static final DateTimeFormatter DATA_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter HORA_FORMATTER = DateTimeFormatter.ISO_LOCAL_TIME;
+    private static final DateTimeFormatter DATA_HORA_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    private static final int LIMITE_CARTOES = 20;
+
+    private final AgendamentoService agendamentoService;
+    private final AutenticacaoClient autenticacaoClient;
+    private final ClienteStatusPatio clienteStatusPatio;
+
+    public CentralAcaoAgendamentoService(AgendamentoService agendamentoService,
+                                         AutenticacaoClient autenticacaoClient,
+                                         ClienteStatusPatio clienteStatusPatio) {
+        this.agendamentoService = agendamentoService;
+        this.autenticacaoClient = autenticacaoClient;
+        this.clienteStatusPatio = clienteStatusPatio;
+    }
+
+    public CentralAcaoAgendamentoRespostaDTO montarVisaoCompleta(String authorizationHeader) {
+        Page<AgendamentoDTO> pagina = agendamentoService.buscar(null, null,
+                PageRequest.of(0, LIMITE_CARTOES, Sort.by(Sort.Direction.ASC, "horarioPrevistoChegada")));
+
+        Optional<StatusPatioResposta> situacaoPatio = clienteStatusPatio.consultarStatus(authorizationHeader);
+        Optional<UserInfoResponse> usuarioAtual = buscarUsuarioAtual(authorizationHeader);
+
+        List<VisaoCompletaAgendamentoDTO> visoes = pagina.getContent().stream()
+                .sorted(Comparator.comparing((AgendamentoDTO dto) ->
+                        Optional.ofNullable(dto.getHorarioPrevistoChegada()).orElse(LocalDateTime.MAX)))
+                .map(dto -> montarVisao(dto, situacaoPatio.orElse(null)))
+                .collect(Collectors.toList());
+
+        CentralAcaoAgendamentoRespostaDTO resposta = new CentralAcaoAgendamentoRespostaDTO();
+        resposta.setAgendamentos(visoes);
+        usuarioAtual.map(this::converterUsuario).ifPresent(resposta::setUsuario);
+        situacaoPatio.map(this::converterSituacaoPatio).ifPresent(resposta::setSituacaoPatio);
+        return resposta;
+    }
+
+    public VisaoCompletaAgendamentoDTO montarVisaoPorId(Long id, String authorizationHeader) {
+        AgendamentoDTO agendamento = agendamentoService.buscarPorId(id);
+        Optional<StatusPatioResposta> situacaoPatio = clienteStatusPatio.consultarStatus(authorizationHeader);
+        return montarVisao(agendamento, situacaoPatio.orElse(null));
+    }
+
+    private VisaoCompletaAgendamentoDTO montarVisao(AgendamentoDTO agendamento, StatusPatioResposta situacaoPatio) {
+        if (agendamento == null) {
+            return new VisaoCompletaAgendamentoDTO();
+        }
+
+        String codigoSanitizado = HtmlUtils.htmlEscape(agendamento.getCodigo());
+        String statusSanitizado = HtmlUtils.htmlEscape(agendamento.getStatus());
+        String statusDescricao = HtmlUtils.htmlEscape(agendamento.getStatusDescricao());
+        String tipoOperacaoDescricao = HtmlUtils.htmlEscape(agendamento.getTipoOperacaoDescricao());
+        String placaVeiculo = HtmlUtils.htmlEscape(agendamento.getPlacaVeiculo());
+        String transportadoraNome = HtmlUtils.htmlEscape(agendamento.getTransportadoraNome());
+        String motoristaNome = HtmlUtils.htmlEscape(agendamento.getMotoristaNome());
+
+        AcaoAgendamentoDTO acao = definirAcaoPrincipal(agendamento);
+        String mensagemOrientacao = construirMensagemOrientacao(agendamento, acao, situacaoPatio);
+
+        VisaoCompletaAgendamentoDTO visao = new VisaoCompletaAgendamentoDTO();
+        visao.setAgendamentoId(agendamento.getId());
+        visao.setCodigo(codigoSanitizado);
+        visao.setStatus(statusSanitizado);
+        visao.setStatusDescricao(statusDescricao);
+        visao.setTipoOperacaoDescricao(tipoOperacaoDescricao);
+        visao.setHorarioPrevistoChegada(formatarDataHora(agendamento.getHorarioPrevistoChegada()));
+        visao.setHorarioPrevistoSaida(formatarDataHora(agendamento.getHorarioPrevistoSaida()));
+        visao.setPlacaVeiculo(placaVeiculo);
+        visao.setTransportadoraNome(transportadoraNome);
+        visao.setMotoristaNome(motoristaNome);
+        visao.setJanelaData(formatarData(agendamento.getDataJanela()));
+        visao.setJanelaHoraInicio(formatarHora(agendamento.getHoraInicioJanela()));
+        visao.setJanelaHoraFim(formatarHora(agendamento.getHoraFimJanela()));
+        visao.setMensagemOrientacao(HtmlUtils.htmlEscape(mensagemOrientacao));
+        visao.setAcaoPrincipal(acao);
+        visao.setDocumentosPendentes(mapearDocumentosPendentes(agendamento.getDocumentos()));
+        return visao;
+    }
+
+    private List<DocumentoPendenteDTO> mapearDocumentosPendentes(List<DocumentoAgendamentoDTO> documentos) {
+        if (documentos == null) {
+            return Collections.emptyList();
+        }
+        return documentos.stream()
+                .filter(Objects::nonNull)
+                .filter(doc -> !"VALIDADO".equalsIgnoreCase(doc.getStatusValidacao()))
+                .map(doc -> new DocumentoPendenteDTO(
+                        doc.getId(),
+                        HtmlUtils.htmlEscape(doc.getNomeArquivo()),
+                        HtmlUtils.htmlEscape(doc.getTipoDocumento()),
+                        HtmlUtils.htmlEscape(Objects.requireNonNullElse(doc.getMensagemValidacao(),
+                                doc.getStatusValidacaoDescricao()))))
+                .collect(Collectors.toList());
+    }
+
+    private String construirMensagemOrientacao(AgendamentoDTO agendamento,
+                                                AcaoAgendamentoDTO acao,
+                                                StatusPatioResposta situacaoPatio) {
+        StringBuilder mensagem = new StringBuilder();
+        String tituloAcao = null;
+        if (acao != null && StringUtils.hasText(acao.getTitulo())) {
+            tituloAcao = HtmlUtils.htmlUnescape(acao.getTitulo());
+        }
+        if (StringUtils.hasText(tituloAcao)) {
+            mensagem.append("Próxima ação: ").append(tituloAcao);
+        }
+        if (agendamento.getHorarioPrevistoChegada() != null) {
+            if (mensagem.length() > 0) {
+                mensagem.append(" • ");
+            }
+            mensagem.append("Janela prevista às ")
+                    .append(HORA_FORMATTER.format(agendamento.getHorarioPrevistoChegada().toLocalTime()));
+        }
+        if (situacaoPatio != null && StringUtils.hasText(situacaoPatio.getDescricao())) {
+            if (mensagem.length() > 0) {
+                mensagem.append(" • ");
+            }
+            mensagem.append("Pátio: ").append(situacaoPatio.getDescricao());
+        }
+        return mensagem.toString();
+    }
+
+    private AcaoAgendamentoDTO definirAcaoPrincipal(AgendamentoDTO agendamento) {
+        StatusAgendamento status = interpretarStatus(agendamento.getStatus());
+        if (status == null) {
+            return null;
+        }
+        String rotaConfirmacao = String.format("/gate/agendamentos/%d/confirmar-chegada", agendamento.getId());
+        switch (status) {
+            case PENDENTE:
+            case CONFIRMADO:
+                return new AcaoAgendamentoDTO(
+                        "CONFIRMAR_CHEGADA",
+                        HtmlUtils.htmlEscape("Confirmar chegada"),
+                        HtmlUtils.htmlEscape("Avise ao gate que você já está no local e aguarde liberação."),
+                        "POST",
+                        rotaConfirmacao,
+                        true
+                );
+            case EM_ATENDIMENTO:
+                return new AcaoAgendamentoDTO(
+                        "AGUARDAR_LIBERACAO",
+                        HtmlUtils.htmlEscape("Aguardar liberação"),
+                        HtmlUtils.htmlEscape("Aguarde a atualização do status do gate pass pelo operador."),
+                        "GET",
+                        null,
+                        false
+                );
+            case EM_EXECUCAO:
+                return new AcaoAgendamentoDTO(
+                        "ACOMPANHAR_OPERACAO",
+                        HtmlUtils.htmlEscape("Acompanhar operação"),
+                        HtmlUtils.htmlEscape("Siga as orientações no local até a conclusão do atendimento."),
+                        "GET",
+                        null,
+                        false
+                );
+            default:
+                return new AcaoAgendamentoDTO(
+                        "FINALIZADO",
+                        HtmlUtils.htmlEscape("Operação finalizada"),
+                        HtmlUtils.htmlEscape("Revise os documentos e prepare-se para o próximo agendamento."),
+                        "GET",
+                        null,
+                        false
+                );
+        }
+    }
+
+    private StatusAgendamento interpretarStatus(String status) {
+        if (!StringUtils.hasText(status)) {
+            return null;
+        }
+        try {
+            return StatusAgendamento.valueOf(status.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private Optional<UserInfoResponse> buscarUsuarioAtual(String authorizationHeader) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof JwtAuthenticationToken) {
+            JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+            Jwt token = jwtAuthenticationToken.getToken();
+            String login = token.getSubject();
+            if (StringUtils.hasText(login)) {
+                return autenticacaoClient.buscarUsuario(login, authorizationHeader);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private UsuarioCentralAcaoDTO converterUsuario(UserInfoResponse response) {
+        if (response == null) {
+            return null;
+        }
+        return new UsuarioCentralAcaoDTO(
+                HtmlUtils.htmlEscape(response.getLogin()),
+                HtmlUtils.htmlEscape(response.getNome()),
+                HtmlUtils.htmlEscape(response.getPerfil()),
+                HtmlUtils.htmlEscape(response.getTransportadoraDocumento()),
+                HtmlUtils.htmlEscape(response.getTransportadoraNome())
+        );
+    }
+
+    private SituacaoPatioDTO converterSituacaoPatio(StatusPatioResposta resposta) {
+        if (resposta == null) {
+            return null;
+        }
+        return new SituacaoPatioDTO(
+                HtmlUtils.htmlEscape(resposta.getStatus()),
+                HtmlUtils.htmlEscape(resposta.getDescricao()),
+                HtmlUtils.htmlEscape(resposta.getVerificadoEm())
+        );
+    }
+
+    private String formatarData(LocalDate data) {
+        return data != null ? DATA_FORMATTER.format(data) : null;
+    }
+
+    private String formatarHora(LocalTime hora) {
+        return hora != null ? HORA_FORMATTER.format(hora) : null;
+    }
+
+    private String formatarDataHora(LocalDateTime dataHora) {
+        return dataHora != null ? DATA_HORA_FORMATTER.format(dataHora) : null;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/AcaoAgendamentoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/AcaoAgendamentoDTO.java
@@ -1,0 +1,76 @@
+package br.com.cloudport.servicogate.app.cidadao.centralacao.dto;
+
+public class AcaoAgendamentoDTO {
+
+    private String codigo;
+    private String titulo;
+    private String descricao;
+    private String metodoHttp;
+    private String rotaApiRelativa;
+    private boolean habilitada;
+
+    public AcaoAgendamentoDTO() {
+    }
+
+    public AcaoAgendamentoDTO(String codigo,
+                               String titulo,
+                               String descricao,
+                               String metodoHttp,
+                               String rotaApiRelativa,
+                               boolean habilitada) {
+        this.codigo = codigo;
+        this.titulo = titulo;
+        this.descricao = descricao;
+        this.metodoHttp = metodoHttp;
+        this.rotaApiRelativa = rotaApiRelativa;
+        this.habilitada = habilitada;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public String getTitulo() {
+        return titulo;
+    }
+
+    public void setTitulo(String titulo) {
+        this.titulo = titulo;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getMetodoHttp() {
+        return metodoHttp;
+    }
+
+    public void setMetodoHttp(String metodoHttp) {
+        this.metodoHttp = metodoHttp;
+    }
+
+    public String getRotaApiRelativa() {
+        return rotaApiRelativa;
+    }
+
+    public void setRotaApiRelativa(String rotaApiRelativa) {
+        this.rotaApiRelativa = rotaApiRelativa;
+    }
+
+    public boolean isHabilitada() {
+        return habilitada;
+    }
+
+    public void setHabilitada(boolean habilitada) {
+        this.habilitada = habilitada;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/CentralAcaoAgendamentoRespostaDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/CentralAcaoAgendamentoRespostaDTO.java
@@ -1,0 +1,48 @@
+package br.com.cloudport.servicogate.app.cidadao.centralacao.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CentralAcaoAgendamentoRespostaDTO {
+
+    private UsuarioCentralAcaoDTO usuario;
+    private SituacaoPatioDTO situacaoPatio;
+    private List<VisaoCompletaAgendamentoDTO> agendamentos = new ArrayList<>();
+
+    public CentralAcaoAgendamentoRespostaDTO() {
+    }
+
+    public CentralAcaoAgendamentoRespostaDTO(UsuarioCentralAcaoDTO usuario,
+                                             SituacaoPatioDTO situacaoPatio,
+                                             List<VisaoCompletaAgendamentoDTO> agendamentos) {
+        this.usuario = usuario;
+        this.situacaoPatio = situacaoPatio;
+        if (agendamentos != null) {
+            this.agendamentos = agendamentos;
+        }
+    }
+
+    public UsuarioCentralAcaoDTO getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(UsuarioCentralAcaoDTO usuario) {
+        this.usuario = usuario;
+    }
+
+    public SituacaoPatioDTO getSituacaoPatio() {
+        return situacaoPatio;
+    }
+
+    public void setSituacaoPatio(SituacaoPatioDTO situacaoPatio) {
+        this.situacaoPatio = situacaoPatio;
+    }
+
+    public List<VisaoCompletaAgendamentoDTO> getAgendamentos() {
+        return agendamentos;
+    }
+
+    public void setAgendamentos(List<VisaoCompletaAgendamentoDTO> agendamentos) {
+        this.agendamentos = agendamentos != null ? agendamentos : new ArrayList<>();
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/DocumentoPendenteDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/DocumentoPendenteDTO.java
@@ -1,0 +1,51 @@
+package br.com.cloudport.servicogate.app.cidadao.centralacao.dto;
+
+public class DocumentoPendenteDTO {
+
+    private Long id;
+    private String nomeArquivo;
+    private String tipoDocumento;
+    private String mensagem;
+
+    public DocumentoPendenteDTO() {
+    }
+
+    public DocumentoPendenteDTO(Long id, String nomeArquivo, String tipoDocumento, String mensagem) {
+        this.id = id;
+        this.nomeArquivo = nomeArquivo;
+        this.tipoDocumento = tipoDocumento;
+        this.mensagem = mensagem;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNomeArquivo() {
+        return nomeArquivo;
+    }
+
+    public void setNomeArquivo(String nomeArquivo) {
+        this.nomeArquivo = nomeArquivo;
+    }
+
+    public String getTipoDocumento() {
+        return tipoDocumento;
+    }
+
+    public void setTipoDocumento(String tipoDocumento) {
+        this.tipoDocumento = tipoDocumento;
+    }
+
+    public String getMensagem() {
+        return mensagem;
+    }
+
+    public void setMensagem(String mensagem) {
+        this.mensagem = mensagem;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/SituacaoPatioDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/SituacaoPatioDTO.java
@@ -1,0 +1,41 @@
+package br.com.cloudport.servicogate.app.cidadao.centralacao.dto;
+
+public class SituacaoPatioDTO {
+
+    private String status;
+    private String descricao;
+    private String verificadoEm;
+
+    public SituacaoPatioDTO() {
+    }
+
+    public SituacaoPatioDTO(String status, String descricao, String verificadoEm) {
+        this.status = status;
+        this.descricao = descricao;
+        this.verificadoEm = verificadoEm;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getVerificadoEm() {
+        return verificadoEm;
+    }
+
+    public void setVerificadoEm(String verificadoEm) {
+        this.verificadoEm = verificadoEm;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/UsuarioCentralAcaoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/UsuarioCentralAcaoDTO.java
@@ -1,0 +1,65 @@
+package br.com.cloudport.servicogate.app.cidadao.centralacao.dto;
+
+public class UsuarioCentralAcaoDTO {
+
+    private String login;
+    private String nome;
+    private String perfil;
+    private String transportadoraDocumento;
+    private String transportadoraNome;
+
+    public UsuarioCentralAcaoDTO() {
+    }
+
+    public UsuarioCentralAcaoDTO(String login,
+                                  String nome,
+                                  String perfil,
+                                  String transportadoraDocumento,
+                                  String transportadoraNome) {
+        this.login = login;
+        this.nome = nome;
+        this.perfil = perfil;
+        this.transportadoraDocumento = transportadoraDocumento;
+        this.transportadoraNome = transportadoraNome;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getPerfil() {
+        return perfil;
+    }
+
+    public void setPerfil(String perfil) {
+        this.perfil = perfil;
+    }
+
+    public String getTransportadoraDocumento() {
+        return transportadoraDocumento;
+    }
+
+    public void setTransportadoraDocumento(String transportadoraDocumento) {
+        this.transportadoraDocumento = transportadoraDocumento;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+
+    public void setTransportadoraNome(String transportadoraNome) {
+        this.transportadoraNome = transportadoraNome;
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/VisaoCompletaAgendamentoDTO.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/centralacao/dto/VisaoCompletaAgendamentoDTO.java
@@ -1,0 +1,191 @@
+package br.com.cloudport.servicogate.app.cidadao.centralacao.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class VisaoCompletaAgendamentoDTO {
+
+    private Long agendamentoId;
+    private String codigo;
+    private String status;
+    private String statusDescricao;
+    private String tipoOperacaoDescricao;
+    private String horarioPrevistoChegada;
+    private String horarioPrevistoSaida;
+    private String placaVeiculo;
+    private String transportadoraNome;
+    private String motoristaNome;
+    private String janelaData;
+    private String janelaHoraInicio;
+    private String janelaHoraFim;
+    private String mensagemOrientacao;
+    private AcaoAgendamentoDTO acaoPrincipal;
+    private List<DocumentoPendenteDTO> documentosPendentes = new ArrayList<>();
+
+    public VisaoCompletaAgendamentoDTO() {
+    }
+
+    public VisaoCompletaAgendamentoDTO(Long agendamentoId,
+                                        String codigo,
+                                        String status,
+                                        String statusDescricao,
+                                        String tipoOperacaoDescricao,
+                                        String horarioPrevistoChegada,
+                                        String horarioPrevistoSaida,
+                                        String placaVeiculo,
+                                        String transportadoraNome,
+                                        String motoristaNome,
+                                        String janelaData,
+                                        String janelaHoraInicio,
+                                        String janelaHoraFim,
+                                        String mensagemOrientacao,
+                                        AcaoAgendamentoDTO acaoPrincipal,
+                                        List<DocumentoPendenteDTO> documentosPendentes) {
+        this.agendamentoId = agendamentoId;
+        this.codigo = codigo;
+        this.status = status;
+        this.statusDescricao = statusDescricao;
+        this.tipoOperacaoDescricao = tipoOperacaoDescricao;
+        this.horarioPrevistoChegada = horarioPrevistoChegada;
+        this.horarioPrevistoSaida = horarioPrevistoSaida;
+        this.placaVeiculo = placaVeiculo;
+        this.transportadoraNome = transportadoraNome;
+        this.motoristaNome = motoristaNome;
+        this.janelaData = janelaData;
+        this.janelaHoraInicio = janelaHoraInicio;
+        this.janelaHoraFim = janelaHoraFim;
+        this.mensagemOrientacao = mensagemOrientacao;
+        this.acaoPrincipal = acaoPrincipal;
+        if (documentosPendentes != null) {
+            this.documentosPendentes = documentosPendentes;
+        }
+    }
+
+    public Long getAgendamentoId() {
+        return agendamentoId;
+    }
+
+    public void setAgendamentoId(Long agendamentoId) {
+        this.agendamentoId = agendamentoId;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatusDescricao() {
+        return statusDescricao;
+    }
+
+    public void setStatusDescricao(String statusDescricao) {
+        this.statusDescricao = statusDescricao;
+    }
+
+    public String getTipoOperacaoDescricao() {
+        return tipoOperacaoDescricao;
+    }
+
+    public void setTipoOperacaoDescricao(String tipoOperacaoDescricao) {
+        this.tipoOperacaoDescricao = tipoOperacaoDescricao;
+    }
+
+    public String getHorarioPrevistoChegada() {
+        return horarioPrevistoChegada;
+    }
+
+    public void setHorarioPrevistoChegada(String horarioPrevistoChegada) {
+        this.horarioPrevistoChegada = horarioPrevistoChegada;
+    }
+
+    public String getHorarioPrevistoSaida() {
+        return horarioPrevistoSaida;
+    }
+
+    public void setHorarioPrevistoSaida(String horarioPrevistoSaida) {
+        this.horarioPrevistoSaida = horarioPrevistoSaida;
+    }
+
+    public String getPlacaVeiculo() {
+        return placaVeiculo;
+    }
+
+    public void setPlacaVeiculo(String placaVeiculo) {
+        this.placaVeiculo = placaVeiculo;
+    }
+
+    public String getTransportadoraNome() {
+        return transportadoraNome;
+    }
+
+    public void setTransportadoraNome(String transportadoraNome) {
+        this.transportadoraNome = transportadoraNome;
+    }
+
+    public String getMotoristaNome() {
+        return motoristaNome;
+    }
+
+    public void setMotoristaNome(String motoristaNome) {
+        this.motoristaNome = motoristaNome;
+    }
+
+    public String getJanelaData() {
+        return janelaData;
+    }
+
+    public void setJanelaData(String janelaData) {
+        this.janelaData = janelaData;
+    }
+
+    public String getJanelaHoraInicio() {
+        return janelaHoraInicio;
+    }
+
+    public void setJanelaHoraInicio(String janelaHoraInicio) {
+        this.janelaHoraInicio = janelaHoraInicio;
+    }
+
+    public String getJanelaHoraFim() {
+        return janelaHoraFim;
+    }
+
+    public void setJanelaHoraFim(String janelaHoraFim) {
+        this.janelaHoraFim = janelaHoraFim;
+    }
+
+    public String getMensagemOrientacao() {
+        return mensagemOrientacao;
+    }
+
+    public void setMensagemOrientacao(String mensagemOrientacao) {
+        this.mensagemOrientacao = mensagemOrientacao;
+    }
+
+    public AcaoAgendamentoDTO getAcaoPrincipal() {
+        return acaoPrincipal;
+    }
+
+    public void setAcaoPrincipal(AcaoAgendamentoDTO acaoPrincipal) {
+        this.acaoPrincipal = acaoPrincipal;
+    }
+
+    public List<DocumentoPendenteDTO> getDocumentosPendentes() {
+        return documentosPendentes;
+    }
+
+    public void setDocumentosPendentes(List<DocumentoPendenteDTO> documentosPendentes) {
+        this.documentosPendentes = documentosPendentes != null ? documentosPendentes : new ArrayList<>();
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/yard/ClienteStatusPatio.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/yard/ClienteStatusPatio.java
@@ -1,0 +1,75 @@
+package br.com.cloudport.servicogate.integration.yard;
+
+import br.com.cloudport.servicogate.integration.yard.dto.StatusPatioResposta;
+import br.com.cloudport.servicogate.monitoring.IntegracaoDegradacaoHandler;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import java.net.URI;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class ClienteStatusPatio {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClienteStatusPatio.class);
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+    private final String statusPath;
+    private final IntegracaoDegradacaoHandler degradacaoHandler;
+    private final String fallbackOrientacao;
+
+    public ClienteStatusPatio(RestTemplate restTemplate,
+                              @Value("${cloudport.integracoes.yard.base-url:http://localhost:8083}") String baseUrl,
+                              @Value("${cloudport.integracoes.yard.status-path:/yard/status}") String statusPath,
+                              IntegracaoDegradacaoHandler degradacaoHandler,
+                              @Value("${cloudport.integracoes.yard.fallback-orientacao:Consultar equipe de pátio para orientações manuais.}")
+                                      String fallbackOrientacao) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+        this.statusPath = statusPath;
+        this.degradacaoHandler = degradacaoHandler;
+        this.fallbackOrientacao = fallbackOrientacao;
+    }
+
+    @CircuitBreaker(name = "yardStatus", fallbackMethod = "fallbackConsultarStatus")
+    public Optional<StatusPatioResposta> consultarStatus(String authorizationHeader) {
+        if (!StringUtils.hasText(baseUrl)) {
+            return Optional.empty();
+        }
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            if (StringUtils.hasText(authorizationHeader)) {
+                headers.set(HttpHeaders.AUTHORIZATION, authorizationHeader);
+            }
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+            URI uri = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                    .path(statusPath)
+                    .build(true)
+                    .toUri();
+            ResponseEntity<StatusPatioResposta> resposta = restTemplate.exchange(uri, HttpMethod.GET, entity, StatusPatioResposta.class);
+            return Optional.ofNullable(resposta.getBody());
+        } catch (RestClientException ex) {
+            LOGGER.debug("Falha ao consultar status do pátio", ex);
+            return Optional.empty();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private Optional<StatusPatioResposta> fallbackConsultarStatus(String authorizationHeader, Throwable throwable) {
+        degradacaoHandler.registrarDegradacao("servico-yard", "circuit-breaker", fallbackOrientacao);
+        LOGGER.warn("event=yard.status.fallback orientacao=\"{}\" causa={}", fallbackOrientacao,
+                throwable != null ? throwable.getMessage() : "indefinida");
+        return Optional.empty();
+    }
+}

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/yard/dto/StatusPatioResposta.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/integration/yard/dto/StatusPatioResposta.java
@@ -1,0 +1,35 @@
+package br.com.cloudport.servicogate.integration.yard.dto;
+
+public class StatusPatioResposta {
+
+    private String status;
+    private String descricao;
+    private String verificadoEm;
+
+    public StatusPatioResposta() {
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getVerificadoEm() {
+        return verificadoEm;
+    }
+
+    public void setVerificadoEm(String verificadoEm) {
+        this.verificadoEm = verificadoEm;
+    }
+}

--- a/backend/servico-gate/src/main/resources/application.properties
+++ b/backend/servico-gate/src/main/resources/application.properties
@@ -22,6 +22,9 @@ spring.rabbitmq.password=${GATE_RABBIT_PASSWORD:guest}
 cloudport.security.jwt.secret=${GATE_SECURITY_JWT_SECRET:change-me}
 cloudport.security.cors.allowed-origins=${GATE_SECURITY_CORS_ALLOWED_ORIGINS:http://localhost:3000}
 cloudport.security.autenticacao.base-url=${GATE_SECURITY_AUTENTICACAO_BASE_URL:http://localhost:8081}
+cloudport.integracoes.yard.base-url=${GATE_INTEGRACAO_YARD_BASE_URL:http://localhost:8081}
+cloudport.integracoes.yard.status-path=${GATE_INTEGRACAO_YARD_STATUS_PATH:/yard/status}
+cloudport.integracoes.yard.fallback-orientacao=${GATE_INTEGRACAO_YARD_FALLBACK:Consultar equipe de pátio para orientações manuais.}
 
 management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.endpoint.health.probes.enabled=true
@@ -97,3 +100,7 @@ resilience4j.circuitbreaker.instances.autenticacao.register-health-indicator=tru
 resilience4j.circuitbreaker.instances.autenticacao.sliding-window-size=${RESILIENCE4J_AUTENTICACAO_WINDOW_SIZE:6}
 resilience4j.circuitbreaker.instances.autenticacao.failure-rate-threshold=${RESILIENCE4J_AUTENTICACAO_FAILURE_THRESHOLD:50}
 resilience4j.circuitbreaker.instances.autenticacao.wait-duration-in-open-state=${RESILIENCE4J_AUTENTICACAO_WAIT_DURATION:PT15S}
+resilience4j.circuitbreaker.instances.yardStatus.register-health-indicator=true
+resilience4j.circuitbreaker.instances.yardStatus.sliding-window-size=${RESILIENCE4J_YARD_WINDOW_SIZE:6}
+resilience4j.circuitbreaker.instances.yardStatus.failure-rate-threshold=${RESILIENCE4J_YARD_FAILURE_THRESHOLD:50}
+resilience4j.circuitbreaker.instances.yardStatus.wait-duration-in-open-state=${RESILIENCE4J_YARD_WAIT_DURATION:PT15S}

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.css
@@ -1,158 +1,225 @@
-.gate-agendamentos {
+.central-acao {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 24px;
-  background: linear-gradient(180deg, rgba(37, 99, 235, 0.05), transparent);
-  min-height: 100vh;
+  gap: 1.5rem;
+  padding: 1.5rem 1rem 2rem;
+  max-width: 960px;
+  margin: 0 auto;
 }
 
-.gate-agendamentos__cabecalho h2 {
+.central-acao__cabecalho {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.central-acao__cabecalho h2 {
+  margin: 0 0 0.25rem;
+  font-size: 1.5rem;
+}
+
+.central-acao__saudacao {
   margin: 0;
-  font-size: 2rem;
+  font-size: 0.95rem;
+  color: #274472;
+}
+
+.central-acao__patio {
+  background-color: rgba(39, 68, 114, 0.08);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
   color: #1f2937;
 }
 
-.gate-agendamentos__cabecalho p {
-  margin: 6px 0 0;
-  color: #6b7280;
+.central-acao__mensagem {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  font-size: 0.95rem;
 }
 
-.gate-agendamentos__metricas {
+.central-acao__mensagem--erro {
+  background-color: rgba(220, 38, 38, 0.1);
+  color: #991b1b;
+}
+
+.central-acao__mensagem--sucesso {
+  background-color: rgba(22, 163, 74, 0.1);
+  color: #047857;
+}
+
+.central-acao__cards {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.central-acao__card {
   background: #ffffff;
   border-radius: 16px;
-  padding: 20px 24px;
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  padding: 1.25rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1rem;
 }
 
-.metricas__cabecalho {
+.card-acao__cabecalho {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card-acao__cabecalho-linha {
+  display: flex;
   justify-content: space-between;
-  gap: 12px;
+  align-items: baseline;
+  gap: 0.75rem;
 }
 
-.btn--terciario {
-  border: 1px solid rgba(37, 99, 235, 0.35);
-  background: rgba(37, 99, 235, 0.08);
-  color: #1d4ed8;
-  padding: 8px 18px;
-  border-radius: 999px;
+.card-acao__codigo {
   font-weight: 600;
-  transition: background 0.2s ease, transform 0.2s ease;
+  color: #1f2937;
 }
 
-.btn--terciario:hover:not(:disabled) {
-  background: rgba(37, 99, 235, 0.16);
-  transform: translateY(-1px);
+.card-acao__status {
+  font-size: 0.85rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background-color: rgba(148, 163, 184, 0.2);
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
-.btn--terciario:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.card-acao__status--ativo {
+  background-color: rgba(22, 163, 74, 0.12);
+  color: #047857;
 }
 
-.metricas__cabecalho h3 {
+.card-acao__status--inativo {
+  background-color: rgba(234, 179, 8, 0.18);
+  color: #92400e;
+}
+
+.card-acao__janela {
   margin: 0;
-  color: #111827;
-  font-size: 1.25rem;
-}
-
-.metricas__estado {
-  margin: 0;
+  font-size: 0.9rem;
   color: #2563eb;
   font-weight: 500;
 }
 
-.metricas__estado--erro {
-  color: #b91c1c;
-}
-
-.metricas__grid {
+.card-acao__informacoes {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
-}
-
-.metricas__card {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(16, 185, 129, 0.12));
-  border-radius: 14px;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  color: #1f2937;
-}
-
-.metricas__card h4 {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
   margin: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
 }
 
-.metricas__card strong {
-  font-size: 1.8rem;
-  font-weight: 700;
+.card-acao__informacoes dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-bottom: 0.15rem;
+}
+
+.card-acao__informacoes dd {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2937;
+  font-size: 0.95rem;
+}
+
+.card-acao__documentos {
+  background-color: rgba(59, 130, 246, 0.08);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.card-acao__documentos h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
   color: #1d4ed8;
 }
 
-.metricas__card span {
-  color: #374151;
-  font-size: 0.85rem;
-}
-
-.metricas__card--largura {
-  grid-column: span 2;
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.15), rgba(59, 130, 246, 0.08));
-}
-
-.metricas__card--largura p {
+.card-acao__documentos ul {
+  list-style: none;
   margin: 0;
-  font-size: 1rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.card-acao__documentos li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  color: #1f2937;
+}
+
+.card-acao__documentos small {
+  color: #1d4ed8;
+  font-size: 0.8rem;
+}
+
+.card-acao__orientacao {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1f2937;
   line-height: 1.4;
 }
 
-.texto--positivo {
-  color: #047857;
+.card-acao__botao {
+  width: 100%;
+  justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2.75rem;
   font-weight: 600;
 }
 
-.texto--negativo {
-  color: #b91c1c;
-  font-weight: 600;
+.card-acao__descricao {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4b5563;
 }
 
-.gate-agendamentos__conteudo {
-  display: grid;
-  grid-template-columns: minmax(360px, 1fr) 1fr;
-  gap: 24px;
-  align-items: start;
+.card-acao__spinner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-top-color: rgba(255, 255, 255, 1);
+  animation: girar 0.8s linear infinite;
 }
 
-.gate-agendamentos__form {
-  animation: surgir 0.3s ease;
+.central-acao__vazio {
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: rgba(148, 163, 184, 0.15);
+  color: #1f2937;
+  font-size: 0.95rem;
 }
 
-@keyframes surgir {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
+@keyframes girar {
   to {
-    opacity: 1;
-    transform: translateY(0);
+    transform: rotate(360deg);
   }
 }
 
-@media (max-width: 1100px) {
-  .gate-agendamentos__conteudo {
-    grid-template-columns: 1fr;
+@media (min-width: 768px) {
+  .central-acao {
+    padding: 2rem 1.5rem 3rem;
   }
 
-  .metricas__card--largura {
-    grid-column: span 1;
+  .central-acao__cards {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   }
 }

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.html
@@ -1,83 +1,96 @@
-<section class="gate-agendamentos">
-  <header class="gate-agendamentos__cabecalho">
+<section class="central-acao">
+  <header class="central-acao__cabecalho">
     <div>
       <h2>{{ titulo }}</h2>
-      <p>Gestão integrada de janelas, documentos e status em tempo real.</p>
+      <p class="central-acao__saudacao" *ngIf="resposta?.usuario?.nome">
+        Olá, {{ resposta?.usuario?.nome }}!
+      </p>
+      <p class="central-acao__saudacao" *ngIf="resposta?.usuario?.transportadoraNome">
+        {{ resposta?.usuario?.transportadoraNome }}
+      </p>
     </div>
+    <button type="button" class="btn btn--terciario" (click)="carregarVisao()" [disabled]="carregando">
+      {{ carregando ? 'Atualizando…' : 'Atualizar visão' }}
+    </button>
   </header>
 
-  <section class="gate-agendamentos__metricas" aria-live="polite">
-    <div class="metricas__cabecalho">
-      <h3>Métricas de adoção</h3>
-      <button type="button" class="btn btn--terciario" (click)="carregarResumoUso()" [disabled]="carregandoResumo">
-        {{ carregandoResumo ? 'Atualizando…' : 'Atualizar métricas' }}
+  <section class="central-acao__patio" *ngIf="resposta?.situacaoPatio as patio">
+    <strong>Situação do pátio:</strong>
+    <span>{{ patio.descricao || patio.status || 'Indisponível' }}</span>
+    <small *ngIf="patio.verificadoEm">Verificado em {{ patio.verificadoEm | date: 'dd/MM/yyyy HH:mm' }}</small>
+  </section>
+
+  <p class="central-acao__mensagem central-acao__mensagem--erro" *ngIf="erroCarregamento">{{ erroCarregamento }}</p>
+  <p class="central-acao__mensagem central-acao__mensagem--sucesso" *ngIf="mensagemSucesso">{{ mensagemSucesso }}</p>
+  <p class="central-acao__mensagem" *ngIf="carregando">Carregando visão consolidada do seu agendamento…</p>
+
+  <section *ngIf="!carregando && resposta?.agendamentos?.length" class="central-acao__cards">
+    <article
+      *ngFor="let card of resposta?.agendamentos; trackBy: trackPorId"
+      class="central-acao__card"
+      aria-label="Card de ação do agendamento"
+    >
+      <header class="card-acao__cabecalho">
+        <div class="card-acao__cabecalho-linha">
+          <span class="card-acao__codigo">Agendamento {{ card.codigo }}</span>
+          <span
+            class="card-acao__status"
+            [ngClass]="{
+              'card-acao__status--ativo': card.acaoPrincipal?.habilitada,
+              'card-acao__status--inativo': !card.acaoPrincipal?.habilitada
+            }"
+          >
+            {{ card.statusDescricao || card.status }}
+          </span>
+        </div>
+        <p class="card-acao__janela">{{ formatarJanela(card) }}</p>
+      </header>
+
+      <dl class="card-acao__informacoes">
+        <div>
+          <dt>Motorista</dt>
+          <dd>{{ card.motoristaNome || 'Não informado' }}</dd>
+        </div>
+        <div>
+          <dt>Transportadora</dt>
+          <dd>{{ card.transportadoraNome || 'Não informado' }}</dd>
+        </div>
+        <div>
+          <dt>Veículo</dt>
+          <dd>{{ card.placaVeiculo || '—' }}</dd>
+        </div>
+        <div>
+          <dt>Chegada prevista</dt>
+          <dd>{{ formatarHorario(card.horarioPrevistoChegada) }}</dd>
+        </div>
+      </dl>
+
+      <section class="card-acao__documentos" *ngIf="card.documentosPendentes?.length">
+        <h4>Documentos pendentes</h4>
+        <ul>
+          <li *ngFor="let documento of card.documentosPendentes">
+            <span>{{ documento.nomeArquivo }}</span>
+            <small>{{ documento.mensagem || 'Aguardando validação automática' }}</small>
+          </li>
+        </ul>
+      </section>
+
+      <p class="card-acao__orientacao" *ngIf="card.mensagemOrientacao">{{ card.mensagemOrientacao }}</p>
+
+      <button
+        type="button"
+        class="btn btn--primario card-acao__botao"
+        (click)="executarAcao(card)"
+        [disabled]="!card.acaoPrincipal?.habilitada || acaoEmExecucao === card.agendamentoId"
+      >
+        <span *ngIf="acaoEmExecucao === card.agendamentoId" class="card-acao__spinner" aria-hidden="true"></span>
+        {{ card.acaoPrincipal?.titulo || 'Sem ações disponíveis' }}
       </button>
-    </div>
-
-    <p class="metricas__estado" *ngIf="carregandoResumo">Carregando métricas consolidadas…</p>
-    <p class="metricas__estado metricas__estado--erro" *ngIf="!carregandoResumo && erroResumo">{{ erroResumo }}</p>
-
-    <div class="metricas__grid" *ngIf="!carregandoResumo && !erroResumo && resumoUso">
-      <article class="metricas__card" aria-label="Total de agendamentos no período">
-        <h4>Total no período</h4>
-        <strong>{{ resumoUso?.totalAgendamentos | number: '1.0-0' }}</strong>
-        <span>Agendamentos concluídos</span>
-      </article>
-
-      <article class="metricas__card" aria-label="Taxa de pontualidade">
-        <h4>Pontualidade</h4>
-        <strong>{{ resumoUso?.percentualPontualidade | number: '1.0-0' }}%</strong>
-        <span>Chegadas dentro da tolerância</span>
-      </article>
-
-      <article class="metricas__card" aria-label="Taxa de abandono do fluxo">
-        <h4>Abandono do fluxo</h4>
-        <strong>{{ resumoUso?.percentualAbandono | number: '1.0-0' }}%</strong>
-        <span>Período anterior: {{ resumoUso?.percentualAbandonoAnterior | number: '1.0-0' }}%</span>
-      </article>
-
-      <article class="metricas__card metricas__card--largura" aria-label="Mensagem de variação do abandono">
-        <h4>Confirmação de adoção</h4>
-        <p [ngClass]="{ 'texto--positivo': variacaoAbandonoEhPositiva(), 'texto--negativo': !variacaoAbandonoEhPositiva() }">
-          {{ obterMensagemVariacaoAbandono() }}
-        </p>
-      </article>
-    </div>
+      <p class="card-acao__descricao" *ngIf="card.acaoPrincipal?.descricao">{{ card.acaoPrincipal?.descricao }}</p>
+    </article>
   </section>
 
-  <div class="gate-agendamentos__conteudo">
-    <app-agendamentos-list
-      class="gate-agendamentos__lista"
-      [agendamentos]="agendamentos$ | async"
-      [loading]="carregandoLista"
-      [selectedId]="selecionadoId"
-      (selecionar)="selecionarAgendamento($event)"
-      (editar)="editarAgendamento($event)"
-      (cancelar)="cancelarAgendamento($event)"
-      (criar)="criarAgendamento()"
-      (atualizar)="atualizarLista()"
-    ></app-agendamentos-list>
-
-    <app-agendamento-detalhe
-      class="gate-agendamentos__detalhe"
-      [agendamento]="selecionado"
-      [uploadStatus]="uploadStatus"
-      (anexarDocumentos)="anexarDocumentos($event)"
-    ></app-agendamento-detalhe>
+  <div class="central-acao__vazio" *ngIf="!carregando && resposta && (!resposta.agendamentos || !resposta.agendamentos.length)">
+    Nenhuma ação pendente no momento. Revise sua documentação e acompanhe as notificações.
   </div>
-
-  <section class="gate-agendamentos__form" *ngIf="exibirFormulario">
-    <app-agendamento-form
-      [agendamento]="emEdicao"
-      [tiposOperacao$]="tiposOperacao$"
-      [status$]="status$"
-      [janelas$]="janelas$"
-      [documentosExistentes]="documentosExistentes"
-      [uploadStatus]="uploadStatus"
-      (salvar)="salvar($event)"
-      (cancelar)="cancelarFormulario()"
-    ></app-agendamento-form>
-  </section>
-
-  <app-modal></app-modal>
 </section>

--- a/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.ts
+++ b/frontend/cloudport/src/app/componentes/gate/agendamentos/gate-agendamentos.component.ts
@@ -1,13 +1,11 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { BehaviorSubject, EMPTY, Observable, Subject, from, of } from 'rxjs';
-import { catchError, concatMap, finalize, map, shareReplay, switchMap, take, takeUntil, tap, toArray } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { GateApiService } from '../../service/servico-gate/gate-api.service';
-import { GateDashboardService } from '../../service/servico-gate/gate-dashboard.service';
-import { Agendamento, AgendamentoFormPayload, DocumentoAgendamento, UploadDocumentoStatus } from '../../model/gate/agendamento.model';
-import { JanelaAtendimento } from '../../model/gate/janela.model';
-import { PopupService } from '../../service/popupService';
-import { HttpEventType } from '@angular/common/http';
-import { DashboardResumo } from '../../model/gate/dashboard.model';
+import {
+  CentralAcaoAgendamentoResposta,
+  VisaoCompletaAgendamento
+} from '../../model/gate/agendamento.model';
 
 @Component({
   selector: 'app-gate-agendamentos',
@@ -15,39 +13,20 @@ import { DashboardResumo } from '../../model/gate/dashboard.model';
   styleUrls: ['./gate-agendamentos.component.css']
 })
 export class GateAgendamentosComponent implements OnInit, OnDestroy {
-  readonly titulo = 'Agendamentos do Gate';
+  readonly titulo = 'Central de Ação do Gate';
+
+  carregando = false;
+  erroCarregamento: string | null = null;
+  mensagemSucesso: string | null = null;
+  resposta: CentralAcaoAgendamentoResposta | null = null;
+  acaoEmExecucao: number | null = null;
 
   private readonly destruir$ = new Subject<void>();
-  private readonly agendamentosSubject = new BehaviorSubject<Agendamento[]>([]);
-  readonly agendamentos$ = this.agendamentosSubject.asObservable();
 
-  readonly tiposOperacao$ = this.gateApi.listarTiposOperacao().pipe(shareReplay(1));
-  readonly status$ = this.gateApi.listarStatusAgendamento().pipe(shareReplay(1));
-  readonly janelas$: Observable<JanelaAtendimento[]> = this.gateApi
-    .listarJanelas({ size: 200 })
-    .pipe(map((pagina) => pagina.content), shareReplay(1));
-
-  selecionadoId: number | null = null;
-  selecionado: Agendamento | null = null;
-  emEdicao: Agendamento | null = null;
-  exibirFormulario = false;
-  carregandoLista = false;
-  carregandoDetalhe = false;
-  uploadStatus: UploadDocumentoStatus[] = [];
-  documentosExistentes: DocumentoAgendamento[] | null = [];
-  resumoUso: DashboardResumo | null = null;
-  carregandoResumo = false;
-  erroResumo: string | null = null;
-
-  constructor(
-    private readonly gateApi: GateApiService,
-    private readonly popupService: PopupService,
-    private readonly dashboardService: GateDashboardService
-  ) {}
+  constructor(private readonly gateApi: GateApiService) {}
 
   ngOnInit(): void {
-    this.carregarAgendamentos();
-    this.carregarResumoUso();
+    this.carregarVisao();
   }
 
   ngOnDestroy(): void {
@@ -55,244 +34,87 @@ export class GateAgendamentosComponent implements OnInit, OnDestroy {
     this.destruir$.complete();
   }
 
-  carregarAgendamentos(): void {
-    this.carregandoLista = true;
-    this.gateApi
-      .listarAgendamentos({ size: 100 })
-      .pipe(
-        finalize(() => (this.carregandoLista = false)),
-        takeUntil(this.destruir$)
-      )
-      .subscribe((pagina) => {
-        this.agendamentosSubject.next(pagina.content);
-        if (this.selecionadoId) {
-          const existe = pagina.content.some((item) => item.id === this.selecionadoId);
-          if (!existe) {
-            this.selecionadoId = null;
-            this.selecionado = null;
-          }
-        }
-        this.carregarResumoUso();
-      });
-  }
-
-  selecionarAgendamento(id: number): void {
-    this.selecionadoId = id;
-    this.carregandoDetalhe = true;
-    this.gateApi
-      .obterAgendamentoPorId(id)
-      .pipe(
-        finalize(() => (this.carregandoDetalhe = false)),
-        takeUntil(this.destruir$)
-      )
-      .subscribe((agendamento) => {
-        this.selecionado = agendamento;
-        this.documentosExistentes = agendamento.documentos ?? [];
-        if (!this.exibirFormulario) {
-          this.emEdicao = null;
-        }
-      });
-  }
-
-  criarAgendamento(): void {
-    this.emEdicao = null;
-    this.documentosExistentes = [];
-    this.exibirFormulario = true;
-  }
-
-  editarAgendamento(id: number): void {
-    this.popupService
-      .openConfirmacao({
-        titulo: 'Editar agendamento',
-        mensagem: 'Deseja editar o agendamento selecionado?',
-        textoConfirmar: 'Editar'
-      })
-      .pipe(take(1))
-      .subscribe((confirmado) => {
-        if (confirmado) {
-          this.iniciarEdicao(id);
-        }
-      });
-  }
-
-  cancelarAgendamento(id: number): void {
-    this.popupService
-      .openConfirmacao({
-        titulo: 'Cancelar agendamento',
-        mensagem: 'Confirma o cancelamento deste agendamento?',
-        textoConfirmar: 'Cancelar',
-        textoCancelar: 'Manter'
-      })
-      .pipe(take(1), switchMap((confirmado) => (confirmado ? this.gateApi.cancelarAgendamento(id) : EMPTY)))
-      .subscribe({
-        next: () => {
-          if (this.selecionadoId === id) {
-            this.selecionadoId = null;
-            this.selecionado = null;
-          }
-          this.carregarAgendamentos();
-        }
-      });
-  }
-
-  salvar(payload: AgendamentoFormPayload): void {
-    const acao$ = this.emEdicao
-      ? this.gateApi.atualizarAgendamento(this.emEdicao.id, payload.request)
-      : this.gateApi.criarAgendamento(payload.request);
-
-    acao$
-      .pipe(
-        switchMap((agendamento) =>
-          this.processarUploads(agendamento.id, payload.arquivos).pipe(map(() => agendamento))
-        ),
-        finalize(() => (this.uploadStatus = [])),
-        takeUntil(this.destruir$)
-      )
-      .subscribe((agendamento) => {
-        this.exibirFormulario = false;
-        this.emEdicao = null;
-        this.documentosExistentes = agendamento.documentos ?? [];
-        this.carregarAgendamentos();
-        this.selecionarAgendamento(agendamento.id);
-      });
-  }
-
-  cancelarFormulario(): void {
-    this.exibirFormulario = false;
-    this.emEdicao = null;
-    this.documentosExistentes = this.selecionado?.documentos ?? [];
-  }
-
-  atualizarLista(): void {
-    this.carregarAgendamentos();
-  }
-
-  anexarDocumentos(files: File[]): void {
-    if (!this.selecionadoId || !files.length) {
+  carregarVisao(): void {
+    if (this.carregando) {
       return;
     }
-    this.processarUploads(this.selecionadoId, files)
-      .pipe(takeUntil(this.destruir$))
-      .subscribe(() => {
-        if (this.selecionadoId) {
-          this.selecionarAgendamento(this.selecionadoId);
-        }
-        this.carregarAgendamentos();
-      });
-  }
-
-  carregarResumoUso(): void {
-    if (this.carregandoResumo) {
-      return;
-    }
-
-    this.carregandoResumo = true;
-    this.erroResumo = null;
-    this.dashboardService
-      .consultarResumo()
+    this.carregando = true;
+    this.erroCarregamento = null;
+    this.mensagemSucesso = null;
+    this.gateApi
+      .obterCentralAcaoAgendamentos()
       .pipe(
-        finalize(() => (this.carregandoResumo = false)),
+        finalize(() => (this.carregando = false)),
         takeUntil(this.destruir$)
       )
       .subscribe({
-        next: (resumo) => {
-          this.resumoUso = resumo;
+        next: (resposta) => {
+          this.resposta = {
+            ...resposta,
+            agendamentos: resposta?.agendamentos ?? []
+          };
         },
         error: () => {
-          this.erroResumo = 'Não foi possível carregar as métricas de adoção.';
-          this.resumoUso = null;
+          this.erroCarregamento = 'Não foi possível carregar seus agendamentos. Tente novamente em instantes.';
+          this.resposta = null;
         }
       });
   }
 
-  obterMensagemVariacaoAbandono(): string | null {
-    if (!this.resumoUso) {
-      return null;
+  executarAcao(card: VisaoCompletaAgendamento): void {
+    const acao = card.acaoPrincipal;
+    if (!acao || !acao.habilitada) {
+      return;
     }
-    const variacao = this.resumoUso.variacaoAbandonoPercentual;
-    if (Math.abs(variacao) < 0.01) {
-      return 'Taxa de abandono estável em comparação ao período anterior.';
-    }
-    const valorFormatado = Math.abs(variacao).toLocaleString('pt-BR', {
-      maximumFractionDigits: 0,
-      minimumFractionDigits: 0
-    });
-    return variacao >= 0
-      ? `Queda de ${valorFormatado}% no abandono do fluxo em comparação ao período anterior.`
-      : `Aumento de ${valorFormatado}% no abandono do fluxo em comparação ao período anterior.`;
-  }
-
-  variacaoAbandonoEhPositiva(): boolean {
-    return (this.resumoUso?.variacaoAbandonoPercentual ?? 0) >= 0;
-  }
-
-  private iniciarEdicao(id: number): void {
+    this.acaoEmExecucao = card.agendamentoId;
+    this.erroCarregamento = null;
+    this.mensagemSucesso = null;
     this.gateApi
-      .obterAgendamentoPorId(id)
-      .pipe(take(1))
-      .subscribe((agendamento) => {
-        this.emEdicao = agendamento;
-        this.documentosExistentes = agendamento.documentos ?? [];
-        this.exibirFormulario = true;
+      .executarAcaoCentral(acao)
+      .pipe(
+        finalize(() => (this.acaoEmExecucao = null)),
+        takeUntil(this.destruir$)
+      )
+      .subscribe({
+        next: () => {
+          this.mensagemSucesso = 'Ação enviada com sucesso.';
+          this.carregarVisao();
+        },
+        error: () => {
+          this.erroCarregamento = 'Não foi possível concluir a ação. Confirme sua conexão e tente novamente.';
+        }
       });
   }
 
-  private processarUploads(id: number, arquivos: File[]): Observable<DocumentoAgendamento[]> {
-    if (!arquivos.length) {
-      return of([]);
+  formatarJanela(card: VisaoCompletaAgendamento): string {
+    if (!card.janelaData) {
+      return 'Janela não definida';
     }
-
-    this.uploadStatus = arquivos.map((arquivo) => ({ fileName: arquivo.name, progress: 0, status: 'pendente' }));
-
-    return from(arquivos).pipe(
-      concatMap((arquivo) =>
-        this.gateApi.uploadDocumentoAgendamento(id, arquivo).pipe(
-          tap((evento) => this.atualizarStatusUpload(arquivo.name, evento)),
-          catchError(() => {
-            this.atualizarStatusUpload(arquivo.name, null, true);
-            return EMPTY;
-          }),
-          switchMap((evento) =>
-            evento.type === HttpEventType.Response ? of(evento.body as DocumentoAgendamento) : EMPTY
-          )
-        )
-      ),
-      toArray(),
-      finalize(() => {
-        setTimeout(() => (this.uploadStatus = []), 800);
-      })
-    );
+    const data = new Date(card.janelaData);
+    const dataFormatada = Number.isNaN(data.getTime()) ? card.janelaData : data.toLocaleDateString('pt-BR');
+    const inicio = this.formatarHorario(card.janelaHoraInicio);
+    const fim = this.formatarHorario(card.janelaHoraFim);
+    return `${dataFormatada} ${inicio} - ${fim}`.trim();
   }
 
-  private atualizarStatusUpload(nome: string, evento: any, erro = false): void {
-    this.uploadStatus = this.uploadStatus.map((status) => {
-      if (status.fileName !== nome) {
-        return status;
+  formatarHorario(valor: string | null): string {
+    if (!valor) {
+      return '—';
+    }
+    const data = new Date(valor);
+    if (!Number.isNaN(data.getTime())) {
+      return data.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+    }
+    if (valor.includes('T')) {
+      const [, horario] = valor.split('T');
+      if (horario && horario.length >= 5) {
+        return horario.substring(0, 5);
       }
+    }
+    return valor.length > 5 ? valor.substring(0, 5) : valor;
+  }
 
-      if (erro) {
-        return { ...status, status: 'erro' };
-      }
-
-      if (!evento) {
-        return status;
-      }
-
-      if (evento.type === HttpEventType.Sent) {
-        return { ...status, status: 'enviando', progress: 0 };
-      }
-
-      if (evento.type === HttpEventType.UploadProgress) {
-        const total = evento.total ?? evento.loaded ?? 1;
-        const progresso = total ? Math.round((evento.loaded * 100) / total) : status.progress;
-        return { ...status, status: 'enviando', progress: progresso };
-      }
-
-      if (evento.type === HttpEventType.Response) {
-        return { ...status, status: 'concluido', progress: 100 };
-      }
-
-      return status;
-    });
+  trackPorId(_: number, card: VisaoCompletaAgendamento): number {
+    return card.agendamentoId;
   }
 }

--- a/frontend/cloudport/src/app/componentes/model/gate/agendamento.model.ts
+++ b/frontend/cloudport/src/app/componentes/model/gate/agendamento.model.ts
@@ -111,3 +111,58 @@ export interface AgendamentoFormPayload {
   request: AgendamentoRequest;
   arquivos: File[];
 }
+
+export interface AcaoCentralAgendamento {
+  codigo: string;
+  titulo: string;
+  descricao: string;
+  metodoHttp: string;
+  rotaApiRelativa: string | null;
+  habilitada: boolean;
+}
+
+export interface DocumentoPendenteAgendamento {
+  id: number;
+  nomeArquivo: string;
+  tipoDocumento: string | null;
+  mensagem: string | null;
+}
+
+export interface SituacaoPatio {
+  status: string | null;
+  descricao: string | null;
+  verificadoEm: string | null;
+}
+
+export interface VisaoCompletaAgendamento {
+  agendamentoId: number;
+  codigo: string;
+  status: string;
+  statusDescricao: string | null;
+  tipoOperacaoDescricao: string | null;
+  horarioPrevistoChegada: string | null;
+  horarioPrevistoSaida: string | null;
+  placaVeiculo: string | null;
+  transportadoraNome: string | null;
+  motoristaNome: string | null;
+  janelaData: string | null;
+  janelaHoraInicio: string | null;
+  janelaHoraFim: string | null;
+  mensagemOrientacao: string | null;
+  acaoPrincipal: AcaoCentralAgendamento | null;
+  documentosPendentes: DocumentoPendenteAgendamento[];
+}
+
+export interface UsuarioCentralAcao {
+  login: string | null;
+  nome: string | null;
+  perfil: string | null;
+  transportadoraDocumento?: string | null;
+  transportadoraNome: string | null;
+}
+
+export interface CentralAcaoAgendamentoResposta {
+  usuario?: UsuarioCentralAcao | null;
+  situacaoPatio?: SituacaoPatio | null;
+  agendamentos: VisaoCompletaAgendamento[];
+}

--- a/frontend/cloudport/src/styles.css
+++ b/frontend/cloudport/src/styles.css
@@ -1,6 +1,3 @@
-@import "~ag-grid-community/styles/ag-grid.css";
-@import "~ag-grid-community/styles/ag-theme-alpine.css";
-
 body {
   background: linear-gradient(to right,  #234986);
   background-image: url('./assets/images/background.png');


### PR DESCRIPTION
## Summary
- criar controlador e serviço de central de ação agregando dados de autenticação, yard e gate em um único endpoint
- adicionar cliente de status do pátio com propriedades e circuit breaker dedicados
- atualizar modelos, serviço e componente Angular para consumir o BFF e exibir cards responsivos sem dependência do ag-grid

## Testing
- `mvn test` *(falha: Maven Central retornou 403 para o parent do projeto)*
- `npm run build --silent` *(falha: Angular CLI indisponível no ambiente sem dependências instaladas)*

------
https://chatgpt.com/codex/tasks/task_e_68f6a24172208327ab7597d9718553a2