### PR TITLE
Enforce per-transportadora access for agendamentos

### DIFF
--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoController.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoController.java
@@ -73,6 +73,7 @@ public class AgendamentoController {
     @Operation(summary = "Acompanha atualizações em tempo real do agendamento")
     @PreAuthorize("hasAnyRole('ADMIN_PORTO','PLANEJADOR','OPERADOR_GATE','TRANSPORTADORA')")
     public SseEmitter acompanhar(@PathVariable Long id) {
+        agendamentoService.buscarPorId(id);
         return agendamentoRealtimeService.registrar(id);
     }
 

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoRepository.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoRepository.java
@@ -36,9 +36,26 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
 
     Page<Agendamento> findByJanelaAtendimentoDataBetween(LocalDate inicio, LocalDate fim, Pageable pageable);
 
+    Page<Agendamento> findByTransportadoraIdAndJanelaAtendimentoDataBetween(Long transportadoraId,
+                                                                             LocalDate inicio,
+                                                                             LocalDate fim,
+                                                                             Pageable pageable);
+
     Page<Agendamento> findByJanelaAtendimentoDataGreaterThanEqual(LocalDate inicio, Pageable pageable);
 
+    Page<Agendamento> findByTransportadoraIdAndJanelaAtendimentoDataGreaterThanEqual(Long transportadoraId,
+                                                                                      LocalDate inicio,
+                                                                                      Pageable pageable);
+
     Page<Agendamento> findByJanelaAtendimentoDataLessThanEqual(LocalDate fim, Pageable pageable);
+
+    Page<Agendamento> findByTransportadoraIdAndJanelaAtendimentoDataLessThanEqual(Long transportadoraId,
+                                                                                   LocalDate fim,
+                                                                                   Pageable pageable);
+
+    Page<Agendamento> findByTransportadoraId(Long transportadoraId, Pageable pageable);
+
+    Optional<Agendamento> findByIdAndTransportadoraId(Long id, Long transportadoraId);
 
     long countByJanelaAtendimentoIdAndStatusNot(Long janelaAtendimentoId, StatusAgendamento status);
 

--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoService.java
@@ -35,11 +35,17 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -93,15 +99,27 @@ public class AgendamentoService {
 
     @Transactional(readOnly = true)
     public Page<AgendamentoDTO> buscar(LocalDate dataInicio, LocalDate dataFim, Pageable pageable) {
+        Optional<Long> transportadoraLogadaId = obterTransportadoraLogadaId();
         Page<Agendamento> page;
         if (dataInicio != null && dataFim != null) {
-            page = agendamentoRepository.findByJanelaAtendimentoDataBetween(dataInicio, dataFim, pageable);
+            page = transportadoraLogadaId
+                    .map(transportadoraId -> agendamentoRepository.findByTransportadoraIdAndJanelaAtendimentoDataBetween(
+                            transportadoraId, dataInicio, dataFim, pageable))
+                    .orElseGet(() -> agendamentoRepository.findByJanelaAtendimentoDataBetween(dataInicio, dataFim, pageable));
         } else if (dataInicio != null) {
-            page = agendamentoRepository.findByJanelaAtendimentoDataGreaterThanEqual(dataInicio, pageable);
+            page = transportadoraLogadaId
+                    .map(transportadoraId -> agendamentoRepository.findByTransportadoraIdAndJanelaAtendimentoDataGreaterThanEqual(
+                            transportadoraId, dataInicio, pageable))
+                    .orElseGet(() -> agendamentoRepository.findByJanelaAtendimentoDataGreaterThanEqual(dataInicio, pageable));
         } else if (dataFim != null) {
-            page = agendamentoRepository.findByJanelaAtendimentoDataLessThanEqual(dataFim, pageable);
+            page = transportadoraLogadaId
+                    .map(transportadoraId -> agendamentoRepository.findByTransportadoraIdAndJanelaAtendimentoDataLessThanEqual(
+                            transportadoraId, dataFim, pageable))
+                    .orElseGet(() -> agendamentoRepository.findByJanelaAtendimentoDataLessThanEqual(dataFim, pageable));
         } else {
-            page = agendamentoRepository.findAll(pageable);
+            page = transportadoraLogadaId
+                    .map(transportadoraId -> agendamentoRepository.findByTransportadoraId(transportadoraId, pageable))
+                    .orElseGet(() -> agendamentoRepository.findAll(pageable));
         }
         return page.map(GateMapper::toAgendamentoDTO);
     }
@@ -346,8 +364,38 @@ public class AgendamentoService {
     }
 
     private Agendamento obterAgendamento(Long id) {
-        return agendamentoRepository.findById(id)
+        Optional<Long> transportadoraLogadaId = obterTransportadoraLogadaId();
+        return transportadoraLogadaId
+                .map(transportadoraId -> agendamentoRepository.findByIdAndTransportadoraId(id, transportadoraId))
+                .orElseGet(() -> agendamentoRepository.findById(id))
                 .orElseThrow(() -> new NotFoundException("Agendamento não encontrado"));
+    }
+
+    private Optional<Long> obterTransportadoraLogadaId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!(authentication instanceof JwtAuthenticationToken) || !possuiRoleTransportadora(authentication)) {
+            return Optional.empty();
+        }
+
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+        Jwt token = jwtAuthenticationToken.getToken();
+        String documento = token.getClaimAsString("transportadoraDocumento");
+        if (!StringUtils.hasText(documento)) {
+            documento = token.getClaimAsString("transportadoraCnpj");
+        }
+        if (!StringUtils.hasText(documento)) {
+            return Optional.empty();
+        }
+
+        String normalizedDocumento = documento.replaceAll("[^0-9A-Za-z]", "").toUpperCase(Locale.ROOT);
+        return transportadoraRepository.findByDocumento(normalizedDocumento)
+                .map(Transportadora::getId);
+    }
+
+    private boolean possuiRoleTransportadora(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch("ROLE_TRANSPORTADORA"::equals);
     }
 
     private JanelaAtendimento buscarJanela(Long id) {


### PR DESCRIPTION
### Motivation

- A gate-pass `token` field was introduced and is returned inside agendamento payloads, but listing/detail/SSE endpoints performed only role-based checks, allowing `TRANSPORTADORA` users to enumerate other transportadoras' agendamentos and leak tokens. 

### Description

- Add repository query methods scoped by `transportadoraId` and `id + transportadoraId` to allow efficient server-side filtering (`AgendamentoRepository`).
- Restrict listing (`buscar`) to return only the logged transportadora's records when the caller has `ROLE_TRANSPORTADORA`, preserving existing behavior for other roles (`AgendamentoService`).
- Enforce ownership on single-item fetch by resolving the logged transportadora from JWT claims (`transportadoraDocumento`/`transportadoraCnpj`) and using `findByIdAndTransportadoraId` when appropriate (`AgendamentoService.obterAgendamento` plus helper `obterTransportadoraLogadaId`).
- Harden SSE registration by validating authorization for the requested agendamento before creating the `SseEmitter` (`AgendamentoController` now calls `agendamentoService.buscarPorId(id)` before `registrar`).

### Testing

- Attempted to compile `backend/servico-gate` with `mvn -q -DskipTests compile`, but the build could not complete in this environment because Maven Central was unreachable (HTTP 403), so no local compile or automated tests could be executed here.
- Changes include only read-path filtering and an additional pre-check for SSE, and rely on existing repository and JWT claims; runtime verification is recommended in CI with network access enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc15d1783483278c5bb77c1ac3ca5a)