### PR TITLE
Implementa gestão integrada de visitas de trem

### DIFF
--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/controlador/VisitaTremControlador.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/controlador/VisitaTremControlador.java
@@ -1,0 +1,50 @@
+package br.com.cloudport.servicoyard.ferrovia.controlador;
+
+import br.com.cloudport.servicoyard.ferrovia.dto.VisitaTremRequisicaoDto;
+import br.com.cloudport.servicoyard.ferrovia.dto.VisitaTremRespostaDto;
+import br.com.cloudport.servicoyard.ferrovia.servico.VisitaTremServico;
+import java.util.List;
+import javax.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/yard/ferrovia/visitas")
+public class VisitaTremControlador {
+
+    private final VisitaTremServico visitaTremServico;
+
+    public VisitaTremControlador(VisitaTremServico visitaTremServico) {
+        this.visitaTremServico = visitaTremServico;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public VisitaTremRespostaDto registrar(@Valid @RequestBody VisitaTremRequisicaoDto dto) {
+        return visitaTremServico.registrarVisita(dto);
+    }
+
+    @PutMapping("/{id}")
+    public VisitaTremRespostaDto atualizar(@PathVariable("id") Long id,
+                                           @Valid @RequestBody VisitaTremRequisicaoDto dto) {
+        return visitaTremServico.atualizarVisita(id, dto);
+    }
+
+    @GetMapping("/{id}")
+    public VisitaTremRespostaDto consultar(@PathVariable("id") Long id) {
+        return visitaTremServico.consultarVisita(id);
+    }
+
+    @GetMapping
+    public List<VisitaTremRespostaDto> listar(@RequestParam(name = "dias", defaultValue = "7") int dias) {
+        return visitaTremServico.listarVisitasProximosDias(dias);
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/VisitaTremRequisicaoDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/VisitaTremRequisicaoDto.java
@@ -1,0 +1,68 @@
+package br.com.cloudport.servicoyard.ferrovia.dto;
+
+import br.com.cloudport.servicoyard.comum.validacao.ValidacaoEntradaUtil;
+import br.com.cloudport.servicoyard.ferrovia.modelo.StatusVisitaTrem;
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class VisitaTremRequisicaoDto {
+
+    @NotBlank
+    @Size(max = 40)
+    private String identificadorTrem;
+
+    @NotBlank
+    @Size(max = 80)
+    private String operadoraFerroviaria;
+
+    @NotNull
+    private LocalDateTime horaChegadaPrevista;
+
+    @NotNull
+    private LocalDateTime horaPartidaPrevista;
+
+    @NotNull
+    private StatusVisitaTrem statusVisita;
+
+    public String getIdentificadorTrem() {
+        return identificadorTrem;
+    }
+
+    public void setIdentificadorTrem(String identificadorTrem) {
+        this.identificadorTrem = ValidacaoEntradaUtil.limparTexto(identificadorTrem);
+    }
+
+    public String getOperadoraFerroviaria() {
+        return operadoraFerroviaria;
+    }
+
+    public void setOperadoraFerroviaria(String operadoraFerroviaria) {
+        this.operadoraFerroviaria = ValidacaoEntradaUtil.limparTexto(operadoraFerroviaria);
+    }
+
+    public LocalDateTime getHoraChegadaPrevista() {
+        return horaChegadaPrevista;
+    }
+
+    public void setHoraChegadaPrevista(LocalDateTime horaChegadaPrevista) {
+        this.horaChegadaPrevista = horaChegadaPrevista;
+    }
+
+    public LocalDateTime getHoraPartidaPrevista() {
+        return horaPartidaPrevista;
+    }
+
+    public void setHoraPartidaPrevista(LocalDateTime horaPartidaPrevista) {
+        this.horaPartidaPrevista = horaPartidaPrevista;
+    }
+
+    public StatusVisitaTrem getStatusVisita() {
+        return statusVisita;
+    }
+
+    public void setStatusVisita(StatusVisitaTrem statusVisita) {
+        this.statusVisita = statusVisita;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/VisitaTremRespostaDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/VisitaTremRespostaDto.java
@@ -1,0 +1,65 @@
+package br.com.cloudport.servicoyard.ferrovia.dto;
+
+import br.com.cloudport.servicoyard.ferrovia.modelo.StatusVisitaTrem;
+import br.com.cloudport.servicoyard.ferrovia.modelo.VisitaTrem;
+import java.time.LocalDateTime;
+import org.springframework.web.util.HtmlUtils;
+
+public class VisitaTremRespostaDto {
+
+    private final Long id;
+    private final String identificadorTrem;
+    private final String operadoraFerroviaria;
+    private final LocalDateTime horaChegadaPrevista;
+    private final LocalDateTime horaPartidaPrevista;
+    private final StatusVisitaTrem statusVisita;
+
+    public VisitaTremRespostaDto(Long id,
+                                 String identificadorTrem,
+                                 String operadoraFerroviaria,
+                                 LocalDateTime horaChegadaPrevista,
+                                 LocalDateTime horaPartidaPrevista,
+                                 StatusVisitaTrem statusVisita) {
+        this.id = id;
+        this.identificadorTrem = identificadorTrem;
+        this.operadoraFerroviaria = operadoraFerroviaria;
+        this.horaChegadaPrevista = horaChegadaPrevista;
+        this.horaPartidaPrevista = horaPartidaPrevista;
+        this.statusVisita = statusVisita;
+    }
+
+    public static VisitaTremRespostaDto deEntidade(VisitaTrem entidade) {
+        return new VisitaTremRespostaDto(
+                entidade.getId(),
+                HtmlUtils.htmlEscape(entidade.getIdentificadorTrem()),
+                HtmlUtils.htmlEscape(entidade.getOperadoraFerroviaria()),
+                entidade.getHoraChegadaPrevista(),
+                entidade.getHoraPartidaPrevista(),
+                entidade.getStatusVisita()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getIdentificadorTrem() {
+        return identificadorTrem;
+    }
+
+    public String getOperadoraFerroviaria() {
+        return operadoraFerroviaria;
+    }
+
+    public LocalDateTime getHoraChegadaPrevista() {
+        return horaChegadaPrevista;
+    }
+
+    public LocalDateTime getHoraPartidaPrevista() {
+        return horaPartidaPrevista;
+    }
+
+    public StatusVisitaTrem getStatusVisita() {
+        return statusVisita;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/StatusVisitaTrem.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/StatusVisitaTrem.java
@@ -1,0 +1,8 @@
+package br.com.cloudport.servicoyard.ferrovia.modelo;
+
+public enum StatusVisitaTrem {
+    PLANEJADO,
+    ANUNCIADO,
+    CHEGOU,
+    PARTIU
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/VisitaTrem.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/VisitaTrem.java
@@ -1,0 +1,123 @@
+package br.com.cloudport.servicoyard.ferrovia.modelo;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "visita_trem")
+public class VisitaTrem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "identificador_trem", nullable = false, length = 40)
+    private String identificadorTrem;
+
+    @Column(name = "operadora_ferroviaria", nullable = false, length = 80)
+    private String operadoraFerroviaria;
+
+    @Column(name = "hora_chegada_prevista", nullable = false)
+    private LocalDateTime horaChegadaPrevista;
+
+    @Column(name = "hora_partida_prevista", nullable = false)
+    private LocalDateTime horaPartidaPrevista;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status_visita", nullable = false, length = 20)
+    private StatusVisitaTrem statusVisita;
+
+    @Column(name = "criado_em", nullable = false)
+    private LocalDateTime criadoEm;
+
+    @Column(name = "atualizado_em", nullable = false)
+    private LocalDateTime atualizadoEm;
+
+    public VisitaTrem() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getIdentificadorTrem() {
+        return identificadorTrem;
+    }
+
+    public void setIdentificadorTrem(String identificadorTrem) {
+        this.identificadorTrem = identificadorTrem;
+    }
+
+    public String getOperadoraFerroviaria() {
+        return operadoraFerroviaria;
+    }
+
+    public void setOperadoraFerroviaria(String operadoraFerroviaria) {
+        this.operadoraFerroviaria = operadoraFerroviaria;
+    }
+
+    public LocalDateTime getHoraChegadaPrevista() {
+        return horaChegadaPrevista;
+    }
+
+    public void setHoraChegadaPrevista(LocalDateTime horaChegadaPrevista) {
+        this.horaChegadaPrevista = horaChegadaPrevista;
+    }
+
+    public LocalDateTime getHoraPartidaPrevista() {
+        return horaPartidaPrevista;
+    }
+
+    public void setHoraPartidaPrevista(LocalDateTime horaPartidaPrevista) {
+        this.horaPartidaPrevista = horaPartidaPrevista;
+    }
+
+    public StatusVisitaTrem getStatusVisita() {
+        return statusVisita;
+    }
+
+    public void setStatusVisita(StatusVisitaTrem statusVisita) {
+        this.statusVisita = statusVisita;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public void setCriadoEm(LocalDateTime criadoEm) {
+        this.criadoEm = criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+
+    public void setAtualizadoEm(LocalDateTime atualizadoEm) {
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    @PrePersist
+    public void aoCriar() {
+        LocalDateTime agora = LocalDateTime.now();
+        this.criadoEm = agora;
+        this.atualizadoEm = agora;
+    }
+
+    @PreUpdate
+    public void aoAtualizar() {
+        this.atualizadoEm = LocalDateTime.now();
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/repositorio/VisitaTremRepositorio.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/repositorio/VisitaTremRepositorio.java
@@ -1,0 +1,23 @@
+package br.com.cloudport.servicoyard.ferrovia.repositorio;
+
+import br.com.cloudport.servicoyard.ferrovia.modelo.StatusVisitaTrem;
+import br.com.cloudport.servicoyard.ferrovia.modelo.VisitaTrem;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface VisitaTremRepositorio extends JpaRepository<VisitaTrem, Long> {
+
+    @Query("SELECT v FROM VisitaTrem v "
+            + "WHERE (v.horaChegadaPrevista BETWEEN :inicio AND :limite) "
+            + "OR ((v.statusVisita <> :statusFinalizado) "
+            + "AND (v.horaPartidaPrevista IS NULL OR v.horaPartidaPrevista >= :referenciaAtiva) "
+            + "AND v.horaChegadaPrevista <= :limite) "
+            + "ORDER BY v.horaChegadaPrevista ASC, v.id ASC")
+    List<VisitaTrem> buscarVisitasPlanejadasOuAtivas(@Param("inicio") LocalDateTime inicio,
+                                                     @Param("referenciaAtiva") LocalDateTime referenciaAtiva,
+                                                     @Param("limite") LocalDateTime limite,
+                                                     @Param("statusFinalizado") StatusVisitaTrem statusFinalizado);
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/servico/VisitaTremServico.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/servico/VisitaTremServico.java
@@ -1,0 +1,118 @@
+package br.com.cloudport.servicoyard.ferrovia.servico;
+
+import br.com.cloudport.servicoyard.comum.validacao.ValidacaoEntradaUtil;
+import br.com.cloudport.servicoyard.container.validacao.SanitizadorEntrada;
+import br.com.cloudport.servicoyard.ferrovia.dto.VisitaTremRequisicaoDto;
+import br.com.cloudport.servicoyard.ferrovia.dto.VisitaTremRespostaDto;
+import br.com.cloudport.servicoyard.ferrovia.modelo.StatusVisitaTrem;
+import br.com.cloudport.servicoyard.ferrovia.modelo.VisitaTrem;
+import br.com.cloudport.servicoyard.ferrovia.repositorio.VisitaTremRepositorio;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class VisitaTremServico {
+
+    private static final int DIAS_MAXIMO_CONSULTA = 30;
+
+    private final VisitaTremRepositorio visitaTremRepositorio;
+    private final SanitizadorEntrada sanitizadorEntrada;
+
+    public VisitaTremServico(VisitaTremRepositorio visitaTremRepositorio,
+                              SanitizadorEntrada sanitizadorEntrada) {
+        this.visitaTremRepositorio = visitaTremRepositorio;
+        this.sanitizadorEntrada = sanitizadorEntrada;
+    }
+
+    @Transactional
+    public VisitaTremRespostaDto registrarVisita(VisitaTremRequisicaoDto dto) {
+        VisitaTrem visita = new VisitaTrem();
+        aplicarDados(visita, dto);
+        VisitaTrem salvo = visitaTremRepositorio.save(visita);
+        return VisitaTremRespostaDto.deEntidade(salvo);
+    }
+
+    @Transactional
+    public VisitaTremRespostaDto atualizarVisita(Long id, VisitaTremRequisicaoDto dto) {
+        VisitaTrem existente = visitaTremRepositorio.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Visita de trem não encontrada."));
+        aplicarDados(existente, dto);
+        VisitaTrem atualizado = visitaTremRepositorio.save(existente);
+        return VisitaTremRespostaDto.deEntidade(atualizado);
+    }
+
+    @Transactional(readOnly = true)
+    public VisitaTremRespostaDto consultarVisita(Long id) {
+        VisitaTrem visita = visitaTremRepositorio.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Visita de trem não encontrada."));
+        return VisitaTremRespostaDto.deEntidade(visita);
+    }
+
+    @Transactional(readOnly = true)
+    public List<VisitaTremRespostaDto> listarVisitasProximosDias(int dias) {
+        if (dias < 1 || dias > DIAS_MAXIMO_CONSULTA) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format(Locale.ROOT, "O intervalo de consulta deve estar entre 1 e %d dias.", DIAS_MAXIMO_CONSULTA));
+        }
+        LocalDateTime agora = LocalDateTime.now();
+        LocalDateTime inicio = agora.minusDays(1);
+        LocalDateTime limite = agora.plusDays(dias);
+        return visitaTremRepositorio.buscarVisitasPlanejadasOuAtivas(inicio, agora, limite, StatusVisitaTrem.PARTIU)
+                .stream()
+                .distinct()
+                .map(VisitaTremRespostaDto::deEntidade)
+                .collect(Collectors.toList());
+    }
+
+    private void aplicarDados(VisitaTrem visita, VisitaTremRequisicaoDto dto) {
+        String identificadorLimpo = sanitizarObrigatorio(dto.getIdentificadorTrem(), "identificador do trem", 40)
+                .toUpperCase(Locale.ROOT);
+        String operadoraLimpa = sanitizarObrigatorio(dto.getOperadoraFerroviaria(), "operadora ferroviária", 80);
+
+        LocalDateTime horaChegada = Objects.requireNonNull(dto.getHoraChegadaPrevista(),
+                "A hora prevista de chegada deve ser informada.");
+        LocalDateTime horaPartida = Objects.requireNonNull(dto.getHoraPartidaPrevista(),
+                "A hora prevista de partida deve ser informada.");
+
+        if (horaPartida.isBefore(horaChegada)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "A partida prevista não pode ser anterior à chegada prevista.");
+        }
+
+        horaChegada = horaChegada.truncatedTo(ChronoUnit.MINUTES);
+        horaPartida = horaPartida.truncatedTo(ChronoUnit.MINUTES);
+
+        StatusVisitaTrem status = Objects.requireNonNull(dto.getStatusVisita(),
+                "O status da visita deve ser informado.");
+
+        visita.setIdentificadorTrem(identificadorLimpo);
+        visita.setOperadoraFerroviaria(operadoraLimpa);
+        visita.setHoraChegadaPrevista(horaChegada);
+        visita.setHoraPartidaPrevista(horaPartida);
+        visita.setStatusVisita(status);
+    }
+
+    private String sanitizarObrigatorio(String valor, String campo, int tamanhoMaximo) {
+        String limpo = sanitizadorEntrada.limparTexto(valor);
+        limpo = ValidacaoEntradaUtil.limparTexto(limpo);
+        if (!StringUtils.hasText(limpo)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format(Locale.ROOT, "O campo %s é obrigatório.", campo));
+        }
+        String normalizado = limpo.trim();
+        if (normalizado.length() > tamanhoMaximo) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format(Locale.ROOT, "O campo %s deve ter no máximo %d caracteres.", campo, tamanhoMaximo));
+        }
+        return normalizado;
+    }
+}

--- a/backend/servico-yard/src/main/resources/db/migration/V2__criar_tabela_visita_trem.sql
+++ b/backend/servico-yard/src/main/resources/db/migration/V2__criar_tabela_visita_trem.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS visita_trem (
+    id BIGSERIAL PRIMARY KEY,
+    identificador_trem VARCHAR(40) NOT NULL,
+    operadora_ferroviaria VARCHAR(80) NOT NULL,
+    hora_chegada_prevista TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    hora_partida_prevista TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    status_visita VARCHAR(20) NOT NULL,
+    criado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    atualizado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_visita_trem_identificador ON visita_trem (identificador_trem);
+CREATE INDEX IF NOT EXISTS idx_visita_trem_janela ON visita_trem (hora_chegada_prevista, hora_partida_prevista);

--- a/frontend/cloudport/src/app/app-routing.module.ts
+++ b/frontend/cloudport/src/app/app-routing.module.ts
@@ -40,6 +40,12 @@ const homeChildRoutes: Routes = [
     loadChildren: () => import('./componentes/gate/gate.module').then(m => m.GateModule)
   },
   {
+    path: 'ferrovia',
+    canActivate: [AuthGuard],
+    canLoad: [AuthGuard],
+    loadChildren: () => import('./componentes/ferrovia/ferrovia.module').then(m => m.FerroviaModule)
+  },
+  {
     path: 'patio',
     canActivate: [AuthGuard],
     canLoad: [AuthGuard],

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.css
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.css
@@ -1,0 +1,81 @@
+.detalhe-visita-trem {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.detalhe-visita-trem header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.detalhe-visita-trem h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.botao-voltar {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  background-color: #4a4a4a;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.botao-voltar:hover,
+.botao-voltar:focus {
+  background-color: #2f2f2f;
+}
+
+.estado-informativo {
+  padding: 12px;
+  background-color: #eef5ff;
+  border-left: 4px solid #005f9e;
+  color: #003b63;
+}
+
+.estado-erro {
+  padding: 12px;
+  background-color: #ffecec;
+  border-left: 4px solid #c62828;
+  color: #7f1d1d;
+}
+
+.cartao-detalhe {
+  border: 1px solid #dcdcdc;
+  border-radius: 8px;
+  padding: 20px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.cartao-detalhe dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin: 0;
+}
+
+.cartao-detalhe dt {
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: #333;
+}
+
+.cartao-detalhe dd {
+  margin: 0;
+  color: #111;
+  font-size: 1.05rem;
+}
+
+.observacao {
+  margin-top: 20px;
+  color: #555;
+  font-style: italic;
+}

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.html
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.html
@@ -1,0 +1,38 @@
+<section class="detalhe-visita-trem">
+  <header>
+    <h1>Detalhes da Visita do Trem</h1>
+    <button type="button" class="botao-voltar" (click)="voltarParaLista()">Voltar para a lista</button>
+  </header>
+
+  <div *ngIf="estaCarregando" class="estado-informativo">Carregando informações do trem...</div>
+
+  <div *ngIf="!estaCarregando && erroCarregamento" class="estado-erro">
+    {{ textoSeguro(erroCarregamento) }}
+  </div>
+
+  <article *ngIf="!estaCarregando && !erroCarregamento && visita" class="cartao-detalhe">
+    <dl>
+      <div>
+        <dt>Trem</dt>
+        <dd>{{ textoSeguro(visita.identificadorTrem) }}</dd>
+      </div>
+      <div>
+        <dt>Operadora Ferroviária</dt>
+        <dd>{{ textoSeguro(visita.operadoraFerroviaria) }}</dd>
+      </div>
+      <div>
+        <dt>Previsão de Chegada (ETA)</dt>
+        <dd>{{ visita.horaChegadaPrevista | date:'dd/MM/yyyy HH:mm' }}</dd>
+      </div>
+      <div>
+        <dt>Previsão de Partida (ETD)</dt>
+        <dd>{{ visita.horaPartidaPrevista | date:'dd/MM/yyyy HH:mm' }}</dd>
+      </div>
+      <div>
+        <dt>Status Atual</dt>
+        <dd>{{ textoSeguro(visita.statusVisita) }}</dd>
+      </div>
+    </dl>
+    <p class="observacao">Essas informações são atualizadas diretamente pelo sistema operacional da ferrovia.</p>
+  </article>
+</section>

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.ts
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { SanitizadorConteudoService } from '../../../service/sanitizacao/sanitizador-conteudo.service';
+import { ServicoFerroviaService, VisitaTrem } from '../../../service/servico-ferrovia/servico-ferrovia.service';
+
+@Component({
+  selector: 'app-detalhe-visita-trem',
+  templateUrl: './detalhe-visita-trem.component.html',
+  styleUrls: ['./detalhe-visita-trem.component.css']
+})
+export class DetalheVisitaTremComponent implements OnInit {
+  visita?: VisitaTrem;
+  estaCarregando = false;
+  erroCarregamento?: string;
+
+  constructor(
+    private readonly rotaAtiva: ActivatedRoute,
+    private readonly router: Router,
+    private readonly servicoFerrovia: ServicoFerroviaService,
+    private readonly sanitizadorConteudo: SanitizadorConteudoService
+  ) {}
+
+  ngOnInit(): void {
+    this.carregarVisita();
+  }
+
+  voltarParaLista(): void {
+    this.router.navigate(['/home', 'ferrovia', 'visitas']);
+  }
+
+  textoSeguro(valor: string | null | undefined): string {
+    return this.sanitizadorConteudo.sanitizar(valor);
+  }
+
+  private carregarVisita(): void {
+    const parametroId = this.rotaAtiva.snapshot.paramMap.get('id');
+    const id = parametroId ? Number(parametroId) : NaN;
+
+    if (!Number.isFinite(id) || id <= 0) {
+      this.erroCarregamento = 'Identificador da visita inválido.';
+      return;
+    }
+
+    this.estaCarregando = true;
+    this.erroCarregamento = undefined;
+
+    this.servicoFerrovia.obterVisita(id)
+      .pipe(finalize(() => this.estaCarregando = false))
+      .subscribe({
+        next: (visita) => {
+          this.visita = visita;
+        },
+        error: () => {
+          this.erroCarregamento = 'Não foi possível localizar a visita do trem solicitada.';
+          this.visita = undefined;
+        }
+      });
+  }
+}

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/lista-visitas-trem/lista-visitas-trem.component.css
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/lista-visitas-trem/lista-visitas-trem.component.css
@@ -1,0 +1,111 @@
+.lista-visitas-trem {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+
+.cabecalho-visitas {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.cabecalho-visitas h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.cabecalho-visitas .descricao {
+  margin: 4px 0 0;
+  color: #555;
+}
+
+.acoes-cabecalho {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.campo-dias {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.campo-dias input {
+  margin-top: 4px;
+  padding: 4px 8px;
+  border: 1px solid #c5c5c5;
+  border-radius: 4px;
+  width: 120px;
+}
+
+.botao-ordenacao {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  background-color: #005f9e;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.botao-ordenacao:hover,
+.botao-ordenacao:focus {
+  background-color: #004b7a;
+}
+
+.estado-informativo {
+  padding: 12px;
+  background-color: #eef5ff;
+  border-left: 4px solid #005f9e;
+  color: #003b63;
+}
+
+.estado-erro {
+  padding: 12px;
+  background-color: #ffecec;
+  border-left: 4px solid #c62828;
+  color: #7f1d1d;
+}
+
+.tabela-visitas {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+}
+
+.tabela-visitas th,
+.tabela-visitas td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #e6e6e6;
+  text-align: left;
+}
+
+.tabela-visitas thead {
+  background-color: #f5f7fa;
+}
+
+.tabela-visitas .coluna-data {
+  min-width: 180px;
+}
+
+.linha-visita {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.linha-visita:hover,
+.linha-visita:focus {
+  background-color: #f0f7ff;
+}
+
+.linha-visita:focus {
+  outline: 2px solid #005f9e;
+  outline-offset: -2px;
+}

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/lista-visitas-trem/lista-visitas-trem.component.html
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/lista-visitas-trem/lista-visitas-trem.component.html
@@ -1,0 +1,63 @@
+<section class="lista-visitas-trem">
+  <header class="cabecalho-visitas">
+    <div>
+      <h1>Visitas de Trem</h1>
+      <p class="descricao">Planeje o pátio acompanhando os trens previstos e em atendimento.</p>
+    </div>
+    <div class="acoes-cabecalho">
+      <label for="filtroDias" class="campo-dias">
+        Período (dias):
+        <input
+          id="filtroDias"
+          type="number"
+          min="1"
+          max="30"
+          [(ngModel)]="diasFiltro"
+          (ngModelChange)="aoAlterarDias()"
+        />
+      </label>
+      <button type="button" class="botao-ordenacao" (click)="alternarOrdenacao()">
+        Ordenar por ETA {{ ordenacaoAscendente ? '▲' : '▼' }}
+      </button>
+    </div>
+  </header>
+
+  <div *ngIf="estaCarregando" class="estado-informativo">Carregando visitas de trem...</div>
+
+  <div *ngIf="!estaCarregando && erroCarregamento" class="estado-erro">
+    {{ textoSeguro(erroCarregamento) }}
+  </div>
+
+  <table *ngIf="!estaCarregando && !erroCarregamento && visitas.length > 0" class="tabela-visitas" aria-label="Tabela de visitas de trem">
+    <thead>
+      <tr>
+        <th scope="col">Trem</th>
+        <th scope="col">Operadora</th>
+        <th scope="col" class="coluna-data">ETA</th>
+        <th scope="col" class="coluna-data">ETD</th>
+        <th scope="col">Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        *ngFor="let visita of visitas"
+        (click)="verDetalhes(visita)"
+        tabindex="0"
+        (keyup.enter)="verDetalhes(visita)"
+        (keyup.space)="verDetalhes(visita)"
+        class="linha-visita"
+        aria-label="Selecionar visita de trem"
+      >
+        <td>{{ textoSeguro(visita.identificadorTrem) }}</td>
+        <td>{{ textoSeguro(visita.operadoraFerroviaria) }}</td>
+        <td>{{ visita.horaChegadaPrevista | date:'dd/MM/yyyy HH:mm' }}</td>
+        <td>{{ visita.horaPartidaPrevista | date:'dd/MM/yyyy HH:mm' }}</td>
+        <td>{{ textoSeguro(visita.statusVisita) }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div *ngIf="!estaCarregando && !erroCarregamento && visitas.length === 0" class="estado-informativo">
+    Nenhuma visita de trem encontrada para o período selecionado.
+  </div>
+</section>

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/lista-visitas-trem/lista-visitas-trem.component.ts
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/lista-visitas-trem/lista-visitas-trem.component.ts
@@ -1,0 +1,89 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { SanitizadorConteudoService } from '../../../service/sanitizacao/sanitizador-conteudo.service';
+import { ServicoFerroviaService, VisitaTrem } from '../../../service/servico-ferrovia/servico-ferrovia.service';
+
+@Component({
+  selector: 'app-lista-visitas-trem',
+  templateUrl: './lista-visitas-trem.component.html',
+  styleUrls: ['./lista-visitas-trem.component.css']
+})
+export class ListaVisitasTremComponent implements OnInit {
+  visitas: VisitaTrem[] = [];
+  estaCarregando = false;
+  erroCarregamento?: string;
+  ordenacaoAscendente = true;
+  diasFiltro = 7;
+
+  constructor(
+    private readonly servicoFerrovia: ServicoFerroviaService,
+    private readonly sanitizadorConteudo: SanitizadorConteudoService,
+    private readonly router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.carregarVisitas();
+  }
+
+  carregarVisitas(): void {
+    this.estaCarregando = true;
+    this.erroCarregamento = undefined;
+    const diasConsulta = this.normalizarDiasFiltro(this.diasFiltro);
+    this.servicoFerrovia.listarVisitasProximosDias(diasConsulta)
+      .pipe(finalize(() => this.estaCarregando = false))
+      .subscribe({
+        next: (visitas) => {
+          this.visitas = this.ordenarPorEta(visitas, this.ordenacaoAscendente);
+        },
+        error: () => {
+          this.erroCarregamento = 'Não foi possível carregar as visitas de trem. Atualize a página ou tente novamente mais tarde.';
+          this.visitas = [];
+        }
+      });
+  }
+
+  alternarOrdenacao(): void {
+    this.ordenacaoAscendente = !this.ordenacaoAscendente;
+    this.visitas = this.ordenarPorEta(this.visitas, this.ordenacaoAscendente);
+  }
+
+  aoAlterarDias(): void {
+    this.diasFiltro = this.normalizarDiasFiltro(this.diasFiltro);
+    this.carregarVisitas();
+  }
+
+  verDetalhes(visita: VisitaTrem): void {
+    if (!visita || visita.id === undefined || visita.id === null) {
+      return;
+    }
+    this.router.navigate(['/home', 'ferrovia', 'visitas', visita.id]);
+  }
+
+  textoSeguro(valor: string | null | undefined): string {
+    return this.sanitizadorConteudo.sanitizar(valor);
+  }
+
+  private ordenarPorEta(visitas: VisitaTrem[], ascendente: boolean): VisitaTrem[] {
+    const ordenadas = [...(visitas ?? [])].sort((a, b) => {
+      const tempoA = Date.parse(a?.horaChegadaPrevista ?? '') || 0;
+      const tempoB = Date.parse(b?.horaChegadaPrevista ?? '') || 0;
+      return tempoA - tempoB;
+    });
+    return ascendente ? ordenadas : ordenadas.reverse();
+  }
+
+  private normalizarDiasFiltro(valor: number): number {
+    if (!Number.isFinite(valor)) {
+      return 7;
+    }
+    const inteiro = Math.floor(Math.abs(valor));
+    if (inteiro < 1) {
+      return 1;
+    }
+    if (inteiro > 30) {
+      return 30;
+    }
+    return inteiro;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/ferrovia/ferrovia-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/ferrovia/ferrovia-routing.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ListaVisitasTremComponent } from './componentes/lista-visitas-trem/lista-visitas-trem.component';
+import { DetalheVisitaTremComponent } from './componentes/detalhe-visita-trem/detalhe-visita-trem.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: 'visitas'
+  },
+  {
+    path: 'visitas',
+    component: ListaVisitasTremComponent
+  },
+  {
+    path: 'visitas/:id',
+    component: DetalheVisitaTremComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class FerroviaRoutingModule { }

--- a/frontend/cloudport/src/app/componentes/ferrovia/ferrovia.module.ts
+++ b/frontend/cloudport/src/app/componentes/ferrovia/ferrovia.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { FerroviaRoutingModule } from './ferrovia-routing.module';
+import { ListaVisitasTremComponent } from './componentes/lista-visitas-trem/lista-visitas-trem.component';
+import { DetalheVisitaTremComponent } from './componentes/detalhe-visita-trem/detalhe-visita-trem.component';
+
+@NgModule({
+  declarations: [
+    ListaVisitasTremComponent,
+    DetalheVisitaTremComponent
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    FerroviaRoutingModule
+  ]
+})
+export class FerroviaModule { }

--- a/frontend/cloudport/src/app/componentes/navbar/TabService.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/TabService.ts
@@ -67,6 +67,11 @@ export const TAB_REGISTRY: Readonly<Record<string, TabItem>> = {
     label: 'Eventos do Operador',
     route: ['gate', 'operador', 'eventos']
   },
+  'ferrovia/visitas': {
+    id: 'ferrovia/visitas',
+    label: 'Visitas de Trem',
+    route: ['ferrovia', 'visitas']
+  },
   'patio/mapa': {
     id: 'patio/mapa',
     label: 'Mapa do Pátio',

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
@@ -34,6 +34,23 @@
         </li>
       </ul>
     </li>
+    <li *ngIf="ferroviaTabs.length" (click)="toggleSubmenu($event)">
+      <button type="button" class="submenu-trigger">Ferrovia</button>
+      <ul>
+        <li *ngFor="let tab of ferroviaTabs">
+          <button
+            type="button"
+            class="submenu-item"
+            [class.coming-soon]="tab.disabled"
+            [disabled]="tab.disabled"
+            (click)="handleTabSelection($event, tab)"
+          >
+            <span>{{ tab.label }}</span>
+            <span *ngIf="tab.disabled" class="submenu-badge">{{ tab.comingSoonMessage || 'Em breve' }}</span>
+          </button>
+        </li>
+      </ul>
+    </li>
     <li *ngIf="yardTabs.length" (click)="toggleSubmenu($event)">
       <button type="button" class="submenu-trigger">Pátio</button>
       <ul>

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -23,6 +23,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
     'gate/operador/console',
     'gate/operador/eventos'
   ];
+  private readonly ferroviaTabIds = ['ferrovia/visitas'];
   private readonly yardTabIds = ['patio/mapa', 'patio/posicoes', 'patio/movimentacoes', 'patio/movimentacao'];
 
   private readonly tabRoles: Record<string, string[]> = {
@@ -37,6 +38,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
     'gate/relatorios': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_GATE'],
     'gate/operador/console': ['ROLE_ADMIN_PORTO', 'ROLE_OPERADOR_GATE', 'ROLE_PLANEJADOR'],
     'gate/operador/eventos': ['ROLE_ADMIN_PORTO', 'ROLE_OPERADOR_GATE', 'ROLE_PLANEJADOR'],
+    'ferrovia/visitas': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
     'patio/mapa': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
     'patio/posicoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
     'patio/movimentacoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
@@ -72,6 +74,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   get gateTabs(): TabItem[] {
     return this.resolveTabs(this.gateTabIds);
+  }
+
+  get ferroviaTabs(): TabItem[] {
+    return this.resolveTabs(this.ferroviaTabIds);
   }
 
   get yardTabs(): TabItem[] {

--- a/frontend/cloudport/src/app/componentes/service/servico-ferrovia/servico-ferrovia.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-ferrovia/servico-ferrovia.service.ts
@@ -1,0 +1,69 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfiguracaoAplicacaoService } from '../../../configuracao/configuracao-aplicacao.service';
+
+export interface VisitaTrem {
+  id: number;
+  identificadorTrem: string;
+  operadoraFerroviaria: string;
+  horaChegadaPrevista: string;
+  horaPartidaPrevista: string;
+  statusVisita: string;
+}
+
+export interface VisitaTremRequisicao {
+  identificadorTrem: string;
+  operadoraFerroviaria: string;
+  horaChegadaPrevista: string;
+  horaPartidaPrevista: string;
+  statusVisita: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServicoFerroviaService {
+  private static readonly CAMINHO_BASE = '/yard/ferrovia/visitas';
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly configuracaoAplicacao: ConfiguracaoAplicacaoService
+  ) {}
+
+  listarVisitasProximosDias(dias: number): Observable<VisitaTrem[]> {
+    const diasAjustado = this.normalizarJanela(dias);
+    const params = new HttpParams().set('dias', diasAjustado.toString());
+    return this.http.get<VisitaTrem[]>(this.construirUrl(''), { params });
+  }
+
+  obterVisita(id: number): Observable<VisitaTrem> {
+    return this.http.get<VisitaTrem>(this.construirUrl(`/${id}`));
+  }
+
+  registrarVisita(payload: VisitaTremRequisicao): Observable<VisitaTrem> {
+    return this.http.post<VisitaTrem>(this.construirUrl(''), payload);
+  }
+
+  atualizarVisita(id: number, payload: VisitaTremRequisicao): Observable<VisitaTrem> {
+    return this.http.put<VisitaTrem>(this.construirUrl(`/${id}`), payload);
+  }
+
+  private construirUrl(caminho: string): string {
+    return this.configuracaoAplicacao.construirUrlApi(`${ServicoFerroviaService.CAMINHO_BASE}${caminho}`);
+  }
+
+  private normalizarJanela(dias: number): number {
+    if (!Number.isFinite(dias)) {
+      return 7;
+    }
+    const inteiro = Math.floor(Math.abs(dias));
+    if (inteiro < 1) {
+      return 1;
+    }
+    if (inteiro > 30) {
+      return 30;
+    }
+    return inteiro;
+  }
+}


### PR DESCRIPTION
## Resumo
- cria tabela e entidade VisitaTrem com regras de validação e sanitização no serviço do pátio
- expõe endpoints REST para registrar, atualizar, consultar e listar visitas de trem
- adiciona módulo de ferrovia no frontend com listagem ordenável, detalhe e consumo da API real
- atualiza navegação principal para incluir o acesso à tela de visitas de trem

## Testes
- `mvn -f backend/servico-yard/pom.xml test` *(falha: bloqueio 403 ao baixar dependências Maven)*
- `npm --prefix frontend/cloudport install` *(falha: bloqueio 403 ao baixar dependências npm)*

------
https://chatgpt.com/codex/tasks/task_e_68f6a75c95a88327a9816d3a97c5f114