### PR TITLE
Implementa lista de trabalho do pátio para operadores

### DIFF
--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/dto/OpcoesCadastroPatioDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/dto/OpcoesCadastroPatioDto.java
@@ -7,15 +7,17 @@ public class OpcoesCadastroPatioDto {
     private List<String> statusConteiner;
     private List<String> tiposEquipamento;
     private List<String> statusEquipamento;
+    private List<String> tiposMovimento;
 
     public OpcoesCadastroPatioDto() {
     }
 
     public OpcoesCadastroPatioDto(List<String> statusConteiner, List<String> tiposEquipamento,
-                                  List<String> statusEquipamento) {
+                                  List<String> statusEquipamento, List<String> tiposMovimento) {
         this.statusConteiner = statusConteiner;
         this.tiposEquipamento = tiposEquipamento;
         this.statusEquipamento = statusEquipamento;
+        this.tiposMovimento = tiposMovimento;
     }
 
     public List<String> getStatusConteiner() {
@@ -40,5 +42,13 @@ public class OpcoesCadastroPatioDto {
 
     public void setStatusEquipamento(List<String> statusEquipamento) {
         this.statusEquipamento = statusEquipamento;
+    }
+
+    public List<String> getTiposMovimento() {
+        return tiposMovimento;
+    }
+
+    public void setTiposMovimento(List<String> tiposMovimento) {
+        this.tiposMovimento = tiposMovimento;
     }
 }

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/controlador/OrdemTrabalhoPatioControlador.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/controlador/OrdemTrabalhoPatioControlador.java
@@ -1,0 +1,47 @@
+package br.com.cloudport.servicoyard.patio.listatrabalho.controlador;
+
+import br.com.cloudport.servicoyard.patio.listatrabalho.dto.AtualizacaoStatusOrdemTrabalhoDto;
+import br.com.cloudport.servicoyard.patio.listatrabalho.dto.OrdemTrabalhoPatioRequisicaoDto;
+import br.com.cloudport.servicoyard.patio.listatrabalho.dto.OrdemTrabalhoPatioRespostaDto;
+import br.com.cloudport.servicoyard.patio.listatrabalho.modelo.StatusOrdemTrabalhoPatio;
+import br.com.cloudport.servicoyard.patio.listatrabalho.servico.OrdemTrabalhoPatioServico;
+import java.util.List;
+import javax.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/yard/patio/ordens")
+public class OrdemTrabalhoPatioControlador {
+
+    private final OrdemTrabalhoPatioServico ordemTrabalhoPatioServico;
+
+    public OrdemTrabalhoPatioControlador(OrdemTrabalhoPatioServico ordemTrabalhoPatioServico) {
+        this.ordemTrabalhoPatioServico = ordemTrabalhoPatioServico;
+    }
+
+    @GetMapping
+    public List<OrdemTrabalhoPatioRespostaDto> listarOrdens(@RequestParam(name = "status", required = false) StatusOrdemTrabalhoPatio status) {
+        return ordemTrabalhoPatioServico.listarOrdens(status);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public OrdemTrabalhoPatioRespostaDto registrarOrdem(@Valid @RequestBody OrdemTrabalhoPatioRequisicaoDto dto) {
+        return ordemTrabalhoPatioServico.registrarOrdem(dto);
+    }
+
+    @PatchMapping("/{id}/status")
+    public OrdemTrabalhoPatioRespostaDto atualizarStatus(@PathVariable("id") Long id,
+                                                         @Valid @RequestBody AtualizacaoStatusOrdemTrabalhoDto dto) {
+        return ordemTrabalhoPatioServico.atualizarStatus(id, dto);
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/dto/AtualizacaoStatusOrdemTrabalhoDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/dto/AtualizacaoStatusOrdemTrabalhoDto.java
@@ -1,0 +1,21 @@
+package br.com.cloudport.servicoyard.patio.listatrabalho.dto;
+
+import br.com.cloudport.servicoyard.patio.listatrabalho.modelo.StatusOrdemTrabalhoPatio;
+import javax.validation.constraints.NotNull;
+
+public class AtualizacaoStatusOrdemTrabalhoDto {
+
+    @NotNull
+    private StatusOrdemTrabalhoPatio statusOrdem;
+
+    public AtualizacaoStatusOrdemTrabalhoDto() {
+    }
+
+    public StatusOrdemTrabalhoPatio getStatusOrdem() {
+        return statusOrdem;
+    }
+
+    public void setStatusOrdem(StatusOrdemTrabalhoPatio statusOrdem) {
+        this.statusOrdem = statusOrdem;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/dto/OrdemTrabalhoPatioRequisicaoDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/dto/OrdemTrabalhoPatioRequisicaoDto.java
@@ -1,0 +1,109 @@
+package br.com.cloudport.servicoyard.patio.listatrabalho.dto;
+
+import br.com.cloudport.servicoyard.comum.validacao.ValidacaoEntradaUtil;
+import br.com.cloudport.servicoyard.patio.modelo.StatusConteiner;
+import br.com.cloudport.servicoyard.patio.modelo.TipoMovimentoPatio;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class OrdemTrabalhoPatioRequisicaoDto {
+
+    @NotBlank
+    @Size(max = 30)
+    private String codigoConteiner;
+
+    @NotBlank
+    @Size(max = 40)
+    private String tipoCarga;
+
+    @NotBlank
+    @Size(max = 60)
+    private String destino;
+
+    @NotNull
+    @Min(0)
+    private Integer linhaDestino;
+
+    @NotNull
+    @Min(0)
+    private Integer colunaDestino;
+
+    @NotBlank
+    @Size(max = 40)
+    private String camadaDestino;
+
+    @NotNull
+    private TipoMovimentoPatio tipoMovimento;
+
+    @NotNull
+    private StatusConteiner statusConteinerDestino;
+
+    public OrdemTrabalhoPatioRequisicaoDto() {
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = ValidacaoEntradaUtil.limparTexto(codigoConteiner);
+    }
+
+    public String getTipoCarga() {
+        return tipoCarga;
+    }
+
+    public void setTipoCarga(String tipoCarga) {
+        this.tipoCarga = ValidacaoEntradaUtil.limparTexto(tipoCarga);
+    }
+
+    public String getDestino() {
+        return destino;
+    }
+
+    public void setDestino(String destino) {
+        this.destino = ValidacaoEntradaUtil.limparTexto(destino);
+    }
+
+    public Integer getLinhaDestino() {
+        return linhaDestino;
+    }
+
+    public void setLinhaDestino(Integer linhaDestino) {
+        this.linhaDestino = linhaDestino;
+    }
+
+    public Integer getColunaDestino() {
+        return colunaDestino;
+    }
+
+    public void setColunaDestino(Integer colunaDestino) {
+        this.colunaDestino = colunaDestino;
+    }
+
+    public String getCamadaDestino() {
+        return camadaDestino;
+    }
+
+    public void setCamadaDestino(String camadaDestino) {
+        this.camadaDestino = ValidacaoEntradaUtil.limparTexto(camadaDestino);
+    }
+
+    public TipoMovimentoPatio getTipoMovimento() {
+        return tipoMovimento;
+    }
+
+    public void setTipoMovimento(TipoMovimentoPatio tipoMovimento) {
+        this.tipoMovimento = tipoMovimento;
+    }
+
+    public StatusConteiner getStatusConteinerDestino() {
+        return statusConteinerDestino;
+    }
+
+    public void setStatusConteinerDestino(StatusConteiner statusConteinerDestino) {
+        this.statusConteinerDestino = statusConteinerDestino;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/dto/OrdemTrabalhoPatioRespostaDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/dto/OrdemTrabalhoPatioRespostaDto.java
@@ -1,0 +1,185 @@
+package br.com.cloudport.servicoyard.patio.listatrabalho.dto;
+
+import br.com.cloudport.servicoyard.patio.listatrabalho.modelo.OrdemTrabalhoPatio;
+import br.com.cloudport.servicoyard.patio.listatrabalho.modelo.StatusOrdemTrabalhoPatio;
+import br.com.cloudport.servicoyard.patio.modelo.StatusConteiner;
+import br.com.cloudport.servicoyard.patio.modelo.TipoMovimentoPatio;
+import java.time.LocalDateTime;
+import org.springframework.web.util.HtmlUtils;
+
+public class OrdemTrabalhoPatioRespostaDto {
+
+    private Long id;
+    private String codigoConteiner;
+    private String tipoCarga;
+    private String destino;
+    private Integer linhaDestino;
+    private Integer colunaDestino;
+    private String camadaDestino;
+    private TipoMovimentoPatio tipoMovimento;
+    private StatusOrdemTrabalhoPatio statusOrdem;
+    private StatusConteiner statusConteinerDestino;
+    private LocalDateTime criadoEm;
+    private LocalDateTime atualizadoEm;
+    private LocalDateTime concluidoEm;
+
+    public OrdemTrabalhoPatioRespostaDto() {
+    }
+
+    public OrdemTrabalhoPatioRespostaDto(Long id,
+                                         String codigoConteiner,
+                                         String tipoCarga,
+                                         String destino,
+                                         Integer linhaDestino,
+                                         Integer colunaDestino,
+                                         String camadaDestino,
+                                         TipoMovimentoPatio tipoMovimento,
+                                         StatusOrdemTrabalhoPatio statusOrdem,
+                                         StatusConteiner statusConteinerDestino,
+                                         LocalDateTime criadoEm,
+                                         LocalDateTime atualizadoEm,
+                                         LocalDateTime concluidoEm) {
+        this.id = id;
+        this.codigoConteiner = codigoConteiner;
+        this.tipoCarga = tipoCarga;
+        this.destino = destino;
+        this.linhaDestino = linhaDestino;
+        this.colunaDestino = colunaDestino;
+        this.camadaDestino = camadaDestino;
+        this.tipoMovimento = tipoMovimento;
+        this.statusOrdem = statusOrdem;
+        this.statusConteinerDestino = statusConteinerDestino;
+        this.criadoEm = criadoEm;
+        this.atualizadoEm = atualizadoEm;
+        this.concluidoEm = concluidoEm;
+    }
+
+    public static OrdemTrabalhoPatioRespostaDto deEntidade(OrdemTrabalhoPatio ordem) {
+        return new OrdemTrabalhoPatioRespostaDto(
+                ordem.getId(),
+                escapar(ordem.getCodigoConteiner()),
+                escapar(ordem.getTipoCarga()),
+                escapar(ordem.getDestino()),
+                ordem.getLinhaDestino(),
+                ordem.getColunaDestino(),
+                escapar(ordem.getCamadaDestino()),
+                ordem.getTipoMovimento(),
+                ordem.getStatusOrdem(),
+                ordem.getStatusConteinerDestino(),
+                ordem.getCriadoEm(),
+                ordem.getAtualizadoEm(),
+                ordem.getConcluidoEm()
+        );
+    }
+
+    private static String escapar(String valor) {
+        if (valor == null) {
+            return null;
+        }
+        return HtmlUtils.htmlEscape(valor, "UTF-8");
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public String getTipoCarga() {
+        return tipoCarga;
+    }
+
+    public void setTipoCarga(String tipoCarga) {
+        this.tipoCarga = tipoCarga;
+    }
+
+    public String getDestino() {
+        return destino;
+    }
+
+    public void setDestino(String destino) {
+        this.destino = destino;
+    }
+
+    public Integer getLinhaDestino() {
+        return linhaDestino;
+    }
+
+    public void setLinhaDestino(Integer linhaDestino) {
+        this.linhaDestino = linhaDestino;
+    }
+
+    public Integer getColunaDestino() {
+        return colunaDestino;
+    }
+
+    public void setColunaDestino(Integer colunaDestino) {
+        this.colunaDestino = colunaDestino;
+    }
+
+    public String getCamadaDestino() {
+        return camadaDestino;
+    }
+
+    public void setCamadaDestino(String camadaDestino) {
+        this.camadaDestino = camadaDestino;
+    }
+
+    public TipoMovimentoPatio getTipoMovimento() {
+        return tipoMovimento;
+    }
+
+    public void setTipoMovimento(TipoMovimentoPatio tipoMovimento) {
+        this.tipoMovimento = tipoMovimento;
+    }
+
+    public StatusOrdemTrabalhoPatio getStatusOrdem() {
+        return statusOrdem;
+    }
+
+    public void setStatusOrdem(StatusOrdemTrabalhoPatio statusOrdem) {
+        this.statusOrdem = statusOrdem;
+    }
+
+    public StatusConteiner getStatusConteinerDestino() {
+        return statusConteinerDestino;
+    }
+
+    public void setStatusConteinerDestino(StatusConteiner statusConteinerDestino) {
+        this.statusConteinerDestino = statusConteinerDestino;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public void setCriadoEm(LocalDateTime criadoEm) {
+        this.criadoEm = criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+
+    public void setAtualizadoEm(LocalDateTime atualizadoEm) {
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    public LocalDateTime getConcluidoEm() {
+        return concluidoEm;
+    }
+
+    public void setConcluidoEm(LocalDateTime concluidoEm) {
+        this.concluidoEm = concluidoEm;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/modelo/OrdemTrabalhoPatio.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/modelo/OrdemTrabalhoPatio.java
@@ -1,0 +1,206 @@
+package br.com.cloudport.servicoyard.patio.listatrabalho.modelo;
+
+import br.com.cloudport.servicoyard.patio.modelo.StatusConteiner;
+import br.com.cloudport.servicoyard.patio.modelo.TipoMovimentoPatio;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import br.com.cloudport.servicoyard.patio.modelo.ConteinerPatio;
+
+@Entity
+@Table(name = "ordem_trabalho_patio")
+public class OrdemTrabalhoPatio {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conteiner_id")
+    private ConteinerPatio conteiner;
+
+    @Column(name = "codigo_conteiner", nullable = false, length = 30)
+    private String codigoConteiner;
+
+    @Column(name = "tipo_carga", nullable = false, length = 40)
+    private String tipoCarga;
+
+    @Column(name = "destino", nullable = false, length = 60)
+    private String destino;
+
+    @Column(name = "linha_destino", nullable = false)
+    private Integer linhaDestino;
+
+    @Column(name = "coluna_destino", nullable = false)
+    private Integer colunaDestino;
+
+    @Column(name = "camada_destino", nullable = false, length = 40)
+    private String camadaDestino;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_movimento", nullable = false, length = 20)
+    private TipoMovimentoPatio tipoMovimento;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status_ordem", nullable = false, length = 20)
+    private StatusOrdemTrabalhoPatio statusOrdem;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status_conteiner_destino", nullable = false, length = 30)
+    private StatusConteiner statusConteinerDestino;
+
+    @Column(name = "criado_em", nullable = false)
+    private LocalDateTime criadoEm;
+
+    @Column(name = "atualizado_em", nullable = false)
+    private LocalDateTime atualizadoEm;
+
+    @Column(name = "concluido_em")
+    private LocalDateTime concluidoEm;
+
+    public OrdemTrabalhoPatio() {
+    }
+
+    public OrdemTrabalhoPatio(ConteinerPatio conteiner,
+                              String codigoConteiner,
+                              String tipoCarga,
+                              String destino,
+                              Integer linhaDestino,
+                              Integer colunaDestino,
+                              String camadaDestino,
+                              TipoMovimentoPatio tipoMovimento,
+                              StatusOrdemTrabalhoPatio statusOrdem,
+                              StatusConteiner statusConteinerDestino,
+                              LocalDateTime criadoEm,
+                              LocalDateTime atualizadoEm) {
+        this.conteiner = conteiner;
+        this.codigoConteiner = codigoConteiner;
+        this.tipoCarga = tipoCarga;
+        this.destino = destino;
+        this.linhaDestino = linhaDestino;
+        this.colunaDestino = colunaDestino;
+        this.camadaDestino = camadaDestino;
+        this.tipoMovimento = tipoMovimento;
+        this.statusOrdem = statusOrdem;
+        this.statusConteinerDestino = statusConteinerDestino;
+        this.criadoEm = criadoEm;
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public ConteinerPatio getConteiner() {
+        return conteiner;
+    }
+
+    public void setConteiner(ConteinerPatio conteiner) {
+        this.conteiner = conteiner;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public String getTipoCarga() {
+        return tipoCarga;
+    }
+
+    public void setTipoCarga(String tipoCarga) {
+        this.tipoCarga = tipoCarga;
+    }
+
+    public String getDestino() {
+        return destino;
+    }
+
+    public void setDestino(String destino) {
+        this.destino = destino;
+    }
+
+    public Integer getLinhaDestino() {
+        return linhaDestino;
+    }
+
+    public void setLinhaDestino(Integer linhaDestino) {
+        this.linhaDestino = linhaDestino;
+    }
+
+    public Integer getColunaDestino() {
+        return colunaDestino;
+    }
+
+    public void setColunaDestino(Integer colunaDestino) {
+        this.colunaDestino = colunaDestino;
+    }
+
+    public String getCamadaDestino() {
+        return camadaDestino;
+    }
+
+    public void setCamadaDestino(String camadaDestino) {
+        this.camadaDestino = camadaDestino;
+    }
+
+    public TipoMovimentoPatio getTipoMovimento() {
+        return tipoMovimento;
+    }
+
+    public void setTipoMovimento(TipoMovimentoPatio tipoMovimento) {
+        this.tipoMovimento = tipoMovimento;
+    }
+
+    public StatusOrdemTrabalhoPatio getStatusOrdem() {
+        return statusOrdem;
+    }
+
+    public void setStatusOrdem(StatusOrdemTrabalhoPatio statusOrdem) {
+        this.statusOrdem = statusOrdem;
+    }
+
+    public StatusConteiner getStatusConteinerDestino() {
+        return statusConteinerDestino;
+    }
+
+    public void setStatusConteinerDestino(StatusConteiner statusConteinerDestino) {
+        this.statusConteinerDestino = statusConteinerDestino;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public void setCriadoEm(LocalDateTime criadoEm) {
+        this.criadoEm = criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+
+    public void setAtualizadoEm(LocalDateTime atualizadoEm) {
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    public LocalDateTime getConcluidoEm() {
+        return concluidoEm;
+    }
+
+    public void setConcluidoEm(LocalDateTime concluidoEm) {
+        this.concluidoEm = concluidoEm;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/modelo/StatusOrdemTrabalhoPatio.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/modelo/StatusOrdemTrabalhoPatio.java
@@ -1,0 +1,7 @@
+package br.com.cloudport.servicoyard.patio.listatrabalho.modelo;
+
+public enum StatusOrdemTrabalhoPatio {
+    PENDENTE,
+    EM_EXECUCAO,
+    CONCLUIDA
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/repositorio/OrdemTrabalhoPatioRepositorio.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/repositorio/OrdemTrabalhoPatioRepositorio.java
@@ -1,0 +1,17 @@
+package br.com.cloudport.servicoyard.patio.listatrabalho.repositorio;
+
+import br.com.cloudport.servicoyard.patio.listatrabalho.modelo.OrdemTrabalhoPatio;
+import br.com.cloudport.servicoyard.patio.listatrabalho.modelo.StatusOrdemTrabalhoPatio;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrdemTrabalhoPatioRepositorio extends JpaRepository<OrdemTrabalhoPatio, Long> {
+
+    List<OrdemTrabalhoPatio> findByStatusOrdemInOrderByCriadoEmAsc(List<StatusOrdemTrabalhoPatio> status);
+
+    boolean existsByCodigoConteinerIgnoreCaseAndStatusOrdemIn(String codigoConteiner,
+                                                              List<StatusOrdemTrabalhoPatio> status);
+
+    Optional<OrdemTrabalhoPatio> findByIdAndStatusOrdemIn(Long id, List<StatusOrdemTrabalhoPatio> status);
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/servico/OrdemTrabalhoPatioServico.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/listatrabalho/servico/OrdemTrabalhoPatioServico.java
@@ -1,0 +1,169 @@
+package br.com.cloudport.servicoyard.patio.listatrabalho.servico;
+
+import br.com.cloudport.servicoyard.patio.dto.ConteinerPatioRequisicaoDto;
+import br.com.cloudport.servicoyard.patio.listatrabalho.dto.AtualizacaoStatusOrdemTrabalhoDto;
+import br.com.cloudport.servicoyard.patio.listatrabalho.dto.OrdemTrabalhoPatioRequisicaoDto;
+import br.com.cloudport.servicoyard.patio.listatrabalho.dto.OrdemTrabalhoPatioRespostaDto;
+import br.com.cloudport.servicoyard.patio.listatrabalho.modelo.OrdemTrabalhoPatio;
+import br.com.cloudport.servicoyard.patio.listatrabalho.modelo.StatusOrdemTrabalhoPatio;
+import br.com.cloudport.servicoyard.patio.listatrabalho.repositorio.OrdemTrabalhoPatioRepositorio;
+import br.com.cloudport.servicoyard.patio.modelo.ConteinerPatio;
+import br.com.cloudport.servicoyard.patio.modelo.StatusConteiner;
+import br.com.cloudport.servicoyard.patio.modelo.TipoMovimentoPatio;
+import br.com.cloudport.servicoyard.patio.repositorio.ConteinerPatioRepositorio;
+import br.com.cloudport.servicoyard.patio.servico.MapaPatioServico;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class OrdemTrabalhoPatioServico {
+
+    private final OrdemTrabalhoPatioRepositorio ordemRepositorio;
+    private final ConteinerPatioRepositorio conteinerRepositorio;
+    private final MapaPatioServico mapaPatioServico;
+
+    public OrdemTrabalhoPatioServico(OrdemTrabalhoPatioRepositorio ordemRepositorio,
+                                     ConteinerPatioRepositorio conteinerRepositorio,
+                                     MapaPatioServico mapaPatioServico) {
+        this.ordemRepositorio = ordemRepositorio;
+        this.conteinerRepositorio = conteinerRepositorio;
+        this.mapaPatioServico = mapaPatioServico;
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrdemTrabalhoPatioRespostaDto> listarOrdens(StatusOrdemTrabalhoPatio status) {
+        List<StatusOrdemTrabalhoPatio> filtros = status != null
+                ? List.of(status)
+                : new ArrayList<>(EnumSet.allOf(StatusOrdemTrabalhoPatio.class));
+        return ordemRepositorio.findByStatusOrdemInOrderByCriadoEmAsc(filtros).stream()
+                .map(OrdemTrabalhoPatioRespostaDto::deEntidade)
+                .toList();
+    }
+
+    @Transactional
+    public OrdemTrabalhoPatioRespostaDto registrarOrdem(OrdemTrabalhoPatioRequisicaoDto dto) {
+        validarCamposObrigatorios(dto);
+        String codigoNormalizado = dto.getCodigoConteiner().toUpperCase(Locale.ROOT);
+        List<StatusOrdemTrabalhoPatio> ativos = List.of(StatusOrdemTrabalhoPatio.PENDENTE,
+                StatusOrdemTrabalhoPatio.EM_EXECUCAO);
+        if (ordemRepositorio.existsByCodigoConteinerIgnoreCaseAndStatusOrdemIn(codigoNormalizado, ativos)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Já existe uma ordem pendente ou em execução para este contêiner.");
+        }
+        ConteinerPatio conteinerExistente = conteinerRepositorio.findByCodigoIgnoreCase(codigoNormalizado).orElse(null);
+        LocalDateTime agora = LocalDateTime.now();
+        OrdemTrabalhoPatio ordem = new OrdemTrabalhoPatio(
+                conteinerExistente,
+                codigoNormalizado,
+                dto.getTipoCarga().toUpperCase(Locale.ROOT),
+                dto.getDestino(),
+                dto.getLinhaDestino(),
+                dto.getColunaDestino(),
+                dto.getCamadaDestino(),
+                dto.getTipoMovimento(),
+                StatusOrdemTrabalhoPatio.PENDENTE,
+                dto.getStatusConteinerDestino(),
+                agora,
+                agora
+        );
+        OrdemTrabalhoPatio salvo = ordemRepositorio.save(ordem);
+        return OrdemTrabalhoPatioRespostaDto.deEntidade(salvo);
+    }
+
+    @Transactional
+    public OrdemTrabalhoPatioRespostaDto atualizarStatus(Long id, AtualizacaoStatusOrdemTrabalhoDto dto) {
+        StatusOrdemTrabalhoPatio novoStatus = Optional.ofNullable(dto.getStatusOrdem())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "O novo status deve ser informado."));
+        OrdemTrabalhoPatio ordem = ordemRepositorio.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Ordem de trabalho não encontrada."));
+        validarTransicaoStatus(ordem.getStatusOrdem(), novoStatus);
+        if (ordem.getStatusOrdem() == novoStatus) {
+            return OrdemTrabalhoPatioRespostaDto.deEntidade(ordem);
+        }
+        ordem.setStatusOrdem(novoStatus);
+        ordem.setAtualizadoEm(LocalDateTime.now());
+        if (novoStatus == StatusOrdemTrabalhoPatio.CONCLUIDA) {
+            ordem.setConcluidoEm(LocalDateTime.now());
+            aplicarAtualizacaoInventario(ordem);
+        }
+        OrdemTrabalhoPatio atualizado = ordemRepositorio.save(ordem);
+        return OrdemTrabalhoPatioRespostaDto.deEntidade(atualizado);
+    }
+
+    private void aplicarAtualizacaoInventario(OrdemTrabalhoPatio ordem) {
+        ConteinerPatioRequisicaoDto requisicao = new ConteinerPatioRequisicaoDto();
+        requisicao.setCodigo(ordem.getCodigoConteiner());
+        requisicao.setLinha(ordem.getLinhaDestino());
+        requisicao.setColuna(ordem.getColunaDestino());
+        requisicao.setStatus(ordem.getStatusConteinerDestino());
+        requisicao.setTipoCarga(ordem.getTipoCarga());
+        requisicao.setDestino(ordem.getDestino());
+        requisicao.setCamadaOperacional(ordem.getCamadaDestino());
+        mapaPatioServico.registrarOuAtualizarConteiner(requisicao);
+        conteinerRepositorio.findByCodigoIgnoreCase(ordem.getCodigoConteiner())
+                .ifPresent(ordem::setConteiner);
+    }
+
+    private void validarCamposObrigatorios(OrdemTrabalhoPatioRequisicaoDto dto) {
+        if (!StringUtils.hasText(dto.getCodigoConteiner())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "O código do contêiner é obrigatório.");
+        }
+        if (dto.getLinhaDestino() == null || dto.getLinhaDestino() < 0
+                || dto.getColunaDestino() == null || dto.getColunaDestino() < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "As coordenadas da posição de destino devem ser válidas.");
+        }
+        if (!StringUtils.hasText(dto.getDestino())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "O destino da carga é obrigatório.");
+        }
+        if (!StringUtils.hasText(dto.getTipoCarga())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "O tipo de carga é obrigatório.");
+        }
+        if (!StringUtils.hasText(dto.getCamadaDestino())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "A camada operacional é obrigatória.");
+        }
+        if (dto.getTipoMovimento() == TipoMovimentoPatio.REMOCAO) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "O tipo de movimento de remoção deve ser tratado pelo módulo de expedição.");
+        }
+        if (dto.getStatusConteinerDestino() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "O status final do contêiner é obrigatório e deve ser válido.");
+        }
+    }
+
+    private void validarTransicaoStatus(StatusOrdemTrabalhoPatio statusAtual,
+                                        StatusOrdemTrabalhoPatio novoStatus) {
+        if (statusAtual == novoStatus) {
+            return;
+        }
+        if (statusAtual == StatusOrdemTrabalhoPatio.PENDENTE
+                && (novoStatus == StatusOrdemTrabalhoPatio.EM_EXECUCAO
+                || novoStatus == StatusOrdemTrabalhoPatio.CONCLUIDA)) {
+            return;
+        }
+        if (statusAtual == StatusOrdemTrabalhoPatio.EM_EXECUCAO
+                && novoStatus == StatusOrdemTrabalhoPatio.CONCLUIDA) {
+            return;
+        }
+        throw new ResponseStatusException(HttpStatus.CONFLICT,
+                String.format(Locale.ROOT,
+                        "A transição de status de %s para %s não é permitida.",
+                        statusAtual, novoStatus));
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/repositorio/ConteinerPatioRepositorio.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/repositorio/ConteinerPatioRepositorio.java
@@ -9,5 +9,7 @@ public interface ConteinerPatioRepositorio extends JpaRepository<ConteinerPatio,
 
     Optional<ConteinerPatio> findByCodigo(String codigo);
 
+    Optional<ConteinerPatio> findByCodigoIgnoreCase(String codigo);
+
     List<ConteinerPatio> findAllByOrderByPosicaoLinhaAscPosicaoColunaAsc();
 }

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/servico/MapaPatioServico.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/patio/servico/MapaPatioServico.java
@@ -181,7 +181,11 @@ public class MapaPatioServico {
         List<String> statusEquipamento = Arrays.stream(StatusEquipamento.values())
                 .map(Enum::name)
                 .collect(Collectors.toList());
-        return new OpcoesCadastroPatioDto(statusConteiner, tiposEquipamento, statusEquipamento);
+        List<String> tiposMovimento = Arrays.stream(TipoMovimentoPatio.values())
+                .filter(tipo -> tipo != TipoMovimentoPatio.REMOCAO)
+                .map(Enum::name)
+                .collect(Collectors.toList());
+        return new OpcoesCadastroPatioDto(statusConteiner, tiposEquipamento, statusEquipamento, tiposMovimento);
     }
 
     @Transactional
@@ -303,7 +307,7 @@ public class MapaPatioServico {
             return conteinerPatioRepositorio.findById(requisicaoDto.getId())
                     .orElseThrow(() -> new IllegalArgumentException("Contêiner não encontrado."));
         }
-        Optional<ConteinerPatio> existente = conteinerPatioRepositorio.findByCodigo(requisicaoDto.getCodigo());
+        Optional<ConteinerPatio> existente = conteinerPatioRepositorio.findByCodigoIgnoreCase(requisicaoDto.getCodigo());
         return existente.orElseGet(ConteinerPatio::new);
     }
 

--- a/frontend/cloudport/src/app/componentes/navbar/TabService.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/TabService.ts
@@ -77,6 +77,11 @@ export const TAB_REGISTRY: Readonly<Record<string, TabItem>> = {
     label: 'Mapa do Pátio',
     route: ['patio', 'mapa']
   },
+  'patio/lista-trabalho': {
+    id: 'patio/lista-trabalho',
+    label: 'Lista de Trabalho do Pátio',
+    route: ['patio', 'lista-trabalho']
+  },
   'patio/posicoes': {
     id: 'patio/posicoes',
     label: 'Posições do Pátio',
@@ -86,11 +91,6 @@ export const TAB_REGISTRY: Readonly<Record<string, TabItem>> = {
     id: 'patio/movimentacoes',
     label: 'Movimentações do Pátio',
     route: ['patio', 'movimentacoes']
-  },
-  'patio/movimentacao': {
-    id: 'patio/movimentacao',
-    label: 'Registrar Movimentação',
-    route: ['patio', 'movimentacao']
   }
 };
 

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -24,7 +24,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
     'gate/operador/eventos'
   ];
   private readonly ferroviaTabIds = ['ferrovia/visitas'];
-  private readonly yardTabIds = ['patio/mapa', 'patio/posicoes', 'patio/movimentacoes', 'patio/movimentacao'];
+  private readonly yardTabIds = ['patio/lista-trabalho', 'patio/mapa', 'patio/posicoes', 'patio/movimentacoes'];
 
   private readonly tabRoles: Record<string, string[]> = {
     role: ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
@@ -39,10 +39,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
     'gate/operador/console': ['ROLE_ADMIN_PORTO', 'ROLE_OPERADOR_GATE', 'ROLE_PLANEJADOR'],
     'gate/operador/eventos': ['ROLE_ADMIN_PORTO', 'ROLE_OPERADOR_GATE', 'ROLE_PLANEJADOR'],
     'ferrovia/visitas': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
+    'patio/lista-trabalho': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR', 'ROLE_OPERADOR_PATIO'],
     'patio/mapa': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
     'patio/posicoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
-    'patio/movimentacoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR'],
-    'patio/movimentacao': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR']
+    'patio/movimentacoes': ['ROLE_ADMIN_PORTO', 'ROLE_PLANEJADOR']
   };
 
   constructor(

--- a/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.css
+++ b/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.css
@@ -1,99 +1,101 @@
-.formulario-movimentacao {
+.formulario-ordem {
   background: #ffffff;
-  border-radius: 8px;
-  padding: 16px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 10px rgba(18, 51, 84, 0.1);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1.25rem;
 }
 
-.formulario-movimentacao header {
+.formulario-ordem header {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
 }
 
-.formularios {
-  display: grid;
-  gap: 16px;
+.formulario-ordem header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #123354;
 }
 
-@media (min-width: 900px) {
-  .formularios {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+.formulario-ordem header p {
+  margin: 0;
+  color: #4a6077;
 }
 
 .bloco {
-  border: 1px solid #e0e0e0;
-  border-radius: 6px;
-  padding: 16px;
+  border: 1px solid #dde5ef;
+  border-radius: 8px;
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  background-color: #fdfdfd;
+  gap: 1rem;
+  background-color: #f8fbff;
 }
 
 .campo {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.35rem;
 }
 
 .campo input,
 .campo select {
-  padding: 8px;
-  border: 1px solid #cbd5e1;
-  border-radius: 4px;
+  padding: 0.65rem;
+  border: 1px solid #c0ccda;
+  border-radius: 6px;
   font-size: 0.95rem;
 }
 
 .duas-colunas {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
 }
 
 .acoes {
   display: flex;
-  gap: 12px;
+  gap: 0.75rem;
   flex-wrap: wrap;
 }
 
 .acoes button {
-  padding: 8px 16px;
+  padding: 0.65rem 1.2rem;
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
-  background-color: #2563eb;
+  font-weight: 600;
+  transition: background-color 0.2s ease;
+  background-color: #0b6efd;
   color: #ffffff;
 }
 
 .acoes button.secundario {
   background-color: #e2e8f0;
-  color: #1e293b;
+  color: #1f2b3a;
 }
 
 .acoes button:disabled {
-  background-color: #93c5fd;
+  background-color: #9bb8de;
   cursor: not-allowed;
 }
 
 .mensagem {
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   margin: 0;
 }
 
 .mensagem.sucesso {
-  color: #15803d;
+  color: #1e8449;
 }
 
 .mensagem.erro {
-  color: #b30021;
+  color: #c0392b;
 }
 
 .estado {
   font-size: 0.95rem;
-  color: #475569;
+  color: #4a6077;
 }

--- a/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.html
+++ b/frontend/cloudport/src/app/componentes/patio/formulario-movimentacao/formulario-movimentacao.component.html
@@ -1,105 +1,67 @@
-<section class="formulario-movimentacao">
+<section class="formulario-ordem">
   <header>
-    <h2>Registrar movimentações</h2>
-    <p>Atualize contêineres e equipamentos com segurança, garantindo dados consistentes.</p>
+    <h2>Planejar ordem de movimentação</h2>
+    <p>Cadastre ordens de trabalho para que os operadores executem as movimentações no pátio. A atualização do inventário ocorre somente após a confirmação da ordem.</p>
   </header>
 
-  <div class="estado" *ngIf="carregandoOpcoes">Carregando opções de cadastro...</div>
+  <div class="estado" *ngIf="carregandoOpcoes">Carregando dados de apoio...</div>
 
-  <div class="formularios">
-    <form [formGroup]="formularioConteiner" (ngSubmit)="submeterConteiner()" class="bloco">
-      <h3>Movimentar contêiner</h3>
+  <form [formGroup]="formularioOrdem" (ngSubmit)="submeterOrdem()" class="bloco">
+    <div class="duas-colunas">
       <div class="campo">
-        <label for="conteiner-id">Identificador interno</label>
-        <input id="conteiner-id" type="number" formControlName="id" placeholder="Informe para atualizar um registro existente" />
-      </div>
-      <div class="duas-colunas">
-        <div class="campo">
-          <label for="conteiner-codigo">Código do contêiner</label>
-          <input id="conteiner-codigo" type="text" formControlName="codigo" required />
-        </div>
-        <div class="campo">
-          <label for="conteiner-status">Status operacional</label>
-          <select id="conteiner-status" formControlName="status" required>
-            <option value="" disabled>Selecione</option>
-            <option *ngFor="let status of opcoes?.statusConteiner" [value]="status">{{ formatarRotulo(status) }}</option>
-          </select>
-        </div>
-      </div>
-      <div class="duas-colunas">
-        <div class="campo">
-          <label for="conteiner-linha">Linha</label>
-          <input id="conteiner-linha" type="number" formControlName="linha" min="0" required />
-        </div>
-        <div class="campo">
-          <label for="conteiner-coluna">Coluna</label>
-          <input id="conteiner-coluna" type="number" formControlName="coluna" min="0" required />
-        </div>
-      </div>
-      <div class="duas-colunas">
-        <div class="campo">
-          <label for="conteiner-tipo-carga">Tipo de carga</label>
-          <input id="conteiner-tipo-carga" type="text" formControlName="tipoCarga" required />
-        </div>
-        <div class="campo">
-          <label for="conteiner-destino">Destino</label>
-          <input id="conteiner-destino" type="text" formControlName="destino" required />
-        </div>
+        <label for="ordem-codigo">Código do contêiner</label>
+        <input id="ordem-codigo" type="text" formControlName="codigo" required />
       </div>
       <div class="campo">
-        <label for="conteiner-camada">Camada operacional</label>
-        <input id="conteiner-camada" type="text" formControlName="camadaOperacional" required />
-      </div>
-      <div class="acoes">
-        <button type="submit" [disabled]="salvandoConteiner">Salvar contêiner</button>
-        <button type="button" class="secundario" (click)="limparFormularioConteiner()">Limpar campos</button>
-      </div>
-      <p class="mensagem sucesso" *ngIf="sucessoConteiner">{{ sucessoConteiner }}</p>
-      <p class="mensagem erro" *ngIf="erroConteiner">{{ erroConteiner }}</p>
-    </form>
-
-    <form [formGroup]="formularioEquipamento" (ngSubmit)="submeterEquipamento()" class="bloco">
-      <h3>Atualizar equipamento</h3>
-      <div class="campo">
-        <label for="equipamento-id">Identificador interno</label>
-        <input id="equipamento-id" type="number" formControlName="id" placeholder="Informe para atualizar um registro existente" />
-      </div>
-      <div class="duas-colunas">
-        <div class="campo">
-          <label for="equipamento-identificador">Identificador</label>
-          <input id="equipamento-identificador" type="text" formControlName="identificador" required />
-        </div>
-        <div class="campo">
-          <label for="equipamento-tipo">Tipo</label>
-          <select id="equipamento-tipo" formControlName="tipoEquipamento" required>
-            <option value="" disabled>Selecione</option>
-            <option *ngFor="let tipo of opcoes?.tiposEquipamento" [value]="tipo">{{ formatarRotulo(tipo) }}</option>
-          </select>
-        </div>
-      </div>
-      <div class="duas-colunas">
-        <div class="campo">
-          <label for="equipamento-linha">Linha</label>
-          <input id="equipamento-linha" type="number" formControlName="linha" min="0" required />
-        </div>
-        <div class="campo">
-          <label for="equipamento-coluna">Coluna</label>
-          <input id="equipamento-coluna" type="number" formControlName="coluna" min="0" required />
-        </div>
-      </div>
-      <div class="campo">
-        <label for="equipamento-status">Status operacional</label>
-        <select id="equipamento-status" formControlName="statusOperacional" required>
+        <label for="ordem-tipo-movimento">Tipo de movimento</label>
+        <select id="ordem-tipo-movimento" formControlName="tipoMovimento" required>
           <option value="" disabled>Selecione</option>
-          <option *ngFor="let status of opcoes?.statusEquipamento" [value]="status">{{ formatarRotulo(status) }}</option>
+          <option *ngFor="let tipo of opcoes?.tiposMovimento" [value]="tipo">{{ formatarRotulo(tipo) }}</option>
         </select>
       </div>
-      <div class="acoes">
-        <button type="submit" [disabled]="salvandoEquipamento">Salvar equipamento</button>
-        <button type="button" class="secundario" (click)="limparFormularioEquipamento()">Limpar campos</button>
+    </div>
+
+    <div class="duas-colunas">
+      <div class="campo">
+        <label for="ordem-tipo-carga">Tipo de carga</label>
+        <input id="ordem-tipo-carga" type="text" formControlName="tipoCarga" required />
       </div>
-      <p class="mensagem sucesso" *ngIf="sucessoEquipamento">{{ sucessoEquipamento }}</p>
-      <p class="mensagem erro" *ngIf="erroEquipamento">{{ erroEquipamento }}</p>
-    </form>
-  </div>
+      <div class="campo">
+        <label for="ordem-status-destino">Status após conclusão</label>
+        <select id="ordem-status-destino" formControlName="statusConteinerDestino" required>
+          <option value="" disabled>Selecione</option>
+          <option *ngFor="let status of opcoes?.statusConteiner" [value]="status">{{ formatarRotulo(status) }}</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="duas-colunas">
+      <div class="campo">
+        <label for="ordem-destino">Destino</label>
+        <input id="ordem-destino" type="text" formControlName="destino" required />
+      </div>
+      <div class="campo">
+        <label for="ordem-camada">Camada operacional</label>
+        <input id="ordem-camada" type="text" formControlName="camadaDestino" required />
+      </div>
+    </div>
+
+    <div class="duas-colunas">
+      <div class="campo">
+        <label for="ordem-linha">Linha</label>
+        <input id="ordem-linha" type="number" formControlName="linhaDestino" min="0" required />
+      </div>
+      <div class="campo">
+        <label for="ordem-coluna">Coluna</label>
+        <input id="ordem-coluna" type="number" formControlName="colunaDestino" min="0" required />
+      </div>
+    </div>
+
+    <div class="acoes">
+      <button type="submit" [disabled]="salvandoOrdem">Registrar ordem</button>
+      <button type="button" class="secundario" (click)="limparFormularioOrdem()">Limpar campos</button>
+    </div>
+    <p class="mensagem sucesso" *ngIf="sucessoOrdem">{{ sucessoOrdem }}</p>
+    <p class="mensagem erro" *ngIf="erroOrdem">{{ erroOrdem }}</p>
+  </form>
 </section>

--- a/frontend/cloudport/src/app/componentes/patio/lista-trabalho-patio/lista-trabalho-patio.component.css
+++ b/frontend/cloudport/src/app/componentes/patio/lista-trabalho-patio/lista-trabalho-patio.component.css
@@ -1,0 +1,186 @@
+.lista-trabalho-patio {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+}
+
+.cabecalho {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cabecalho h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  color: #123354;
+}
+
+.cabecalho p {
+  margin: 0.25rem 0 0 0;
+  color: #48617a;
+}
+
+.acoes {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.rotulo-filtro {
+  font-size: 0.85rem;
+  color: #48617a;
+}
+
+select {
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #c7d1dc;
+  font-size: 0.95rem;
+}
+
+button {
+  padding: 0.55rem 1rem;
+  border: none;
+  border-radius: 6px;
+  background-color: #0b6efd;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background-color 0.2s ease;
+}
+
+button:disabled {
+  background-color: #a7b9d0;
+  cursor: not-allowed;
+}
+
+.estado {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #48617a;
+}
+
+.estado.erro {
+  color: #c0392b;
+}
+
+.estado.sucesso {
+  color: #1e8449;
+}
+
+.estado.pequeno {
+  font-size: 0.85rem;
+}
+
+.cartoes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.cartao {
+  padding: 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background-color: #f8fbff;
+}
+
+.cartao-cabecalho {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cartao-cabecalho h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #123354;
+}
+
+.status {
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.status.pendente {
+  background-color: #f1c40f;
+}
+
+.status.execucao {
+  background-color: #2980b9;
+}
+
+.status.concluida {
+  background-color: #27ae60;
+}
+
+.detalhes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.detalhes div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.detalhes dt {
+  font-size: 0.85rem;
+  color: #48617a;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detalhes dd {
+  margin: 0;
+  font-weight: 600;
+  color: #123354;
+}
+
+.acoes-cartao {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.botao {
+  padding: 0.55rem 1rem;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.botao-primario {
+  background-color: #0b6efd;
+  color: #ffffff;
+}
+
+.botao-primario:disabled {
+  background-color: #a7b9d0;
+}
+
+.botao-sucesso {
+  background-color: #27ae60;
+  color: #ffffff;
+}
+
+.botao-sucesso:disabled {
+  background-color: #a9d5b8;
+}

--- a/frontend/cloudport/src/app/componentes/patio/lista-trabalho-patio/lista-trabalho-patio.component.html
+++ b/frontend/cloudport/src/app/componentes/patio/lista-trabalho-patio/lista-trabalho-patio.component.html
@@ -1,0 +1,72 @@
+<section class="lista-trabalho-patio" aria-live="polite">
+  <header class="cabecalho">
+    <div>
+      <h1>Lista de Trabalho do Pátio</h1>
+      <p>O operador consulta as tarefas pendentes e confirma as movimentações assim que concluir a execução física.</p>
+    </div>
+    <div class="acoes">
+      <label for="filtro-status" class="rotulo-filtro">Filtrar por status</label>
+      <select id="filtro-status" [value]="filtroStatus ?? ''" (change)="alterarFiltro($event)">
+        <option value="">Todos</option>
+        <option value="PENDENTE">Pendentes</option>
+        <option value="EM_EXECUCAO">Em execução</option>
+        <option value="CONCLUIDA">Concluídas</option>
+      </select>
+      <button type="button" (click)="carregarOrdens(filtroStatus)" [disabled]="carregando">Atualizar lista</button>
+    </div>
+  </header>
+
+  <p class="estado" *ngIf="carregando">Carregando ordens do pátio...</p>
+  <p class="estado erro" *ngIf="mensagemErro">{{ sanitizar(mensagemErro) }}</p>
+  <p class="estado sucesso" *ngIf="mensagemSucesso">{{ sanitizar(mensagemSucesso) }}</p>
+
+  <section class="cartoes" *ngIf="!carregando && ordens.length">
+    <article class="cartao" *ngFor="let ordem of ordens">
+      <header class="cartao-cabecalho">
+        <h2>Contêiner {{ sanitizar(ordem.codigoConteiner) }}</h2>
+        <span class="status" [ngClass]="{
+            'pendente': ordem.statusOrdem === 'PENDENTE',
+            'execucao': ordem.statusOrdem === 'EM_EXECUCAO',
+            'concluida': ordem.statusOrdem === 'CONCLUIDA'
+          }">{{ descricaoStatus(ordem.statusOrdem) }}</span>
+      </header>
+      <dl class="detalhes">
+        <div>
+          <dt>Movimento</dt>
+          <dd>{{ descricaoMovimento(ordem.tipoMovimento) }}</dd>
+        </div>
+        <div>
+          <dt>Destino operacional</dt>
+          <dd>Linha {{ ordem.linhaDestino }}, Coluna {{ ordem.colunaDestino }}, Camada {{ sanitizar(ordem.camadaDestino) }}</dd>
+        </div>
+        <div>
+          <dt>Status após conclusão</dt>
+          <dd>{{ sanitizar(ordem.statusConteinerDestino) }}</dd>
+        </div>
+        <div>
+          <dt>Última atualização</dt>
+          <dd>{{ ordem.atualizadoEm | date:'dd/MM/yyyy HH:mm' }}</dd>
+        </div>
+      </dl>
+      <footer class="acoes-cartao">
+        <button type="button"
+                class="botao botao-primario"
+                (click)="iniciarOrdem(ordem)"
+                [disabled]="!podeIniciar(ordem) || estaAtualizando(ordem)">
+          Assumir tarefa
+        </button>
+        <button type="button"
+                class="botao botao-sucesso"
+                (click)="concluirOrdem(ordem)"
+                [disabled]="!podeConcluir(ordem) || estaAtualizando(ordem)">
+          Marcar como concluída
+        </button>
+      </footer>
+      <p class="estado pequeno" *ngIf="estaAtualizando(ordem)">Atualizando ordem...</p>
+    </article>
+  </section>
+
+  <p class="estado" *ngIf="!carregando && !ordens.length && !mensagemErro">
+    Nenhuma ordem foi encontrada para os filtros selecionados.
+  </p>
+</section>

--- a/frontend/cloudport/src/app/componentes/patio/lista-trabalho-patio/lista-trabalho-patio.component.ts
+++ b/frontend/cloudport/src/app/componentes/patio/lista-trabalho-patio/lista-trabalho-patio.component.ts
@@ -1,0 +1,131 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import {
+  OrdemTrabalhoPatio,
+  ServicoListaTrabalhoPatioService,
+  StatusOrdemTrabalhoPatio
+} from '../../service/servico-lista-trabalho-patio/servico-lista-trabalho-patio.service';
+import { SanitizadorConteudoService } from '../../service/sanitizacao/sanitizador-conteudo.service';
+
+@Component({
+  selector: 'app-lista-trabalho-patio',
+  templateUrl: './lista-trabalho-patio.component.html',
+  styleUrls: ['./lista-trabalho-patio.component.css']
+})
+export class ListaTrabalhoPatioComponent implements OnInit, OnDestroy {
+  ordens: OrdemTrabalhoPatio[] = [];
+  carregando = false;
+  mensagemErro?: string;
+  mensagemSucesso?: string;
+  ordensEmAtualizacao = new Set<number>();
+  filtroStatus?: StatusOrdemTrabalhoPatio;
+  private inscricao?: Subscription;
+
+  constructor(
+    private readonly servicoListaTrabalho: ServicoListaTrabalhoPatioService,
+    private readonly sanitizador: SanitizadorConteudoService
+  ) {}
+
+  ngOnInit(): void {
+    this.carregarOrdens();
+  }
+
+  ngOnDestroy(): void {
+    this.inscricao?.unsubscribe();
+  }
+
+  carregarOrdens(status?: StatusOrdemTrabalhoPatio): void {
+    this.filtroStatus = status;
+    this.carregando = true;
+    this.mensagemErro = undefined;
+    this.mensagemSucesso = undefined;
+    this.inscricao?.unsubscribe();
+    this.inscricao = this.servicoListaTrabalho.listarOrdens(status)
+      .pipe(finalize(() => (this.carregando = false)))
+      .subscribe({
+        next: (ordens) => {
+          this.ordens = ordens;
+        },
+        error: () => {
+          this.mensagemErro = 'Não foi possível carregar a lista de trabalho do pátio.';
+          this.ordens = [];
+        }
+      });
+  }
+
+  alterarFiltro(evento: Event): void {
+    const alvo = evento.target as HTMLSelectElement;
+    const valor = (alvo?.value ?? '').trim();
+    const novoStatus = valor === '' ? undefined : (valor as StatusOrdemTrabalhoPatio);
+    this.carregarOrdens(novoStatus);
+  }
+
+  iniciarOrdem(ordem: OrdemTrabalhoPatio): void {
+    if (!this.podeIniciar(ordem)) {
+      return;
+    }
+    this.atualizarStatus(ordem, 'EM_EXECUCAO');
+  }
+
+  concluirOrdem(ordem: OrdemTrabalhoPatio): void {
+    if (!this.podeConcluir(ordem)) {
+      return;
+    }
+    this.atualizarStatus(ordem, 'CONCLUIDA');
+  }
+
+  podeIniciar(ordem: OrdemTrabalhoPatio): boolean {
+    return ordem.statusOrdem === 'PENDENTE';
+  }
+
+  podeConcluir(ordem: OrdemTrabalhoPatio): boolean {
+    return ordem.statusOrdem === 'EM_EXECUCAO';
+  }
+
+  estaAtualizando(ordem: OrdemTrabalhoPatio): boolean {
+    return this.ordensEmAtualizacao.has(ordem.id);
+  }
+
+  descricaoStatus(status: StatusOrdemTrabalhoPatio): string {
+    switch (status) {
+      case 'PENDENTE':
+        return 'Pendente';
+      case 'EM_EXECUCAO':
+        return 'Em execução';
+      case 'CONCLUIDA':
+        return 'Concluída';
+      default:
+        return status;
+    }
+  }
+
+  descricaoMovimento(tipo: string): string {
+    const texto = tipo.replace(/_/g, ' ').toLowerCase();
+    return texto.charAt(0).toUpperCase() + texto.slice(1);
+  }
+
+  sanitizar(valor?: string): string {
+    return this.sanitizador.sanitizar(valor ?? '');
+  }
+
+  private atualizarStatus(ordem: OrdemTrabalhoPatio, novoStatus: StatusOrdemTrabalhoPatio): void {
+    this.ordensEmAtualizacao.add(ordem.id);
+    this.mensagemErro = undefined;
+    this.mensagemSucesso = undefined;
+    this.servicoListaTrabalho.atualizarStatus(ordem.id, novoStatus)
+      .pipe(finalize(() => this.ordensEmAtualizacao.delete(ordem.id)))
+      .subscribe({
+        next: (atualizada) => {
+          const indice = this.ordens.findIndex((item) => item.id === atualizada.id);
+          if (indice >= 0) {
+            this.ordens[indice] = atualizada;
+          }
+          this.mensagemSucesso = `Ordem do contêiner ${this.sanitizar(atualizada.codigoConteiner)} atualizada com sucesso.`;
+        },
+        error: () => {
+          this.mensagemErro = 'Não foi possível atualizar o status da ordem.';
+        }
+      });
+  }
+}

--- a/frontend/cloudport/src/app/componentes/patio/patio-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/patio/patio-routing.module.ts
@@ -4,8 +4,13 @@ import { MapaPatioComponent } from './mapa-patio/mapa-patio.component';
 import { ListaPosicoesComponent } from './lista-posicoes/lista-posicoes.component';
 import { ListaMovimentacoesComponent } from './lista-movimentacoes/lista-movimentacoes.component';
 import { FormularioMovimentacaoComponent } from './formulario-movimentacao/formulario-movimentacao.component';
+import { ListaTrabalhoPatioComponent } from './lista-trabalho-patio/lista-trabalho-patio.component';
 
 const routes: Routes = [
+  {
+    path: 'lista-trabalho',
+    component: ListaTrabalhoPatioComponent
+  },
   {
     path: 'mapa',
     component: MapaPatioComponent
@@ -25,7 +30,7 @@ const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
-    redirectTo: 'mapa'
+    redirectTo: 'lista-trabalho'
   }
 ];
 

--- a/frontend/cloudport/src/app/componentes/patio/patio.module.ts
+++ b/frontend/cloudport/src/app/componentes/patio/patio.module.ts
@@ -5,6 +5,7 @@ import { MapaPatioComponent } from './mapa-patio/mapa-patio.component';
 import { ListaPosicoesComponent } from './lista-posicoes/lista-posicoes.component';
 import { ListaMovimentacoesComponent } from './lista-movimentacoes/lista-movimentacoes.component';
 import { FormularioMovimentacaoComponent } from './formulario-movimentacao/formulario-movimentacao.component';
+import { ListaTrabalhoPatioComponent } from './lista-trabalho-patio/lista-trabalho-patio.component';
 import { PatioRoutingModule } from './patio-routing.module';
 
 @NgModule({
@@ -12,7 +13,8 @@ import { PatioRoutingModule } from './patio-routing.module';
     MapaPatioComponent,
     ListaPosicoesComponent,
     ListaMovimentacoesComponent,
-    FormularioMovimentacaoComponent
+    FormularioMovimentacaoComponent,
+    ListaTrabalhoPatioComponent
   ],
   imports: [CommonModule, ReactiveFormsModule, PatioRoutingModule]
 })

--- a/frontend/cloudport/src/app/componentes/service/servico-lista-trabalho-patio/servico-lista-trabalho-patio.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-lista-trabalho-patio/servico-lista-trabalho-patio.service.ts
@@ -1,0 +1,74 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfiguracaoAplicacaoService } from '../../../configuracao/configuracao-aplicacao.service';
+
+export type StatusOrdemTrabalhoPatio = 'PENDENTE' | 'EM_EXECUCAO' | 'CONCLUIDA';
+export type TipoMovimentoPatio = 'ALOCACAO' | 'ATUALIZACAO' | 'REMOCAO';
+
+export interface OrdemTrabalhoPatio {
+  id: number;
+  codigoConteiner: string;
+  tipoCarga: string;
+  destino: string;
+  linhaDestino: number;
+  colunaDestino: number;
+  camadaDestino: string;
+  tipoMovimento: TipoMovimentoPatio;
+  statusOrdem: StatusOrdemTrabalhoPatio;
+  statusConteinerDestino: string;
+  criadoEm: string;
+  atualizadoEm: string;
+  concluidoEm?: string;
+}
+
+export interface NovaOrdemTrabalhoPatio {
+  codigoConteiner: string;
+  tipoCarga: string;
+  destino: string;
+  linhaDestino: number;
+  colunaDestino: number;
+  camadaDestino: string;
+  tipoMovimento: TipoMovimentoPatio;
+  statusConteinerDestino: string;
+}
+
+export interface AtualizacaoStatusOrdemTrabalhoPatio {
+  statusOrdem: StatusOrdemTrabalhoPatio;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ServicoListaTrabalhoPatioService {
+  private static readonly CAMINHO_BASE = '/yard/patio/ordens';
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly configuracaoAplicacao: ConfiguracaoAplicacaoService
+  ) {}
+
+  listarOrdens(status?: StatusOrdemTrabalhoPatio): Observable<OrdemTrabalhoPatio[]> {
+    const params = this.criarParametros(status);
+    return this.http.get<OrdemTrabalhoPatio[]>(this.construirUrl(''), { params });
+  }
+
+  registrarOrdem(payload: NovaOrdemTrabalhoPatio): Observable<OrdemTrabalhoPatio> {
+    return this.http.post<OrdemTrabalhoPatio>(this.construirUrl(''), payload);
+  }
+
+  atualizarStatus(id: number, status: StatusOrdemTrabalhoPatio): Observable<OrdemTrabalhoPatio> {
+    const corpo: AtualizacaoStatusOrdemTrabalhoPatio = { statusOrdem: status };
+    return this.http.patch<OrdemTrabalhoPatio>(this.construirUrl(`/${encodeURIComponent(id)}/status`), corpo);
+  }
+
+  private construirUrl(caminho: string): string {
+    return this.configuracaoAplicacao.construirUrlApi(`${ServicoListaTrabalhoPatioService.CAMINHO_BASE}${caminho}`);
+  }
+
+  private criarParametros(status?: StatusOrdemTrabalhoPatio): HttpParams {
+    let params = new HttpParams();
+    if (status) {
+      params = params.set('status', status);
+    }
+    return params;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/service/servico-patio/servico-patio.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-patio/servico-patio.service.ts
@@ -50,6 +50,7 @@ export interface OpcoesCadastroPatio {
   statusConteiner: string[];
   tiposEquipamento: string[];
   statusEquipamento: string[];
+  tiposMovimento: string[];
 }
 
 export interface MapaPatioResposta {


### PR DESCRIPTION
## Resumo
- cria o módulo de lista de trabalho do pátio no backend, incluindo entidade, serviço, repositório e controlador REST para gerar e atualizar ordens
- amplia o endpoint de opções do pátio e ajusta repositórios para consultas case insensitive, mantendo a sanitização de dados
- adiciona nova experiência no frontend com serviço real de ordens, componente de lista de trabalho, ajustes de rotas/menus e reformulação do formulário para planejar ordens

## Testes
- npm run lint *(falhou: script "lint" não definido no projeto Angular)*
- ./mvnw -q test *(falhou: Maven Wrapper indisponível no módulo servico-yard)*

------
https://chatgpt.com/codex/tasks/task_e_68f6f672397c8327be85f13bd6da466f