### PR TITLE
Adicionar controle de carga e descarga nas visitas de trem

### DIFF
--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/controlador/VisitaTremControlador.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/controlador/VisitaTremControlador.java
@@ -1,12 +1,16 @@
 package br.com.cloudport.servicoyard.ferrovia.controlador;
 
+import br.com.cloudport.servicoyard.ferrovia.dto.AtualizacaoStatusOperacaoConteinerDto;
+import br.com.cloudport.servicoyard.ferrovia.dto.OperacaoConteinerVisitaRequisicaoDto;
 import br.com.cloudport.servicoyard.ferrovia.dto.VisitaTremRequisicaoDto;
 import br.com.cloudport.servicoyard.ferrovia.dto.VisitaTremRespostaDto;
 import br.com.cloudport.servicoyard.ferrovia.servico.VisitaTremServico;
 import java.util.List;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -46,5 +50,43 @@ public class VisitaTremControlador {
     @GetMapping
     public List<VisitaTremRespostaDto> listar(@RequestParam(name = "dias", defaultValue = "7") int dias) {
         return visitaTremServico.listarVisitasProximosDias(dias);
+    }
+
+    @PostMapping("/{id}/descarga")
+    public VisitaTremRespostaDto adicionarConteinerDescarga(@PathVariable("id") Long id,
+                                                            @Valid @RequestBody OperacaoConteinerVisitaRequisicaoDto dto) {
+        return visitaTremServico.adicionarConteinerDescarga(id, dto);
+    }
+
+    @PostMapping("/{id}/carga")
+    public VisitaTremRespostaDto adicionarConteinerCarga(@PathVariable("id") Long id,
+                                                         @Valid @RequestBody OperacaoConteinerVisitaRequisicaoDto dto) {
+        return visitaTremServico.adicionarConteinerCarga(id, dto);
+    }
+
+    @DeleteMapping("/{id}/descarga/{idConteiner}")
+    public VisitaTremRespostaDto removerConteinerDescarga(@PathVariable("id") Long id,
+                                                          @PathVariable("idConteiner") Long idConteiner) {
+        return visitaTremServico.removerConteinerDescarga(id, idConteiner);
+    }
+
+    @DeleteMapping("/{id}/carga/{idConteiner}")
+    public VisitaTremRespostaDto removerConteinerCarga(@PathVariable("id") Long id,
+                                                       @PathVariable("idConteiner") Long idConteiner) {
+        return visitaTremServico.removerConteinerCarga(id, idConteiner);
+    }
+
+    @PatchMapping("/{id}/descarga/{idConteiner}/status")
+    public VisitaTremRespostaDto atualizarStatusDescarga(@PathVariable("id") Long id,
+                                                         @PathVariable("idConteiner") Long idConteiner,
+                                                         @Valid @RequestBody AtualizacaoStatusOperacaoConteinerDto dto) {
+        return visitaTremServico.atualizarStatusDescarga(id, idConteiner, dto.getStatusOperacao());
+    }
+
+    @PatchMapping("/{id}/carga/{idConteiner}/status")
+    public VisitaTremRespostaDto atualizarStatusCarga(@PathVariable("id") Long id,
+                                                      @PathVariable("idConteiner") Long idConteiner,
+                                                      @Valid @RequestBody AtualizacaoStatusOperacaoConteinerDto dto) {
+        return visitaTremServico.atualizarStatusCarga(id, idConteiner, dto.getStatusOperacao());
     }
 }

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/AtualizacaoStatusOperacaoConteinerDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/AtualizacaoStatusOperacaoConteinerDto.java
@@ -1,0 +1,18 @@
+package br.com.cloudport.servicoyard.ferrovia.dto;
+
+import br.com.cloudport.servicoyard.ferrovia.modelo.StatusOperacaoConteinerVisita;
+import javax.validation.constraints.NotNull;
+
+public class AtualizacaoStatusOperacaoConteinerDto {
+
+    @NotNull
+    private StatusOperacaoConteinerVisita statusOperacao;
+
+    public StatusOperacaoConteinerVisita getStatusOperacao() {
+        return statusOperacao;
+    }
+
+    public void setStatusOperacao(StatusOperacaoConteinerVisita statusOperacao) {
+        this.statusOperacao = statusOperacao;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/OperacaoConteinerVisitaRequisicaoDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/OperacaoConteinerVisitaRequisicaoDto.java
@@ -1,0 +1,32 @@
+package br.com.cloudport.servicoyard.ferrovia.dto;
+
+import br.com.cloudport.servicoyard.ferrovia.modelo.StatusOperacaoConteinerVisita;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+public class OperacaoConteinerVisitaRequisicaoDto {
+
+    @NotNull
+    @Min(1)
+    private Long idConteiner;
+
+    private StatusOperacaoConteinerVisita statusOperacao = StatusOperacaoConteinerVisita.PENDENTE;
+
+    public Long getIdConteiner() {
+        return idConteiner;
+    }
+
+    public void setIdConteiner(Long idConteiner) {
+        this.idConteiner = idConteiner;
+    }
+
+    public StatusOperacaoConteinerVisita getStatusOperacao() {
+        return statusOperacao;
+    }
+
+    public void setStatusOperacao(StatusOperacaoConteinerVisita statusOperacao) {
+        if (statusOperacao != null) {
+            this.statusOperacao = statusOperacao;
+        }
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/OperacaoConteinerVisitaRespostaDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/OperacaoConteinerVisitaRespostaDto.java
@@ -1,0 +1,28 @@
+package br.com.cloudport.servicoyard.ferrovia.dto;
+
+import br.com.cloudport.servicoyard.ferrovia.modelo.OperacaoConteinerVisita;
+import br.com.cloudport.servicoyard.ferrovia.modelo.StatusOperacaoConteinerVisita;
+
+public class OperacaoConteinerVisitaRespostaDto {
+
+    private final Long idConteiner;
+    private final StatusOperacaoConteinerVisita statusOperacao;
+
+    public OperacaoConteinerVisitaRespostaDto(Long idConteiner,
+                                              StatusOperacaoConteinerVisita statusOperacao) {
+        this.idConteiner = idConteiner;
+        this.statusOperacao = statusOperacao;
+    }
+
+    public static OperacaoConteinerVisitaRespostaDto deEmbeddable(OperacaoConteinerVisita operacao) {
+        return new OperacaoConteinerVisitaRespostaDto(operacao.getIdConteiner(), operacao.getStatusOperacao());
+    }
+
+    public Long getIdConteiner() {
+        return idConteiner;
+    }
+
+    public StatusOperacaoConteinerVisita getStatusOperacao() {
+        return statusOperacao;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/VisitaTremRespostaDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/dto/VisitaTremRespostaDto.java
@@ -3,6 +3,9 @@ package br.com.cloudport.servicoyard.ferrovia.dto;
 import br.com.cloudport.servicoyard.ferrovia.modelo.StatusVisitaTrem;
 import br.com.cloudport.servicoyard.ferrovia.modelo.VisitaTrem;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.web.util.HtmlUtils;
 
 public class VisitaTremRespostaDto {
@@ -13,19 +16,25 @@ public class VisitaTremRespostaDto {
     private final LocalDateTime horaChegadaPrevista;
     private final LocalDateTime horaPartidaPrevista;
     private final StatusVisitaTrem statusVisita;
+    private final List<OperacaoConteinerVisitaRespostaDto> listaDescarga;
+    private final List<OperacaoConteinerVisitaRespostaDto> listaCarga;
 
     public VisitaTremRespostaDto(Long id,
                                  String identificadorTrem,
                                  String operadoraFerroviaria,
                                  LocalDateTime horaChegadaPrevista,
                                  LocalDateTime horaPartidaPrevista,
-                                 StatusVisitaTrem statusVisita) {
+                                 StatusVisitaTrem statusVisita,
+                                 List<OperacaoConteinerVisitaRespostaDto> listaDescarga,
+                                 List<OperacaoConteinerVisitaRespostaDto> listaCarga) {
         this.id = id;
         this.identificadorTrem = identificadorTrem;
         this.operadoraFerroviaria = operadoraFerroviaria;
         this.horaChegadaPrevista = horaChegadaPrevista;
         this.horaPartidaPrevista = horaPartidaPrevista;
         this.statusVisita = statusVisita;
+        this.listaDescarga = listaDescarga;
+        this.listaCarga = listaCarga;
     }
 
     public static VisitaTremRespostaDto deEntidade(VisitaTrem entidade) {
@@ -35,7 +44,28 @@ public class VisitaTremRespostaDto {
                 HtmlUtils.htmlEscape(entidade.getOperadoraFerroviaria()),
                 entidade.getHoraChegadaPrevista(),
                 entidade.getHoraPartidaPrevista(),
-                entidade.getStatusVisita()
+                entidade.getStatusVisita(),
+                entidade.getListaDescarga()
+                        .stream()
+                        .map(OperacaoConteinerVisitaRespostaDto::deEmbeddable)
+                        .collect(Collectors.toList()),
+                entidade.getListaCarga()
+                        .stream()
+                        .map(OperacaoConteinerVisitaRespostaDto::deEmbeddable)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public static VisitaTremRespostaDto deEntidadeSemListas(VisitaTrem entidade) {
+        return new VisitaTremRespostaDto(
+                entidade.getId(),
+                HtmlUtils.htmlEscape(entidade.getIdentificadorTrem()),
+                HtmlUtils.htmlEscape(entidade.getOperadoraFerroviaria()),
+                entidade.getHoraChegadaPrevista(),
+                entidade.getHoraPartidaPrevista(),
+                entidade.getStatusVisita(),
+                Collections.emptyList(),
+                Collections.emptyList()
         );
     }
 
@@ -61,5 +91,13 @@ public class VisitaTremRespostaDto {
 
     public StatusVisitaTrem getStatusVisita() {
         return statusVisita;
+    }
+
+    public List<OperacaoConteinerVisitaRespostaDto> getListaDescarga() {
+        return listaDescarga;
+    }
+
+    public List<OperacaoConteinerVisitaRespostaDto> getListaCarga() {
+        return listaCarga;
     }
 }

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/OperacaoConteinerVisita.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/OperacaoConteinerVisita.java
@@ -1,0 +1,60 @@
+package br.com.cloudport.servicoyard.ferrovia.modelo;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Embeddable
+public class OperacaoConteinerVisita {
+
+    @Column(name = "id_conteiner", nullable = false)
+    private Long idConteiner;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status_operacao", nullable = false, length = 20)
+    private StatusOperacaoConteinerVisita statusOperacao = StatusOperacaoConteinerVisita.PENDENTE;
+
+    public OperacaoConteinerVisita() {
+    }
+
+    public OperacaoConteinerVisita(Long idConteiner, StatusOperacaoConteinerVisita statusOperacao) {
+        this.idConteiner = idConteiner;
+        this.statusOperacao = statusOperacao;
+    }
+
+    public Long getIdConteiner() {
+        return idConteiner;
+    }
+
+    public void setIdConteiner(Long idConteiner) {
+        this.idConteiner = idConteiner;
+    }
+
+    public StatusOperacaoConteinerVisita getStatusOperacao() {
+        return statusOperacao;
+    }
+
+    public void setStatusOperacao(StatusOperacaoConteinerVisita statusOperacao) {
+        this.statusOperacao = statusOperacao;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OperacaoConteinerVisita that = (OperacaoConteinerVisita) o;
+        return Objects.equals(idConteiner, that.idConteiner)
+                && statusOperacao == that.statusOperacao;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idConteiner, statusOperacao);
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/StatusOperacaoConteinerVisita.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/StatusOperacaoConteinerVisita.java
@@ -1,0 +1,6 @@
+package br.com.cloudport.servicoyard.ferrovia.modelo;
+
+public enum StatusOperacaoConteinerVisita {
+    PENDENTE,
+    CONCLUIDO
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/VisitaTrem.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/modelo/VisitaTrem.java
@@ -1,13 +1,18 @@
 package br.com.cloudport.servicoyard.ferrovia.modelo;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
@@ -41,6 +46,14 @@ public class VisitaTrem {
 
     @Column(name = "atualizado_em", nullable = false)
     private LocalDateTime atualizadoEm;
+
+    @ElementCollection
+    @CollectionTable(name = "visita_trem_descarga", joinColumns = @JoinColumn(name = "visita_trem_id"))
+    private List<OperacaoConteinerVisita> listaDescarga = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "visita_trem_carga", joinColumns = @JoinColumn(name = "visita_trem_id"))
+    private List<OperacaoConteinerVisita> listaCarga = new ArrayList<>();
 
     public VisitaTrem() {
     }
@@ -107,6 +120,28 @@ public class VisitaTrem {
 
     public void setAtualizadoEm(LocalDateTime atualizadoEm) {
         this.atualizadoEm = atualizadoEm;
+    }
+
+    public List<OperacaoConteinerVisita> getListaDescarga() {
+        return listaDescarga;
+    }
+
+    public void definirListaDescarga(List<OperacaoConteinerVisita> listaDescarga) {
+        this.listaDescarga.clear();
+        if (listaDescarga != null) {
+            this.listaDescarga.addAll(listaDescarga);
+        }
+    }
+
+    public List<OperacaoConteinerVisita> getListaCarga() {
+        return listaCarga;
+    }
+
+    public void definirListaCarga(List<OperacaoConteinerVisita> listaCarga) {
+        this.listaCarga.clear();
+        if (listaCarga != null) {
+            this.listaCarga.addAll(listaCarga);
+        }
     }
 
     @PrePersist

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/repositorio/VisitaTremRepositorio.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/repositorio/VisitaTremRepositorio.java
@@ -4,6 +4,7 @@ import br.com.cloudport.servicoyard.ferrovia.modelo.StatusVisitaTrem;
 import br.com.cloudport.servicoyard.ferrovia.modelo.VisitaTrem;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +21,10 @@ public interface VisitaTremRepositorio extends JpaRepository<VisitaTrem, Long> {
                                                      @Param("referenciaAtiva") LocalDateTime referenciaAtiva,
                                                      @Param("limite") LocalDateTime limite,
                                                      @Param("statusFinalizado") StatusVisitaTrem statusFinalizado);
+
+    @Query("SELECT DISTINCT v FROM VisitaTrem v "
+            + "LEFT JOIN FETCH v.listaDescarga "
+            + "LEFT JOIN FETCH v.listaCarga "
+            + "WHERE v.id = :id")
+    Optional<VisitaTrem> buscarPorIdComListas(@Param("id") Long id);
 }

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/servico/VisitaTremServico.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/ferrovia/servico/VisitaTremServico.java
@@ -1,9 +1,13 @@
 package br.com.cloudport.servicoyard.ferrovia.servico;
 
 import br.com.cloudport.servicoyard.comum.validacao.ValidacaoEntradaUtil;
+import br.com.cloudport.servicoyard.container.repositorio.ConteinerRepositorio;
 import br.com.cloudport.servicoyard.container.validacao.SanitizadorEntrada;
+import br.com.cloudport.servicoyard.ferrovia.dto.OperacaoConteinerVisitaRequisicaoDto;
 import br.com.cloudport.servicoyard.ferrovia.dto.VisitaTremRequisicaoDto;
 import br.com.cloudport.servicoyard.ferrovia.dto.VisitaTremRespostaDto;
+import br.com.cloudport.servicoyard.ferrovia.modelo.OperacaoConteinerVisita;
+import br.com.cloudport.servicoyard.ferrovia.modelo.StatusOperacaoConteinerVisita;
 import br.com.cloudport.servicoyard.ferrovia.modelo.StatusVisitaTrem;
 import br.com.cloudport.servicoyard.ferrovia.modelo.VisitaTrem;
 import br.com.cloudport.servicoyard.ferrovia.repositorio.VisitaTremRepositorio;
@@ -12,6 +16,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -25,11 +30,14 @@ public class VisitaTremServico {
     private static final int DIAS_MAXIMO_CONSULTA = 30;
 
     private final VisitaTremRepositorio visitaTremRepositorio;
+    private final ConteinerRepositorio conteinerRepositorio;
     private final SanitizadorEntrada sanitizadorEntrada;
 
     public VisitaTremServico(VisitaTremRepositorio visitaTremRepositorio,
+                              ConteinerRepositorio conteinerRepositorio,
                               SanitizadorEntrada sanitizadorEntrada) {
         this.visitaTremRepositorio = visitaTremRepositorio;
+        this.conteinerRepositorio = conteinerRepositorio;
         this.sanitizadorEntrada = sanitizadorEntrada;
     }
 
@@ -43,8 +51,7 @@ public class VisitaTremServico {
 
     @Transactional
     public VisitaTremRespostaDto atualizarVisita(Long id, VisitaTremRequisicaoDto dto) {
-        VisitaTrem existente = visitaTremRepositorio.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Visita de trem não encontrada."));
+        VisitaTrem existente = buscarVisitaComListas(id);
         aplicarDados(existente, dto);
         VisitaTrem atualizado = visitaTremRepositorio.save(existente);
         return VisitaTremRespostaDto.deEntidade(atualizado);
@@ -52,8 +59,7 @@ public class VisitaTremServico {
 
     @Transactional(readOnly = true)
     public VisitaTremRespostaDto consultarVisita(Long id) {
-        VisitaTrem visita = visitaTremRepositorio.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Visita de trem não encontrada."));
+        VisitaTrem visita = buscarVisitaComListas(id);
         return VisitaTremRespostaDto.deEntidade(visita);
     }
 
@@ -69,8 +75,42 @@ public class VisitaTremServico {
         return visitaTremRepositorio.buscarVisitasPlanejadasOuAtivas(inicio, agora, limite, StatusVisitaTrem.PARTIU)
                 .stream()
                 .distinct()
-                .map(VisitaTremRespostaDto::deEntidade)
+                .map(VisitaTremRespostaDto::deEntidadeSemListas)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public VisitaTremRespostaDto adicionarConteinerDescarga(Long idVisita, OperacaoConteinerVisitaRequisicaoDto dto) {
+        return adicionarOperacaoConteiner(idVisita, dto, TipoListaOperacaoVisita.DESCARGA);
+    }
+
+    @Transactional
+    public VisitaTremRespostaDto adicionarConteinerCarga(Long idVisita, OperacaoConteinerVisitaRequisicaoDto dto) {
+        return adicionarOperacaoConteiner(idVisita, dto, TipoListaOperacaoVisita.CARGA);
+    }
+
+    @Transactional
+    public VisitaTremRespostaDto removerConteinerDescarga(Long idVisita, Long idConteiner) {
+        return removerOperacaoConteiner(idVisita, idConteiner, TipoListaOperacaoVisita.DESCARGA);
+    }
+
+    @Transactional
+    public VisitaTremRespostaDto removerConteinerCarga(Long idVisita, Long idConteiner) {
+        return removerOperacaoConteiner(idVisita, idConteiner, TipoListaOperacaoVisita.CARGA);
+    }
+
+    @Transactional
+    public VisitaTremRespostaDto atualizarStatusDescarga(Long idVisita,
+                                                         Long idConteiner,
+                                                         StatusOperacaoConteinerVisita status) {
+        return atualizarStatusOperacaoConteiner(idVisita, idConteiner, status, TipoListaOperacaoVisita.DESCARGA);
+    }
+
+    @Transactional
+    public VisitaTremRespostaDto atualizarStatusCarga(Long idVisita,
+                                                      Long idConteiner,
+                                                      StatusOperacaoConteinerVisita status) {
+        return atualizarStatusOperacaoConteiner(idVisita, idConteiner, status, TipoListaOperacaoVisita.CARGA);
     }
 
     private void aplicarDados(VisitaTrem visita, VisitaTremRequisicaoDto dto) {
@@ -114,5 +154,111 @@ public class VisitaTremServico {
                     String.format(Locale.ROOT, "O campo %s deve ter no máximo %d caracteres.", campo, tamanhoMaximo));
         }
         return normalizado;
+    }
+
+    private VisitaTrem buscarVisitaComListas(Long id) {
+        return visitaTremRepositorio.buscarPorIdComListas(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Visita de trem não encontrada."));
+    }
+
+    private VisitaTremRespostaDto adicionarOperacaoConteiner(Long idVisita,
+                                                             OperacaoConteinerVisitaRequisicaoDto dto,
+                                                             TipoListaOperacaoVisita tipoLista) {
+        VisitaTrem visita = buscarVisitaComListas(idVisita);
+        OperacaoConteinerVisita novaOperacao = converterParaOperacao(dto);
+
+        List<OperacaoConteinerVisita> listaAlvo = obterListaPorTipo(visita, tipoLista);
+        boolean jaExiste = listaAlvo.stream()
+                .anyMatch(item -> item.getIdConteiner().equals(novaOperacao.getIdConteiner()));
+        if (jaExiste) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "O contêiner informado já está planejado para esta visita.");
+        }
+
+        List<OperacaoConteinerVisita> listaOposta = obterListaPorTipo(visita, tipoLista.inverso());
+        boolean emListaOposta = listaOposta.stream()
+                .anyMatch(item -> item.getIdConteiner().equals(novaOperacao.getIdConteiner()));
+        if (emListaOposta) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "O contêiner informado já está associado à outra lista desta visita.");
+        }
+
+        listaAlvo.add(novaOperacao);
+        visitaTremRepositorio.save(visita);
+        return VisitaTremRespostaDto.deEntidade(visita);
+    }
+
+    private VisitaTremRespostaDto removerOperacaoConteiner(Long idVisita,
+                                                           Long idConteiner,
+                                                           TipoListaOperacaoVisita tipoLista) {
+        VisitaTrem visita = buscarVisitaComListas(idVisita);
+        Long idValidado = validarIdConteiner(idConteiner);
+        List<OperacaoConteinerVisita> listaAlvo = obterListaPorTipo(visita, tipoLista);
+        boolean removido = listaAlvo.removeIf(item -> idValidado.equals(item.getIdConteiner()));
+        if (!removido) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "O contêiner informado não está relacionado a esta visita.");
+        }
+        visitaTremRepositorio.save(visita);
+        return VisitaTremRespostaDto.deEntidade(visita);
+    }
+
+    private VisitaTremRespostaDto atualizarStatusOperacaoConteiner(Long idVisita,
+                                                                   Long idConteiner,
+                                                                   StatusOperacaoConteinerVisita status,
+                                                                   TipoListaOperacaoVisita tipoLista) {
+        VisitaTrem visita = buscarVisitaComListas(idVisita);
+        Long idValidado = validarIdConteiner(idConteiner);
+        StatusOperacaoConteinerVisita statusValidado = Optional.ofNullable(status)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "O status da operação deve ser informado."));
+        List<OperacaoConteinerVisita> listaAlvo = obterListaPorTipo(visita, tipoLista);
+        OperacaoConteinerVisita operacao = listaAlvo.stream()
+                .filter(item -> idValidado.equals(item.getIdConteiner()))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "O contêiner informado não está relacionado a esta visita."));
+        operacao.setStatusOperacao(statusValidado);
+        visitaTremRepositorio.save(visita);
+        return VisitaTremRespostaDto.deEntidade(visita);
+    }
+
+    private List<OperacaoConteinerVisita> obterListaPorTipo(VisitaTrem visita, TipoListaOperacaoVisita tipoLista) {
+        if (tipoLista == TipoListaOperacaoVisita.DESCARGA) {
+            return visita.getListaDescarga();
+        }
+        return visita.getListaCarga();
+    }
+
+    private OperacaoConteinerVisita converterParaOperacao(OperacaoConteinerVisitaRequisicaoDto dto) {
+        Long idConteiner = validarIdConteiner(dto.getIdConteiner());
+        validarExistenciaConteiner(idConteiner);
+        StatusOperacaoConteinerVisita status = Optional.ofNullable(dto.getStatusOperacao())
+                .orElse(StatusOperacaoConteinerVisita.PENDENTE);
+        return new OperacaoConteinerVisita(idConteiner, status);
+    }
+
+    private Long validarIdConteiner(Long idConteiner) {
+        if (idConteiner == null || idConteiner <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "O identificador do contêiner deve ser um número positivo.");
+        }
+        return idConteiner;
+    }
+
+    private void validarExistenciaConteiner(Long idConteiner) {
+        if (!conteinerRepositorio.existsById(idConteiner)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "O contêiner informado não foi localizado no pátio.");
+        }
+    }
+
+    private enum TipoListaOperacaoVisita {
+        DESCARGA,
+        CARGA;
+
+        TipoListaOperacaoVisita inverso() {
+            return this == DESCARGA ? CARGA : DESCARGA;
+        }
     }
 }

--- a/backend/servico-yard/src/main/resources/db/migration/V3__criar_tabelas_visita_trem_conteineres.sql
+++ b/backend/servico-yard/src/main/resources/db/migration/V3__criar_tabelas_visita_trem_conteineres.sql
@@ -1,0 +1,21 @@
+CREATE TABLE visita_trem_descarga (
+    visita_trem_id BIGINT NOT NULL,
+    id_conteiner BIGINT NOT NULL,
+    status_operacao VARCHAR(20) NOT NULL,
+    CONSTRAINT fk_visita_descarga_visita FOREIGN KEY (visita_trem_id)
+        REFERENCES visita_trem (id) ON DELETE CASCADE
+);
+
+CREATE TABLE visita_trem_carga (
+    visita_trem_id BIGINT NOT NULL,
+    id_conteiner BIGINT NOT NULL,
+    status_operacao VARCHAR(20) NOT NULL,
+    CONSTRAINT fk_visita_carga_visita FOREIGN KEY (visita_trem_id)
+        REFERENCES visita_trem (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX uk_visita_trem_descarga_conteiner
+    ON visita_trem_descarga (visita_trem_id, id_conteiner);
+
+CREATE UNIQUE INDEX uk_visita_trem_carga_conteiner
+    ON visita_trem_carga (visita_trem_id, id_conteiner);

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.css
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.css
@@ -79,3 +79,113 @@
   color: #555;
   font-style: italic;
 }
+
+.painel-operacoes {
+  border: 1px solid #dcdcdc;
+  border-radius: 8px;
+  padding: 20px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.painel-operacoes h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #1d1d1d;
+}
+
+.abas-operacoes {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.abas-operacoes button {
+  padding: 8px 16px;
+  border: 1px solid #d0d0d0;
+  border-radius: 20px;
+  background-color: #f5f5f5;
+  color: #333;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.abas-operacoes button.ativa {
+  background-color: #005f9e;
+  color: #fff;
+  border-color: #005f9e;
+}
+
+.abas-operacoes button:not(.ativa):hover,
+.abas-operacoes button:not(.ativa):focus {
+  background-color: #e0e0e0;
+}
+
+.lista-operacoes {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.linha-operacao {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border: 1px solid #e3e3e3;
+  border-radius: 6px;
+  background-color: #fafafa;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.informacoes-conteiner {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.informacoes-conteiner .identificador {
+  font-weight: 600;
+  color: #222;
+}
+
+.informacoes-conteiner .status {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #9c6b00;
+}
+
+.informacoes-conteiner .status.concluido {
+  color: #117a00;
+}
+
+.botao-status {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #1e88e5;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.botao-status:disabled {
+  background-color: #9bbce0;
+  cursor: not-allowed;
+}
+
+.botao-status:not(:disabled):hover,
+.botao-status:not(:disabled):focus {
+  background-color: #1565c0;
+}
+
+.estado-sucesso {
+  padding: 12px;
+  background-color: #e7f8ed;
+  border-left: 4px solid #2e7d32;
+  color: #1b5e20;
+}

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.html
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.html
@@ -35,4 +35,44 @@
     </dl>
     <p class="observacao">Essas informações são atualizadas diretamente pelo sistema operacional da ferrovia.</p>
   </article>
+
+  <section *ngIf="!estaCarregando && !erroCarregamento && visita" class="painel-operacoes">
+    <h2>Planejamento de Contêineres</h2>
+    <nav class="abas-operacoes" aria-label="Seleção de operações">
+      <button type="button"
+              [class.ativa]="abaAtiva === 'DESCARGA'"
+              (click)="selecionarAba('DESCARGA')">
+        Para Descarregar ({{ obterItensAba('DESCARGA').length }})
+      </button>
+      <button type="button"
+              [class.ativa]="abaAtiva === 'CARGA'"
+              (click)="selecionarAba('CARGA')">
+        Para Carregar ({{ obterItensAba('CARGA').length }})
+      </button>
+    </nav>
+
+    <div *ngIf="mensagemOperacao" class="estado-sucesso">{{ textoSeguro(mensagemOperacao) }}</div>
+    <div *ngIf="erroOperacao" class="estado-erro">{{ textoSeguro(erroOperacao) }}</div>
+
+    <section class="lista-operacoes" *ngIf="obterItensAba(abaAtiva).length > 0; else semItens">
+      <article class="linha-operacao" *ngFor="let item of obterItensAba(abaAtiva)">
+        <div class="informacoes-conteiner">
+          <span class="identificador">Contêiner ID: {{ textoSeguro(item.idConteiner.toString()) }}</span>
+          <span class="status" [class.concluido]="estaConcluido(item.statusOperacao)">
+            {{ textoSeguro(descricaoStatus(item.statusOperacao)) }}
+          </span>
+        </div>
+        <button type="button"
+                class="botao-status"
+                [disabled]="estaConcluido(item.statusOperacao) || operacaoEmAndamento"
+                (click)="marcarComoConcluido(abaAtiva, item.idConteiner)">
+          Marcar como concluído
+        </button>
+      </article>
+    </section>
+
+    <ng-template #semItens>
+      <p class="estado-informativo">Nenhum contêiner planejado para esta operação.</p>
+    </ng-template>
+  </section>
 </section>

--- a/frontend/cloudport/src/app/componentes/service/servico-ferrovia/servico-ferrovia.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-ferrovia/servico-ferrovia.service.ts
@@ -3,6 +3,22 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ConfiguracaoAplicacaoService } from '../../../configuracao/configuracao-aplicacao.service';
 
+export type StatusOperacaoConteinerVisita = 'PENDENTE' | 'CONCLUIDO';
+
+export interface OperacaoConteinerVisita {
+  idConteiner: number;
+  statusOperacao: StatusOperacaoConteinerVisita;
+}
+
+export interface OperacaoConteinerVisitaEnvio {
+  idConteiner: number;
+  statusOperacao?: StatusOperacaoConteinerVisita;
+}
+
+export interface AtualizacaoStatusOperacaoConteiner {
+  statusOperacao: StatusOperacaoConteinerVisita;
+}
+
 export interface VisitaTrem {
   id: number;
   identificadorTrem: string;
@@ -10,6 +26,8 @@ export interface VisitaTrem {
   horaChegadaPrevista: string;
   horaPartidaPrevista: string;
   statusVisita: string;
+  listaDescarga: OperacaoConteinerVisita[];
+  listaCarga: OperacaoConteinerVisita[];
 }
 
 export interface VisitaTremRequisicao {
@@ -47,6 +65,34 @@ export class ServicoFerroviaService {
 
   atualizarVisita(id: number, payload: VisitaTremRequisicao): Observable<VisitaTrem> {
     return this.http.put<VisitaTrem>(this.construirUrl(`/${id}`), payload);
+  }
+
+  adicionarConteinerDescarga(idVisita: number, payload: OperacaoConteinerVisitaEnvio): Observable<VisitaTrem> {
+    return this.http.post<VisitaTrem>(this.construirUrl(`/${idVisita}/descarga`), payload);
+  }
+
+  adicionarConteinerCarga(idVisita: number, payload: OperacaoConteinerVisitaEnvio): Observable<VisitaTrem> {
+    return this.http.post<VisitaTrem>(this.construirUrl(`/${idVisita}/carga`), payload);
+  }
+
+  removerConteinerDescarga(idVisita: number, idConteiner: number): Observable<VisitaTrem> {
+    return this.http.delete<VisitaTrem>(this.construirUrl(`/${idVisita}/descarga/${idConteiner}`));
+  }
+
+  removerConteinerCarga(idVisita: number, idConteiner: number): Observable<VisitaTrem> {
+    return this.http.delete<VisitaTrem>(this.construirUrl(`/${idVisita}/carga/${idConteiner}`));
+  }
+
+  atualizarStatusDescarga(idVisita: number,
+                          idConteiner: number,
+                          payload: AtualizacaoStatusOperacaoConteiner): Observable<VisitaTrem> {
+    return this.http.patch<VisitaTrem>(this.construirUrl(`/${idVisita}/descarga/${idConteiner}/status`), payload);
+  }
+
+  atualizarStatusCarga(idVisita: number,
+                       idConteiner: number,
+                       payload: AtualizacaoStatusOperacaoConteiner): Observable<VisitaTrem> {
+    return this.http.patch<VisitaTrem>(this.construirUrl(`/${idVisita}/carga/${idConteiner}/status`), payload);
   }
 
   private construirUrl(caminho: string): string {


### PR DESCRIPTION
## Resumo
- adicionar suporte no backend para listas de contêineres de carga e descarga nas visitas de trem, incluindo novos endpoints de gestão e migração de banco de dados
- expor os dados das listas nas respostas da API e permitir atualização de status de cada operação
- atualizar a tela de detalhe de visita de trem para exibir abas de carga e descarga com ação de conclusão integrada à API real

## Testes
- `mvn -q test` *(falhou: dependência pai do Spring Boot não pôde ser baixada no ambiente por retorno 403 da Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68f6bb2c2f948327b1929dcb32a0bbaf