### PR TITLE
Implementa visão hierárquica de contêineres por vagão na visita do trem

### DIFF
--- a/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/dto/OperacaoConteinerVisitaRequisicaoDto.java
+++ b/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/dto/OperacaoConteinerVisitaRequisicaoDto.java
@@ -1,5 +1,6 @@
 package br.com.cloudport.servicorail.ferrovia.dto;
 
+import br.com.cloudport.servicorail.comum.validacao.ValidacaoEntradaUtil;
 import br.com.cloudport.servicorail.ferrovia.modelo.StatusOperacaoConteinerVisita;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -10,6 +11,9 @@ public class OperacaoConteinerVisitaRequisicaoDto {
     @Size(max = 20)
     private String codigoConteiner;
 
+    @Size(max = 35)
+    private String identificadorVagao;
+
     private StatusOperacaoConteinerVisita statusOperacao = StatusOperacaoConteinerVisita.PENDENTE;
 
     public String getCodigoConteiner() {
@@ -18,6 +22,14 @@ public class OperacaoConteinerVisitaRequisicaoDto {
 
     public void setCodigoConteiner(String codigoConteiner) {
         this.codigoConteiner = codigoConteiner;
+    }
+
+    public String getIdentificadorVagao() {
+        return identificadorVagao;
+    }
+
+    public void setIdentificadorVagao(String identificadorVagao) {
+        this.identificadorVagao = ValidacaoEntradaUtil.limparTexto(identificadorVagao);
     }
 
     public StatusOperacaoConteinerVisita getStatusOperacao() {

--- a/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/dto/OperacaoConteinerVisitaRespostaDto.java
+++ b/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/dto/OperacaoConteinerVisitaRespostaDto.java
@@ -8,17 +8,21 @@ public class OperacaoConteinerVisitaRespostaDto {
 
     private final String codigoConteiner;
     private final StatusOperacaoConteinerVisita statusOperacao;
+    private final String identificadorVagao;
 
     public OperacaoConteinerVisitaRespostaDto(String codigoConteiner,
-                                              StatusOperacaoConteinerVisita statusOperacao) {
+                                              StatusOperacaoConteinerVisita statusOperacao,
+                                              String identificadorVagao) {
         this.codigoConteiner = codigoConteiner;
         this.statusOperacao = statusOperacao;
+        this.identificadorVagao = identificadorVagao;
     }
 
     public static OperacaoConteinerVisitaRespostaDto deEmbeddable(OperacaoConteinerVisita operacao) {
         return new OperacaoConteinerVisitaRespostaDto(
                 HtmlUtils.htmlEscape(operacao.getCodigoConteiner()),
-                operacao.getStatusOperacao()
+                operacao.getStatusOperacao(),
+                HtmlUtils.htmlEscape(operacao.getIdentificadorVagao())
         );
     }
 
@@ -28,5 +32,9 @@ public class OperacaoConteinerVisitaRespostaDto {
 
     public StatusOperacaoConteinerVisita getStatusOperacao() {
         return statusOperacao;
+    }
+
+    public String getIdentificadorVagao() {
+        return identificadorVagao;
     }
 }

--- a/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/modelo/OperacaoConteinerVisita.java
+++ b/backend/servico-rail/src/main/java/br/com/cloudport/servicorail/ferrovia/modelo/OperacaoConteinerVisita.java
@@ -16,12 +16,18 @@ public class OperacaoConteinerVisita {
     @Column(name = "status_operacao", nullable = false, length = 20)
     private StatusOperacaoConteinerVisita statusOperacao = StatusOperacaoConteinerVisita.PENDENTE;
 
+    @Column(name = "identificador_vagao", nullable = true, length = 35)
+    private String identificadorVagao;
+
     public OperacaoConteinerVisita() {
     }
 
-    public OperacaoConteinerVisita(String codigoConteiner, StatusOperacaoConteinerVisita statusOperacao) {
+    public OperacaoConteinerVisita(String codigoConteiner,
+                                  StatusOperacaoConteinerVisita statusOperacao,
+                                  String identificadorVagao) {
         this.codigoConteiner = codigoConteiner;
         this.statusOperacao = statusOperacao;
+        this.identificadorVagao = identificadorVagao;
     }
 
     public String getCodigoConteiner() {
@@ -40,6 +46,14 @@ public class OperacaoConteinerVisita {
         this.statusOperacao = statusOperacao;
     }
 
+    public String getIdentificadorVagao() {
+        return identificadorVagao;
+    }
+
+    public void setIdentificadorVagao(String identificadorVagao) {
+        this.identificadorVagao = identificadorVagao;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -50,11 +64,12 @@ public class OperacaoConteinerVisita {
         }
         OperacaoConteinerVisita that = (OperacaoConteinerVisita) o;
         return Objects.equals(codigoConteiner, that.codigoConteiner)
-                && statusOperacao == that.statusOperacao;
+                && statusOperacao == that.statusOperacao
+                && Objects.equals(identificadorVagao, that.identificadorVagao);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(codigoConteiner, statusOperacao);
+        return Objects.hash(codigoConteiner, statusOperacao, identificadorVagao);
     }
 }

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.css
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.css
@@ -112,70 +112,97 @@
   color: #1d1d1d;
 }
 
-.abas-operacoes {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
 
-.abas-operacoes button {
-  padding: 8px 16px;
-  border: 1px solid #d0d0d0;
-  border-radius: 20px;
-  background-color: #f5f5f5;
-  color: #333;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.abas-operacoes button.ativa {
-  background-color: #005f9e;
-  color: #fff;
-  border-color: #005f9e;
-}
-
-.abas-operacoes button:not(.ativa):hover,
-.abas-operacoes button:not(.ativa):focus {
-  background-color: #e0e0e0;
-}
-
-.lista-operacoes {
+.arvore-vagoes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
-.linha-operacao {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
+.nodo-vagao {
   border: 1px solid #e3e3e3;
   border-radius: 6px;
   background-color: #fafafa;
-  gap: 16px;
-  flex-wrap: wrap;
-}
-
-.informacoes-conteiner {
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 12px;
 }
 
-.informacoes-conteiner .identificador {
+.cabecalho-vagao {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  font-weight: 600;
+  color: #1d1d1d;
+}
+
+.cabecalho-vagao .posicao-vagao,
+.cabecalho-vagao .tipo-vagao {
+  font-weight: 500;
+  color: #424242;
+}
+
+.lista-conteineres {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nodo-conteiner {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background-color: #ffffff;
+  padding: 12px 14px;
+}
+
+.linha-conteiner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.linha-conteiner .identificador {
   font-weight: 600;
   color: #222;
 }
 
-.informacoes-conteiner .status {
+.linha-conteiner .tipo-movimentacao {
+  font-size: 0.95rem;
+  color: #555;
+}
+
+.linha-conteiner .status {
   font-size: 0.95rem;
   font-weight: 500;
   color: #9c6b00;
 }
 
-.informacoes-conteiner .status.concluido {
+.linha-conteiner .status.concluido {
   color: #117a00;
+}
+
+.secao-nao-alocados {
+  border-top: 1px solid #dcdcdc;
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.secao-nao-alocados h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #1d1d1d;
 }
 
 .botao-status {

--- a/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.html
+++ b/frontend/cloudport/src/app/componentes/ferrovia/componentes/detalhe-visita-trem/detalhe-visita-trem.component.html
@@ -43,42 +43,64 @@
   </article>
 
   <section *ngIf="!estaCarregando && !erroCarregamento && visita" class="painel-operacoes">
-    <h2>Planejamento de Contêineres</h2>
-    <nav class="abas-operacoes" aria-label="Seleção de operações">
-      <button type="button"
-              [class.ativa]="abaAtiva === 'DESCARGA'"
-              (click)="selecionarAba('DESCARGA')">
-        Para Descarregar ({{ obterItensAba('DESCARGA').length }})
-      </button>
-      <button type="button"
-              [class.ativa]="abaAtiva === 'CARGA'"
-              (click)="selecionarAba('CARGA')">
-        Para Carregar ({{ obterItensAba('CARGA').length }})
-      </button>
-    </nav>
+    <h2>Planejamento de Contêineres por Vagão</h2>
 
     <div *ngIf="mensagemOperacao" class="estado-sucesso">{{ textoSeguro(mensagemOperacao) }}</div>
     <div *ngIf="erroOperacao" class="estado-erro">{{ textoSeguro(erroOperacao) }}</div>
 
-    <section class="lista-operacoes" *ngIf="obterItensAba(abaAtiva).length > 0; else semItens">
-      <article class="linha-operacao" *ngFor="let item of obterItensAba(abaAtiva)">
-        <div class="informacoes-conteiner">
-          <span class="identificador">Contêiner: {{ textoSeguro(item.codigoConteiner) }}</span>
-          <span class="status" [class.concluido]="estaConcluido(item.statusOperacao)">
-            {{ textoSeguro(descricaoStatus(item.statusOperacao)) }}
-          </span>
-        </div>
-        <button type="button"
-                class="botao-status"
-                [disabled]="estaConcluido(item.statusOperacao) || operacaoEmAndamento"
-                (click)="marcarComoConcluido(abaAtiva, item.codigoConteiner)">
-          Marcar como concluído
-        </button>
-      </article>
-    </section>
+    <div *ngIf="vagoesAgrupados.length === 0" class="estado-informativo">
+      Nenhum vagão cadastrado para esta visita.
+    </div>
 
-    <ng-template #semItens>
-      <p class="estado-informativo">Nenhum contêiner planejado para esta operação.</p>
-    </ng-template>
+    <ul class="arvore-vagoes" *ngIf="vagoesAgrupados.length > 0">
+      <li *ngFor="let vagao of vagoesAgrupados" class="nodo-vagao">
+        <div class="cabecalho-vagao">
+          <span class="titulo-vagao">Vagão {{ textoSeguro(vagao.identificadorVagao) }}</span>
+          <span class="posicao-vagao">Posição {{ vagao.posicaoNoTrem }}</span>
+          <span class="tipo-vagao" *ngIf="vagao.tipoVagao">Tipo {{ textoSeguro(vagao.tipoVagao) }}</span>
+        </div>
+        <ul class="lista-conteineres" *ngIf="vagao.conteineres.length > 0">
+          <li *ngFor="let conteiner of vagao.conteineres" class="nodo-conteiner">
+            <div class="linha-conteiner">
+              <span class="identificador">Contêiner {{ textoSeguro(conteiner.codigoConteiner) }}</span>
+              <span class="tipo-movimentacao">{{ descricaoTipo(conteiner.tipoMovimentacao) }}</span>
+              <span class="status" [class.concluido]="estaConcluido(conteiner.statusOperacao)">
+                {{ descricaoStatus(conteiner.statusOperacao) }}
+              </span>
+              <button type="button"
+                      class="botao-status"
+                      [disabled]="estaConcluido(conteiner.statusOperacao) || operacaoEmAndamento"
+                      (click)="marcarComoConcluido(conteiner)">
+                Marcar como concluído
+              </button>
+            </div>
+          </li>
+        </ul>
+        <p class="estado-informativo" *ngIf="vagao.conteineres.length === 0">
+          Nenhum contêiner associado a este vagão.
+        </p>
+      </li>
+    </ul>
+
+    <section *ngIf="conteineresNaoAlocados.length > 0" class="secao-nao-alocados">
+      <h3>Contêineres sem vagão associado</h3>
+      <ul class="lista-conteineres">
+        <li *ngFor="let conteiner of conteineresNaoAlocados" class="nodo-conteiner">
+          <div class="linha-conteiner">
+            <span class="identificador">Contêiner {{ textoSeguro(conteiner.codigoConteiner) }}</span>
+            <span class="tipo-movimentacao">{{ descricaoTipo(conteiner.tipoMovimentacao) }}</span>
+            <span class="status" [class.concluido]="estaConcluido(conteiner.statusOperacao)">
+              {{ descricaoStatus(conteiner.statusOperacao) }}
+            </span>
+            <button type="button"
+                    class="botao-status"
+                    [disabled]="estaConcluido(conteiner.statusOperacao) || operacaoEmAndamento"
+                    (click)="marcarComoConcluido(conteiner)">
+              Marcar como concluído
+            </button>
+          </div>
+        </li>
+      </ul>
+    </section>
   </section>
 </section>

--- a/frontend/cloudport/src/app/componentes/service/servico-ferrovia/servico-ferrovia.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-ferrovia/servico-ferrovia.service.ts
@@ -8,11 +8,19 @@ export type StatusOperacaoConteinerVisita = 'PENDENTE' | 'CONCLUIDO';
 export interface OperacaoConteinerVisita {
   codigoConteiner: string;
   statusOperacao: StatusOperacaoConteinerVisita;
+  identificadorVagao?: string | null;
 }
 
 export interface OperacaoConteinerVisitaEnvio {
   codigoConteiner: string;
   statusOperacao?: StatusOperacaoConteinerVisita;
+  identificadorVagao?: string | null;
+}
+
+export interface VagaoVisita {
+  posicaoNoTrem: number;
+  identificadorVagao: string;
+  tipoVagao?: string | null;
 }
 
 export interface AtualizacaoStatusOperacaoConteiner {
@@ -28,6 +36,7 @@ export interface VisitaTrem {
   statusVisita: string;
   listaDescarga: OperacaoConteinerVisita[];
   listaCarga: OperacaoConteinerVisita[];
+  listaVagoes: VagaoVisita[];
 }
 
 export interface VisitaTremRequisicao {


### PR DESCRIPTION
## Resumo
- adiciona o identificador de vagão aos modelos e DTOs de operações de contêiner na ferrovia
- valida e sanitiza a associação entre contêineres e vagões durante os fluxos de visita de trem
- exibe os contêineres em visão hierárquica por vagão no frontend, incluindo tratamento para itens sem associação

## Testes
- mvn test *(falha: bloqueio 403 ao resolver dependências do Maven)*
- npm run lint *(falha: script ausente no projeto Angular)*

------
https://chatgpt.com/codex/tasks/task_e_68f7b25cdb708327b923346ef183e570