### PR TITLE
Remove hardcoded default admin user seeding

### DIFF
--- a/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java
+++ b/backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java
@@ -1,47 +1,25 @@
 package br.com.cloudport.servicoautenticacao.config;
 
-import br.com.cloudport.servicoautenticacao.app.usuarioslista.UsuarioRepositorio;
 import br.com.cloudport.servicoautenticacao.model.Papel;
-import br.com.cloudport.servicoautenticacao.model.Usuario;
-import br.com.cloudport.servicoautenticacao.model.UsuarioPapel;
 import br.com.cloudport.servicoautenticacao.repositories.PapelRepositorio;
-import java.util.HashSet;
-import java.util.Set;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UserInitializer implements CommandLineRunner {
 
-    private final UsuarioRepositorio usuarioRepositorio;
     private final PapelRepositorio papelRepositorio;
 
-    public UserInitializer(UsuarioRepositorio usuarioRepositorio, PapelRepositorio papelRepositorio) {
-        this.usuarioRepositorio = usuarioRepositorio;
+    public UserInitializer(PapelRepositorio papelRepositorio) {
         this.papelRepositorio = papelRepositorio;
     }
 
     @Override
     public void run(String... args) {
-        String loginAdministrador = "gitpod";
-        String senhaAdministrador = new BCryptPasswordEncoder().encode("gitpod");
-
-        Papel papelAdministrador = garantirPapel("ROLE_ADMIN_PORTO");
+        garantirPapel("ROLE_ADMIN_PORTO");
         garantirPapel("ROLE_PLANEJADOR");
         garantirPapel("ROLE_OPERADOR_GATE");
         garantirPapel("ROLE_TRANSPORTADORA");
-
-        if (usuarioRepositorio.findByLogin(loginAdministrador).isEmpty()) {
-            Usuario administrador = new Usuario(loginAdministrador, senhaAdministrador, "Administrador CloudPort",
-                    null, null, new HashSet<>());
-
-            Set<UsuarioPapel> papeis = administrador.getPapeis();
-            UsuarioPapel papelUsuarioAdministrador = new UsuarioPapel(administrador, papelAdministrador);
-            papeis.add(papelUsuarioAdministrador);
-
-            usuarioRepositorio.save(administrador);
-        }
     }
 
     private Papel garantirPapel(String identificadorPapel) {


### PR DESCRIPTION
### Motivation
- The application previously created an administrator account with fixed credentials (`gitpod`/`gitpod`) at startup, introducing a default-credential vulnerability that allows trivial admin takeover.
- The goal is to eliminate automatic creation of a predictable admin account while keeping required roles present in the system.

### Description
- Removed the user-seeding logic that created a default admin user from `backend/servico-autenticacao/src/main/java/br/com/cloudport/servicoautenticacao/config/UserInitializer.java`.
- Preserved role initialization by keeping calls to `garantirPapel("ROLE_ADMIN_PORTO")`, `garantirPapel("ROLE_PLANEJADOR")`, `garantirPapel("ROLE_OPERADOR_GATE")`, and `garantirPapel("ROLE_TRANSPORTADORA")` so roles are still ensured at startup.
- Cleaned up the class constructor and imports so the initializer no longer depends on `UsuarioRepositorio` or `BCryptPasswordEncoder` after removing user creation code.
- The change minimizes behavior impact by only removing the insecure automatic admin creation and retaining role setup.

### Testing
- Searched the updated file for the fixed credential strings and encoder usage with `rg -n "gitpod|BCryptPasswordEncoder\(\)\.encode(\"gitpod\")"` and confirmed the hardcoded credentials are no longer present (search returned no results).
- Attempted to build the authentication service with `./mvnw -q -DskipTests package`, but the build could not complete in this environment because the Maven wrapper failed to download dependencies due to a network outage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc18396400832789b2ed799eb4a0ac)