### PR TITLE
Integra evento ferroviário ao histórico do contêiner no gate

### DIFF
--- a/backend/servico-rail/pom.xml
+++ b/backend/servico-rail/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/configuracao/RabbitConfiguracao.java
+++ b/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/configuracao/RabbitConfiguracao.java
@@ -1,0 +1,15 @@
+package br.com.cloudport.servicorail.configuracao;
+
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitConfiguracao {
+
+    @Bean
+    public MessageConverter conversorMensagemJson() {
+        return new Jackson2JsonMessageConverter();
+    }
+}

--- a/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/dto/EventoMovimentacaoTremConcluidaDto.java
+++ b/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/dto/EventoMovimentacaoTremConcluidaDto.java
@@ -1,0 +1,78 @@
+package br.com.cloudport.servicorail.ferrovia.dto;
+
+import java.time.OffsetDateTime;
+
+public class EventoMovimentacaoTremConcluidaDto {
+
+    private Long idVisitaTrem;
+    private Long idOrdemMovimentacao;
+    private String codigoConteiner;
+    private String tipoMovimentacao;
+    private OffsetDateTime concluidoEm;
+    private String statusEvento;
+
+    public EventoMovimentacaoTremConcluidaDto() {
+    }
+
+    public EventoMovimentacaoTremConcluidaDto(Long idVisitaTrem,
+                                              Long idOrdemMovimentacao,
+                                              String codigoConteiner,
+                                              String tipoMovimentacao,
+                                              OffsetDateTime concluidoEm,
+                                              String statusEvento) {
+        this.idVisitaTrem = idVisitaTrem;
+        this.idOrdemMovimentacao = idOrdemMovimentacao;
+        this.codigoConteiner = codigoConteiner;
+        this.tipoMovimentacao = tipoMovimentacao;
+        this.concluidoEm = concluidoEm;
+        this.statusEvento = statusEvento;
+    }
+
+    public Long getIdVisitaTrem() {
+        return idVisitaTrem;
+    }
+
+    public void setIdVisitaTrem(Long idVisitaTrem) {
+        this.idVisitaTrem = idVisitaTrem;
+    }
+
+    public Long getIdOrdemMovimentacao() {
+        return idOrdemMovimentacao;
+    }
+
+    public void setIdOrdemMovimentacao(Long idOrdemMovimentacao) {
+        this.idOrdemMovimentacao = idOrdemMovimentacao;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public String getTipoMovimentacao() {
+        return tipoMovimentacao;
+    }
+
+    public void setTipoMovimentacao(String tipoMovimentacao) {
+        this.tipoMovimentacao = tipoMovimentacao;
+    }
+
+    public OffsetDateTime getConcluidoEm() {
+        return concluidoEm;
+    }
+
+    public void setConcluidoEm(OffsetDateTime concluidoEm) {
+        this.concluidoEm = concluidoEm;
+    }
+
+    public String getStatusEvento() {
+        return statusEvento;
+    }
+
+    public void setStatusEvento(String statusEvento) {
+        this.statusEvento = statusEvento;
+    }
+}

--- a/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/evento/PublicadorEventoMovimentacaoTrem.java
+++ b/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/evento/PublicadorEventoMovimentacaoTrem.java
@@ -1,0 +1,35 @@
+package br.com.cloudport.servicorail.ferrovia.evento;
+
+import br.com.cloudport.servicorail.ferrovia.dto.EventoMovimentacaoTremConcluidaDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class PublicadorEventoMovimentacaoTrem {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PublicadorEventoMovimentacaoTrem.class);
+
+    private final RabbitTemplate rabbitTemplate;
+    private final String exchange;
+    private final String routingKey;
+
+    public PublicadorEventoMovimentacaoTrem(RabbitTemplate rabbitTemplate,
+                                            @Value("${cloudport.rail.eventos.exchange}") String exchange,
+                                            @Value("${cloudport.rail.eventos.routing-movimentacao}") String routingKey) {
+        this.rabbitTemplate = rabbitTemplate;
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+    }
+
+    public void publicar(EventoMovimentacaoTremConcluidaDto evento) {
+        Assert.notNull(evento, "Evento da movimentação do trem não pode ser nulo");
+        LOGGER.info("event=movimentacao_trem.publicada ordem={} visita={} conteiner={} tipo={}",
+                evento.getIdOrdemMovimentacao(), evento.getIdVisitaTrem(), evento.getCodigoConteiner(),
+                evento.getTipoMovimentacao());
+        rabbitTemplate.convertAndSend(exchange, routingKey, evento);
+    }
+}

--- a/backend/servico-rail/src/main/resources/application.properties
+++ b/backend/servico-rail/src/main/resources/application.properties
@@ -15,3 +15,11 @@ spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 spring.flyway.default-schema=${RAIL_FLYWAY_SCHEMA:cloudport_rail}
 spring.flyway.schemas=${RAIL_FLYWAY_SCHEMA:cloudport_rail}
+
+spring.rabbitmq.host=${RAIL_RABBIT_HOST:localhost}
+spring.rabbitmq.port=${RAIL_RABBIT_PORT:5672}
+spring.rabbitmq.username=${RAIL_RABBIT_USERNAME:guest}
+spring.rabbitmq.password=${RAIL_RABBIT_PASSWORD:guest}
+
+cloudport.rail.eventos.exchange=${RAIL_EVENTOS_EXCHANGE:ferrovia.eventos}
+cloudport.rail.eventos.routing-movimentacao=${RAIL_EVENTOS_ROUTING_MOVIMENTACAO:rail.movimentacao.concluida}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/configuracao/IntegracaoFerroviaRabbitConfiguracao.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/configuracao/IntegracaoFerroviaRabbitConfiguracao.java
@@ -1,0 +1,34 @@
+package br.com.cloudport.servicoyard.configuracao;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IntegracaoFerroviaRabbitConfiguracao {
+
+    @Bean
+    public TopicExchange exchangeMovimentacaoFerrovia(
+            @Value("${cloudport.yard.integracoes.ferrovia.exchange}") String exchange) {
+        return new TopicExchange(exchange, true, false);
+    }
+
+    @Bean
+    public Queue filaMovimentacaoFerrovia(
+            @Value("${cloudport.yard.integracoes.ferrovia.queue}") String queue) {
+        return new Queue(queue, true);
+    }
+
+    @Bean
+    public Binding bindingMovimentacaoFerrovia(Queue filaMovimentacaoFerrovia,
+                                               TopicExchange exchangeMovimentacaoFerrovia,
+                                               @Value("${cloudport.yard.integracoes.ferrovia.routing}") String routingKey) {
+        return BindingBuilder.bind(filaMovimentacaoFerrovia)
+                .to(exchangeMovimentacaoFerrovia)
+                .with(routingKey);
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/controlador/ConteinerControlador.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/controlador/ConteinerControlador.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,6 +42,11 @@ public class ConteinerControlador {
     @GetMapping("/{identificador}")
     public ConteinerDetalheDTO detalhar(@PathVariable Long identificador) {
         return conteinerServico.buscarDetalhe(identificador);
+    }
+
+    @GetMapping("/por-codigo")
+    public ConteinerDetalheDTO detalharPorCodigo(@RequestParam("codigo") String codigo) {
+        return conteinerServico.buscarDetalhePorCodigo(codigo);
     }
 
     @PostMapping
@@ -76,5 +82,10 @@ public class ConteinerControlador {
     @GetMapping("/{identificador}/historico")
     public List<HistoricoOperacaoDTO> historico(@PathVariable Long identificador) {
         return conteinerServico.consultarHistorico(identificador);
+    }
+
+    @GetMapping("/por-codigo/historico")
+    public List<HistoricoOperacaoDTO> historicoPorCodigo(@RequestParam("codigo") String codigo) {
+        return conteinerServico.consultarHistoricoPorCodigo(codigo);
     }
 }

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/dto/MovimentacaoTremConcluidaEventoDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/dto/MovimentacaoTremConcluidaEventoDto.java
@@ -1,0 +1,64 @@
+package br.com.cloudport.servicoyard.container.dto;
+
+import java.time.OffsetDateTime;
+
+public class MovimentacaoTremConcluidaEventoDto {
+
+    private Long idVisitaTrem;
+    private Long idOrdemMovimentacao;
+    private String codigoConteiner;
+    private String tipoMovimentacao;
+    private OffsetDateTime concluidoEm;
+    private String statusEvento;
+
+    public MovimentacaoTremConcluidaEventoDto() {
+    }
+
+    public Long getIdVisitaTrem() {
+        return idVisitaTrem;
+    }
+
+    public void setIdVisitaTrem(Long idVisitaTrem) {
+        this.idVisitaTrem = idVisitaTrem;
+    }
+
+    public Long getIdOrdemMovimentacao() {
+        return idOrdemMovimentacao;
+    }
+
+    public void setIdOrdemMovimentacao(Long idOrdemMovimentacao) {
+        this.idOrdemMovimentacao = idOrdemMovimentacao;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public String getTipoMovimentacao() {
+        return tipoMovimentacao;
+    }
+
+    public void setTipoMovimentacao(String tipoMovimentacao) {
+        this.tipoMovimentacao = tipoMovimentacao;
+    }
+
+    public OffsetDateTime getConcluidoEm() {
+        return concluidoEm;
+    }
+
+    public void setConcluidoEm(OffsetDateTime concluidoEm) {
+        this.concluidoEm = concluidoEm;
+    }
+
+    public String getStatusEvento() {
+        return statusEvento;
+    }
+
+    public void setStatusEvento(String statusEvento) {
+        this.statusEvento = statusEvento;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/entidade/TipoOperacaoConteiner.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/entidade/TipoOperacaoConteiner.java
@@ -5,5 +5,7 @@ public enum TipoOperacaoConteiner {
     TRANSFERENCIA,
     INSPECAO,
     LIBERACAO,
-    ATUALIZACAO_CADASTRAL
+    ATUALIZACAO_CADASTRAL,
+    DESCARGA_TREM,
+    CARGA_TREM
 }

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/servico/MovimentacaoTremListener.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/servico/MovimentacaoTremListener.java
@@ -1,0 +1,28 @@
+package br.com.cloudport.servicoyard.container.servico;
+
+import br.com.cloudport.servicoyard.container.dto.MovimentacaoTremConcluidaEventoDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MovimentacaoTremListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MovimentacaoTremListener.class);
+
+    private final ProcessadorMovimentacaoTremService processadorMovimentacaoTremService;
+
+    public MovimentacaoTremListener(ProcessadorMovimentacaoTremService processadorMovimentacaoTremService) {
+        this.processadorMovimentacaoTremService = processadorMovimentacaoTremService;
+    }
+
+    @RabbitListener(queues = "${cloudport.yard.integracoes.ferrovia.queue}")
+    public void aoReceberMovimentacao(MovimentacaoTremConcluidaEventoDto evento) {
+        LOGGER.info("event=movimentacao_trem.recebida ordem={} visita={} conteiner={}",
+                evento != null ? evento.getIdOrdemMovimentacao() : null,
+                evento != null ? evento.getIdVisitaTrem() : null,
+                evento != null ? evento.getCodigoConteiner() : null);
+        processadorMovimentacaoTremService.processar(evento);
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/servico/ProcessadorMovimentacaoTremService.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/servico/ProcessadorMovimentacaoTremService.java
@@ -1,0 +1,132 @@
+package br.com.cloudport.servicoyard.container.servico;
+
+import br.com.cloudport.servicoyard.container.dto.MovimentacaoTremConcluidaEventoDto;
+import br.com.cloudport.servicoyard.container.entidade.Conteiner;
+import br.com.cloudport.servicoyard.container.entidade.HistoricoOperacaoConteiner;
+import br.com.cloudport.servicoyard.container.entidade.StatusOperacionalConteiner;
+import br.com.cloudport.servicoyard.container.entidade.TipoOperacaoConteiner;
+import br.com.cloudport.servicoyard.container.repositorio.ConteinerRepositorio;
+import br.com.cloudport.servicoyard.container.repositorio.HistoricoOperacaoConteinerRepositorio;
+import br.com.cloudport.servicoyard.container.validacao.SanitizadorEntrada;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class ProcessadorMovimentacaoTremService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessadorMovimentacaoTremService.class);
+    private static final String RESPONSAVEL_INTEGRACAO = "Integração Ferrovia";
+
+    private final ConteinerRepositorio conteinerRepositorio;
+    private final HistoricoOperacaoConteinerRepositorio historicoRepositorio;
+    private final SanitizadorEntrada sanitizadorEntrada;
+
+    public ProcessadorMovimentacaoTremService(ConteinerRepositorio conteinerRepositorio,
+                                              HistoricoOperacaoConteinerRepositorio historicoRepositorio,
+                                              SanitizadorEntrada sanitizadorEntrada) {
+        this.conteinerRepositorio = conteinerRepositorio;
+        this.historicoRepositorio = historicoRepositorio;
+        this.sanitizadorEntrada = sanitizadorEntrada;
+    }
+
+    @Transactional
+    public void processar(MovimentacaoTremConcluidaEventoDto evento) {
+        if (evento == null) {
+            LOGGER.warn("event=movimentacao_trem.evento_nulo");
+            return;
+        }
+        String codigoConteiner = Optional.ofNullable(evento.getCodigoConteiner())
+                .map(sanitizadorEntrada::limparTexto)
+                .map(valor -> valor.toUpperCase(Locale.ROOT))
+                .orElse(null);
+        if (!StringUtils.hasText(codigoConteiner)) {
+            LOGGER.warn("event=movimentacao_trem.codigo_ausente ordem={} visita={}",
+                    evento.getIdOrdemMovimentacao(), evento.getIdVisitaTrem());
+            return;
+        }
+        TipoOperacaoConteiner tipoOperacao = mapearTipoOperacao(evento.getTipoMovimentacao());
+        if (tipoOperacao == null) {
+            LOGGER.warn("event=movimentacao_trem.tipo_desconhecido tipo={} ordem={} visita={}",
+                    evento.getTipoMovimentacao(), evento.getIdOrdemMovimentacao(), evento.getIdVisitaTrem());
+            return;
+        }
+        Conteiner conteiner = conteinerRepositorio.findByIdentificacaoIgnoreCase(codigoConteiner)
+                .orElse(null);
+        if (conteiner == null) {
+            LOGGER.warn("event=movimentacao_trem.conteiner_nao_localizado codigo={} ordem={} visita={}",
+                    codigoConteiner, evento.getIdOrdemMovimentacao(), evento.getIdVisitaTrem());
+            return;
+        }
+        StatusOperacionalConteiner statusAnterior = conteiner.getStatusOperacional();
+        StatusOperacionalConteiner novoStatus = definirStatusPosMovimentacao(tipoOperacao, statusAnterior);
+        if (novoStatus != null && novoStatus != statusAnterior) {
+            conteiner.setStatusOperacional(novoStatus);
+            conteinerRepositorio.save(conteiner);
+        }
+        registrarHistorico(conteiner, tipoOperacao, evento, statusAnterior, novoStatus);
+    }
+
+    private void registrarHistorico(Conteiner conteiner,
+                                    TipoOperacaoConteiner tipoOperacao,
+                                    MovimentacaoTremConcluidaEventoDto evento,
+                                    StatusOperacionalConteiner statusAnterior,
+                                    StatusOperacionalConteiner novoStatus) {
+        HistoricoOperacaoConteiner historico = new HistoricoOperacaoConteiner();
+        historico.setConteiner(conteiner);
+        historico.setTipoOperacao(tipoOperacao);
+        historico.setDescricao(montarDescricao(tipoOperacao, statusAnterior, novoStatus));
+        historico.setPosicaoAnterior(null);
+        historico.setPosicaoAtual(conteiner.getPosicaoPatio());
+        historico.setResponsavel(sanitizadorEntrada.limparTexto(RESPONSAVEL_INTEGRACAO));
+        OffsetDateTime dataRegistro = Optional.ofNullable(evento.getConcluidoEm())
+                .orElse(OffsetDateTime.now(ZoneOffset.UTC));
+        historico.setDataRegistro(dataRegistro);
+        historicoRepositorio.save(historico);
+    }
+
+    private TipoOperacaoConteiner mapearTipoOperacao(String tipoMovimentacao) {
+        if (!StringUtils.hasText(tipoMovimentacao)) {
+            return null;
+        }
+        String tipoNormalizado = tipoMovimentacao.trim().toUpperCase(Locale.ROOT);
+        if ("DESCARGA_TREM".equals(tipoNormalizado)) {
+            return TipoOperacaoConteiner.DESCARGA_TREM;
+        }
+        if ("CARGA_TREM".equals(tipoNormalizado)) {
+            return TipoOperacaoConteiner.CARGA_TREM;
+        }
+        return null;
+    }
+
+    private StatusOperacionalConteiner definirStatusPosMovimentacao(TipoOperacaoConteiner tipoOperacao,
+                                                                    StatusOperacionalConteiner statusAtual) {
+        if (tipoOperacao == TipoOperacaoConteiner.DESCARGA_TREM) {
+            return StatusOperacionalConteiner.ALOCADO;
+        }
+        if (tipoOperacao == TipoOperacaoConteiner.CARGA_TREM) {
+            return StatusOperacionalConteiner.EM_TRANSFERENCIA;
+        }
+        return statusAtual;
+    }
+
+    private String montarDescricao(TipoOperacaoConteiner tipoOperacao,
+                                   StatusOperacionalConteiner statusAnterior,
+                                   StatusOperacionalConteiner novoStatus) {
+        if (tipoOperacao == TipoOperacaoConteiner.DESCARGA_TREM) {
+            return "Descarga do trem concluída e contêiner disponível no pátio.";
+        }
+        if (tipoOperacao == TipoOperacaoConteiner.CARGA_TREM) {
+            return "Carga no trem concluída e contêiner encaminhado para o modal ferroviário.";
+        }
+        return String.format(Locale.ROOT,
+                "Movimentação atualizada de %s para %s.",
+                statusAnterior, novoStatus);
+    }
+}

--- a/backend/servico-yard/src/main/resources/application.properties
+++ b/backend/servico-yard/src/main/resources/application.properties
@@ -23,3 +23,6 @@ spring.rabbitmq.password=${YARD_RABBIT_PASSWORD:guest}
 
 cloudport.yard.eventos.exchange=${YARD_EVENTOS_EXCHANGE:yard.eventos}
 cloudport.yard.eventos.routing-movimento=${YARD_EVENTOS_ROUTING_MOVIMENTO:yard.movimento.registrado}
+cloudport.yard.integracoes.ferrovia.exchange=${YARD_FERROVIA_EXCHANGE:ferrovia.eventos}
+cloudport.yard.integracoes.ferrovia.queue=${YARD_FERROVIA_QUEUE:yard.movimentacao.trem}
+cloudport.yard.integracoes.ferrovia.routing=${YARD_FERROVIA_ROUTING:rail.movimentacao.concluida}

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.css
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.css
@@ -165,6 +165,91 @@
   gap: 16px;
 }
 
+.agendamento-detalhe__historico-conteiner {
+  background: #f9fafb;
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.historico-conteiner__cabecalho {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.historico-conteiner__cabecalho h4 {
+  margin: 0 0 6px 0;
+  font-size: 1.05rem;
+  color: #1f2937;
+}
+
+.historico-conteiner__cabecalho span {
+  display: block;
+  color: #4b5563;
+  font-size: 0.85rem;
+}
+
+.historico-conteiner__atualizacao {
+  color: #6b7280;
+  font-size: 0.8rem;
+}
+
+.historico-conteiner__mensagem {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.historico-conteiner__mensagem--erro {
+  color: #b91c1c;
+}
+
+.historico-conteiner__mensagem--vazio {
+  color: #6b7280;
+}
+
+.historico-conteiner__lista {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.historico-conteiner__item {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 12px 16px;
+  box-shadow: inset 0 0 0 1px rgba(209, 213, 219, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.historico-conteiner__item-cabecalho {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.historico-conteiner__item-cabecalho strong {
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.historico-conteiner__item-cabecalho span {
+  color: #6b7280;
+  font-size: 0.8rem;
+}
+
 .agendamento-detalhe__grid div {
   display: flex;
   flex-direction: column;

--- a/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.html
+++ b/frontend/cloudport/src/app/componentes/gate/portal/agendamento-detalhe/agendamento-detalhe.component.html
@@ -85,6 +85,52 @@
     [agendamentoCodigo]="agendamento?.codigo"
   ></app-motorista-pass>
 
+  <section class="agendamento-detalhe__historico-conteiner" *ngIf="codigoConteinerSelecionado">
+    <header class="historico-conteiner__cabecalho">
+      <div>
+        <h4>{{ 'gate.agendamentoDetalhe.historicoConteiner.titulo' | translate:{ codigo: codigoConteinerSelecionado } }}</h4>
+        <span *ngIf="detalheConteiner">
+          {{ 'gate.agendamentoDetalhe.historicoConteiner.statusAtual' | translate:{ status: formatarStatusConteiner() || detalheConteiner?.statusOperacional } }}
+        </span>
+        <span *ngIf="detalheConteiner?.posicaoPatio">
+          {{ 'gate.agendamentoDetalhe.historicoConteiner.posicaoAtual' | translate:{ posicao: detalheConteiner?.posicaoPatio } }}
+        </span>
+      </div>
+      <span class="historico-conteiner__atualizacao" *ngIf="detalheConteiner?.ultimaAtualizacao">
+        {{ 'gate.agendamentoDetalhe.historicoConteiner.ultimaAtualizacao' | translate:{ data: (detalheConteiner?.ultimaAtualizacao | date: 'dd/MM/yyyy HH:mm') } }}
+      </span>
+    </header>
+    <p class="historico-conteiner__mensagem" *ngIf="carregandoHistoricoConteiner">
+      {{ 'gate.agendamentoDetalhe.historicoConteiner.carregando' | translate }}
+    </p>
+    <p class="historico-conteiner__mensagem historico-conteiner__mensagem--erro"
+      *ngIf="!carregandoHistoricoConteiner && erroHistoricoConteiner">
+      {{ erroHistoricoConteiner }}
+    </p>
+    <ul class="historico-conteiner__lista"
+      *ngIf="!carregandoHistoricoConteiner && !erroHistoricoConteiner && historicoConteiner.length; else historicoConteinerVazio"
+      [attr.aria-live]="'polite'">
+      <li class="historico-conteiner__item" *ngFor="let evento of historicoConteiner; trackBy: trackPorHistorico">
+        <div class="historico-conteiner__item-cabecalho">
+          <strong>{{ descricaoTipoOperacao(evento.tipoOperacao) }}</strong>
+          <span>{{ evento.dataRegistro | date: 'dd/MM/yyyy HH:mm' }}</span>
+        </div>
+        <p>{{ sanitizarTexto(evento.descricao) }}</p>
+        <small *ngIf="evento.responsavel">
+          {{ 'gate.agendamentoDetalhe.historicoConteiner.responsavel' | translate:{ responsavel: sanitizarTexto(evento.responsavel) } }}
+        </small>
+        <small *ngIf="evento.posicaoAtual">
+          {{ 'gate.agendamentoDetalhe.historicoConteiner.posicaoMovimentacao' | translate:{ posicao: sanitizarTexto(evento.posicaoAtual || '') } }}
+        </small>
+      </li>
+    </ul>
+    <ng-template #historicoConteinerVazio>
+      <p class="historico-conteiner__mensagem historico-conteiner__mensagem--vazio">
+        {{ 'gate.agendamentoDetalhe.historicoConteiner.vazio' | translate }}
+      </p>
+    </ng-template>
+  </section>
+
   <section class="agendamento-detalhe__documentos">
     <header>
       <h4>{{ 'gate.agendamentoDetalhe.documentosAnexados' | translate }}</h4>

--- a/frontend/cloudport/src/app/componentes/service/servico-gate/historico-conteiner.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-gate/historico-conteiner.service.ts
@@ -1,0 +1,67 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, throwError } from 'rxjs';
+import { ConfiguracaoAplicacaoService } from '../../../configuracao/configuracao-aplicacao.service';
+
+export interface DetalheConteiner {
+  identificador: number;
+  identificacao: string;
+  posicaoPatio: string;
+  tipoCarga: string;
+  pesoToneladas: number;
+  restricoes: string | null;
+  statusOperacional: string;
+  ultimaAtualizacao: string;
+}
+
+export interface HistoricoConteiner {
+  tipoOperacao: string;
+  descricao: string;
+  posicaoAnterior: string | null;
+  posicaoAtual: string | null;
+  responsavel: string | null;
+  dataRegistro: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HistoricoConteinerService {
+  private readonly detalhesEndpoint = '/yard/conteineres/por-codigo';
+  private readonly historicoEndpoint = '/yard/conteineres/por-codigo/historico';
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly configuracaoAplicacao: ConfiguracaoAplicacaoService
+  ) {}
+
+  obterDetalhePorCodigo(codigoConteiner: string): Observable<DetalheConteiner> {
+    const params = this.construirParametros(codigoConteiner);
+    if (!params) {
+      return throwError(() => new Error('Código do contêiner inválido.'));
+    }
+    return this.http.get<DetalheConteiner>(
+      this.configuracaoAplicacao.construirUrlApi(this.detalhesEndpoint),
+      { params }
+    );
+  }
+
+  obterHistoricoPorCodigo(codigoConteiner: string): Observable<HistoricoConteiner[]> {
+    const params = this.construirParametros(codigoConteiner);
+    if (!params) {
+      return throwError(() => new Error('Código do contêiner inválido.'));
+    }
+    return this.http.get<HistoricoConteiner[]>(
+      this.configuracaoAplicacao.construirUrlApi(this.historicoEndpoint),
+      { params }
+    );
+  }
+
+  private construirParametros(codigoConteiner: string): HttpParams | null {
+    const codigo = (codigoConteiner ?? '').trim();
+    if (!codigo) {
+      return null;
+    }
+    return new HttpParams().set('codigo', codigo.toUpperCase());
+  }
+}

--- a/frontend/cloudport/src/assets/i18n/en.json
+++ b/frontend/cloudport/src/assets/i18n/en.json
@@ -56,6 +56,24 @@
         "status": "Pass status",
         "atualizadoEm": "Updated on {{data}}"
       },
+      "historicoConteiner": {
+        "titulo": "Histórico do contêiner {{codigo}}",
+        "statusAtual": "Status atual: {{status}}",
+        "posicaoAtual": "Posição no pátio: {{posicao}}",
+        "ultimaAtualizacao": "Última atualização: {{data}}",
+        "carregando": "Carregando histórico do contêiner...",
+        "erroCarregamento": "Não foi possível carregar o histórico do contêiner. Tente novamente em instantes.",
+        "vazio": "Nenhuma movimentação registrada para este contêiner ainda.",
+        "responsavel": "Responsável: {{responsavel}}",
+        "posicaoMovimentacao": "Posição registrada: {{posicao}}",
+        "descargaTrem": "Descarga do trem concluída",
+        "cargaTrem": "Carga no trem concluída",
+        "alocacao": "Alocação registrada",
+        "transferencia": "Transferência realizada",
+        "inspecao": "Inspeção registrada",
+        "liberacao": "Liberação registrada",
+        "atualizacaoCadastral": "Atualização cadastral"
+      },
       "realtime": {
         "titulo": "Real-time status",
         "status": {

--- a/frontend/cloudport/src/assets/i18n/es.json
+++ b/frontend/cloudport/src/assets/i18n/es.json
@@ -56,6 +56,24 @@
         "status": "Estado del pase",
         "atualizadoEm": "Actualizado el {{data}}"
       },
+      "historicoConteiner": {
+        "titulo": "Histórico del contenedor {{codigo}}",
+        "statusAtual": "Estado actual: {{status}}",
+        "posicaoAtual": "Ubicación en patio: {{posicao}}",
+        "ultimaAtualizacao": "Última actualización: {{data}}",
+        "carregando": "Cargando histórico del contenedor...",
+        "erroCarregamento": "No fue posible cargar el histórico del contenedor. Intente nuevamente.",
+        "vazio": "Aún no hay movimientos registrados para este contenedor.",
+        "responsavel": "Responsable: {{responsavel}}",
+        "posicaoMovimentacao": "Ubicación registrada: {{posicao}}",
+        "descargaTrem": "Descarga del tren concluida",
+        "cargaTrem": "Carga en el tren concluida",
+        "alocacao": "Asignación registrada",
+        "transferencia": "Transferencia registrada",
+        "inspecao": "Inspección registrada",
+        "liberacao": "Liberación registrada",
+        "atualizacaoCadastral": "Actualización de registro"
+      },
       "realtime": {
         "titulo": "Estado en tiempo real",
         "status": {

--- a/frontend/cloudport/src/assets/i18n/pt.json
+++ b/frontend/cloudport/src/assets/i18n/pt.json
@@ -56,6 +56,24 @@
         "status": "Status do passe",
         "atualizadoEm": "Atualizado em {{data}}"
       },
+      "historicoConteiner": {
+        "titulo": "Histórico do contêiner {{codigo}}",
+        "statusAtual": "Status atual: {{status}}",
+        "posicaoAtual": "Posição no pátio: {{posicao}}",
+        "ultimaAtualizacao": "Última atualização: {{data}}",
+        "carregando": "Carregando histórico do contêiner...",
+        "erroCarregamento": "Não foi possível carregar o histórico do contêiner. Tente novamente em instantes.",
+        "vazio": "Nenhuma movimentação registrada para este contêiner ainda.",
+        "responsavel": "Responsável: {{responsavel}}",
+        "posicaoMovimentacao": "Posição registrada: {{posicao}}",
+        "descargaTrem": "Descarga do trem concluída",
+        "cargaTrem": "Carga no trem concluída",
+        "alocacao": "Alocação registrada",
+        "transferencia": "Transferência realizada",
+        "inspecao": "Inspeção registrada",
+        "liberacao": "Liberação registrada",
+        "atualizacaoCadastral": "Atualização cadastral"
+      },
       "realtime": {
         "titulo": "Atualização em tempo real",
         "status": {


### PR DESCRIPTION
## Resumo
- publica o evento de conclusão de movimentação ferroviária no serviço de trem utilizando RabbitMQ
- cria consumidor no serviço de pátio para atualizar status e histórico de contêiner, além de expor consultas por código
- apresenta o histórico integrado do contêiner na tela de agendamento do módulo de caminhão com atualizações automáticas

## Testes
- mvn -pl . -am test (serviço rail) *(falha: dependência bloqueada pelo proxy 403)*
- mvn -pl . -am test (serviço yard) *(falha: dependência bloqueada pelo proxy 403)*
- npm --prefix frontend/cloudport run lint *(falha: script não definido no projeto)*

------
https://chatgpt.com/codex/tasks/task_e_68f6ed00a70883279366060aaaa75131