### PR TITLE
Desativa cadastro público e esclarece copy de login administrativo

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/SecurityConfigurations.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/SecurityConfigurations.java
@@ -46,7 +46,6 @@ public class SecurityConfigurations {
                     .antMatchers("/auth/**").permitAll()
                     .antMatchers(HttpMethod.POST, "/auth").permitAll()
                     .antMatchers(HttpMethod.POST, "/auth/login").permitAll()
-                    .antMatchers(HttpMethod.POST, "/auth/register").permitAll()
                     .antMatchers(HttpMethod.POST, "/product").hasRole("ADMIN_PORTO")
                     .anyRequest().authenticated()
                 .and()

--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationController.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationController.java
@@ -2,7 +2,6 @@ package br.com.cloudport.servicoautenticacao.controllers;
 
 import br.com.cloudport.servicoautenticacao.app.configuracoes.dto.AuthenticationDTO;
 import br.com.cloudport.servicoautenticacao.app.configuracoes.dto.LoginResponseDTO;
-import br.com.cloudport.servicoautenticacao.app.configuracoes.dto.RegisterDTO;
 import br.com.cloudport.servicoautenticacao.app.configuracoes.validacao.SanitizadorEntrada;
 import br.com.cloudport.servicoautenticacao.app.administracao.dto.UsuarioInfoDTO;
 import br.com.cloudport.servicoautenticacao.app.usuarioslista.UsuarioRepositorio;
@@ -12,19 +11,15 @@ import br.com.cloudport.servicoautenticacao.model.Usuario;
 import br.com.cloudport.servicoautenticacao.model.UsuarioPapel;
 import br.com.cloudport.servicoautenticacao.repositories.PapelRepositorio;
 import br.com.cloudport.servicoautenticacao.repositories.UsuarioPapelRepositorio;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,8 +38,6 @@ public class AuthenticationController {
     private final TokenService tokenService;
     private final UsuarioPapelRepositorio usuarioPapelRepositorio;
 
-    @Value("${api.security.self-registration.allowed-roles:USER}")
-    private String papeisPermitidosAutoCadastro;
 
     public AuthenticationController(AuthenticationManager authenticationManager,
                                      UsuarioRepositorio usuarioRepositorio,
@@ -98,61 +91,8 @@ public class AuthenticationController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<Void> registrar(@RequestBody @Valid RegisterDTO dados){
-        String loginSanitizado;
-        String senhaSanitizada;
-        try {
-            loginSanitizado = SanitizadorEntrada.sanitizarLogin(dados.getLogin());
-            senhaSanitizada = SanitizadorEntrada.sanitizarSenha(dados.getPassword());
-        } catch (IllegalArgumentException ex) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage());
-        }
-
-        if (this.usuarioRepositorio.findByLogin(loginSanitizado).isPresent()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Login informado já está em uso.");
-        }
-
-        String senhaCriptografada = new BCryptPasswordEncoder().encode(senhaSanitizada);
-
-        Set<String> papeisPermitidosNormalizados = Arrays.stream(papeisPermitidosAutoCadastro.split(","))
-                .map(String::trim)
-                .filter(papel -> !papel.isEmpty())
-                .collect(Collectors.collectingAndThen(Collectors.toSet(), conjunto -> conjunto.isEmpty() ? Collections.singleton("USER") : conjunto));
-
-        Set<String> papeisSolicitados = dados.getRoles().stream()
-                .map(String::trim)
-                .filter(papel -> !papel.isEmpty())
-                .collect(Collectors.toSet());
-
-        if (!papeisPermitidosNormalizados.containsAll(papeisSolicitados)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Papéis informados não são permitidos para auto-registro.");
-        }
-
-        Set<UsuarioPapel> papeis = papeisSolicitados.stream()
-                              .map(nomePapel -> {
-                                  Papel papel = papelRepositorio.findByNome(nomePapel)
-                                          .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Papel '" + nomePapel + "' não encontrado."));
-                                  return new UsuarioPapel(null, papel);
-                              })
-                              .collect(Collectors.toSet());
-
-        if (papeis.isEmpty()) {
-            papeis = papeisPermitidosNormalizados.stream()
-                    .map(nomePapel -> papelRepositorio.findByNome(nomePapel)
-                            .map(papel -> new UsuarioPapel(null, papel))
-                            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Papel '" + nomePapel + "' não encontrado.")))
-                    .collect(Collectors.toSet());
-        }
-
-        Usuario novoUsuario = new Usuario(loginSanitizado, senhaCriptografada, dados.getNome(),
-                dados.getTransportadoraDocumento(), dados.getTransportadoraNome(), papeis);
-
-        papeis.forEach(papel -> papel.setUsuario(novoUsuario));
-
-        this.usuarioRepositorio.save(novoUsuario);
-        this.usuarioPapelRepositorio.saveAll(papeis);
-
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Void> registrar() {
+        return ResponseEntity.status(HttpStatus.GONE).build();
     }
 
     @GetMapping("/usuarios/{login}")

--- a/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
+++ b/backend/servico-autenticacao/src/test/java/br/com/cloudport/servicoautenticacao/controllers/AuthenticationControllerTest.java
@@ -1,7 +1,6 @@
 package br.com.cloudport.servicoautenticacao.controllers;
 
 import br.com.cloudport.servicoautenticacao.app.configuracoes.dto.AuthenticationDTO;
-import br.com.cloudport.servicoautenticacao.app.configuracoes.dto.RegisterDTO;
 import br.com.cloudport.servicoautenticacao.app.usuarioslista.UsuarioRepositorio;
 import br.com.cloudport.servicoautenticacao.config.TokenService;
 import br.com.cloudport.servicoautenticacao.model.Papel;
@@ -11,11 +10,8 @@ import br.com.cloudport.servicoautenticacao.repositories.PapelRepositorio;
 import br.com.cloudport.servicoautenticacao.repositories.UsuarioPapelRepositorio;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -27,9 +23,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -123,85 +117,10 @@ class AuthenticationControllerTest {
     }
 
     @Test
-    void registrar_loginDuplicado() throws Exception {
-        when(usuarioRepositorio.findByLogin("john"))
-                .thenReturn(Optional.of(new Usuario()));
-
-        RegisterDTO dto = new RegisterDTO("john", "pass", Collections.singleton("ADMIN"));
-
+    void registrar_desativado_retornaGone() throws Exception {
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Login informado já está em uso."));
-    }
-
-    @Test
-    void registrar_payloadInvalido_retornaErros() throws Exception {
-        RegisterDTO dto = new RegisterDTO("", "", Collections.emptySet());
-
-        mockMvc.perform(post("/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.mensagem").value("Erro de validação dos dados enviados."))
-                .andExpect(jsonPath("$.erros.login").value("O login é obrigatório."))
-                .andExpect(jsonPath("$.erros.password").value("A senha é obrigatória."))
-                .andExpect(jsonPath("$.erros.roles").value("Informe ao menos uma role."));
-    }
-
-    @Test
-    void registrar_roleEmBranco_retornaErroDeElemento() throws Exception {
-        Set<String> roles = new LinkedHashSet<>();
-        roles.add(" ");
-        roles.add("ADMIN");
-
-        RegisterDTO dto = new RegisterDTO("usuario", "segredo", roles);
-
-        mockMvc.perform(post("/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.mensagem").value("Erro de validação dos dados enviados."))
-                .andExpect(jsonPath("$.erros['roles[0]']").value("A role não pode ser vazia."));
-    }
-
-    @Test
-    void registrar_sucesso() throws Exception {
-        when(usuarioRepositorio.findByLogin("john")).thenReturn(Optional.empty());
-        when(papelRepositorio.findByNome("ADMIN")).thenReturn(Optional.of(new Papel("ADMIN")));
-
-        RegisterDTO dto = new RegisterDTO("john", "pass", Collections.singleton("ADMIN"));
-
-        mockMvc.perform(post("/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isOk());
-
-        verify(usuarioRepositorio).save(any(Usuario.class));
-
-        ArgumentCaptor<Iterable<UsuarioPapel>> papeisCaptor = ArgumentCaptor.forClass(Iterable.class);
-        verify(usuarioPapelRepositorio).saveAll(papeisCaptor.capture());
-
-        Iterable<UsuarioPapel> papeisSalvos = papeisCaptor.getValue();
-        assertNotNull(papeisSalvos);
-        assertTrue(papeisSalvos.iterator().hasNext());
-        UsuarioPapel papelSalvo = papeisSalvos.iterator().next();
-        assertNotNull(papelSalvo.getUsuario());
-        assertEquals("john", papelSalvo.getUsuario().getLogin());
-    }
-
-    @Test
-    void registrar_papelNaoEncontrado() throws Exception {
-        when(usuarioRepositorio.findByLogin("john")).thenReturn(Optional.empty());
-        when(papelRepositorio.findByNome("UNKNOWN")).thenReturn(Optional.empty());
-
-        RegisterDTO dto = new RegisterDTO("john", "pass", Collections.singleton("UNKNOWN"));
-
-        mockMvc.perform(post("/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("Papel 'UNKNOWN' não encontrado."));
+                        .content("{}"))
+                .andExpect(status().isGone());
     }
 }

--- a/frontend/cloudport/src/app/componentes/login/login.component.html
+++ b/frontend/cloudport/src/app/componentes/login/login.component.html
@@ -3,6 +3,10 @@
     <div class="col-lg-8 mx-auto">
       <div class="bg-white rounded-lg shadow-sm p-5 box">
         <form [formGroup]="formularioLogin" (ngSubmit)="aoEnviar()">
+      <div class="mb-4 text-center">
+        <h1 class="h4 mb-2">Acesso administrativo</h1>
+        <p class="text-muted mb-0">Login exclusivo para gestores e administradores autorizados.</p>
+      </div>
           <div class="form-group">
             <label class="form-label" for="loginFormUser1">Login</label>
             <input


### PR DESCRIPTION
### Motivation
- Evitar que usuários externos criem contas publicamente, alinhando o backend à regra de negócio que centraliza cadastro de prefeituras/gestores via admin.
- Garantir que a tela de login comunique que o acesso é restrito a gestores e administradores, reduzindo expectativas de signup para cidadãos.
- Aplicar uma mudança segura e mínima no backend mantendo o endpoint de registro compatível (mas inativo) para evitar que criações automáticas ocorram.

### Description
- Substituí a lógica de self-registration em `AuthenticationController` para que `POST /auth/register` retorne `410 Gone` e não crie usuários, removendo validações/fluxo de criação de usuário público. (arquivo: `backend/servico-autenticacao/src/main/java/.../AuthenticationController.java`).
- Removi a permissão explícita de `permitAll` para `/auth/register` na configuração de segurança, exigindo autorização para demais operações por padrão. (arquivo: `backend/servico-autenticacao/src/main/java/.../SecurityConfigurations.java`).
- Atualizei os testes de `AuthenticationController` para refletir o novo comportamento do endpoint de registro e manter cobertura de login; o teste agora espera `410 Gone` para `/auth/register`. (arquivo: `backend/servico-autenticacao/src/test/java/.../AuthenticationControllerTest.java`).
- Ajustei a copy da página de login no frontend Angular para explicitar que o formulário é para acesso administrativo (gestores/administradores autorizados). (arquivo: `frontend/cloudport/src/app/componentes/login/login.component.html`).

### Testing
- Atualizei os testes unitários de `AuthenticationController` (`WebMvcTest`) para validar que `/auth/register` está desativado, porém os testes não foram concluídos aqui por limitações do ambiente.
- Tentei executar `cd backend/servico-autenticacao && ./mvnw -Dtest=AuthenticationControllerTest test`, mas a execução falhou devido a erro de rede ao baixar dependências do Maven Wrapper, portanto não houve execução bem-sucedida dos testes automatizados neste ambiente.
- Recomenda-se executar a suíte de testes completa em CI/ambiente com acesso à rede (por exemplo: `./mvnw test`) e verificar o build para confirmar que alterações não introduziram regressões.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9a59953a88325b540acfe0608811e)