### PR TITLE
Deny access for ROLE_TRANSPORTADORA when transportadora claim is missing or unmapped

### DIFF
--- a/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoService.java
+++ b/backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoService.java
@@ -43,6 +43,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -100,6 +101,7 @@ public class AgendamentoService {
     @Transactional(readOnly = true)
     public Page<AgendamentoDTO> buscar(LocalDate dataInicio, LocalDate dataFim, Pageable pageable) {
         Optional<Long> transportadoraLogadaId = obterTransportadoraLogadaId();
+        validarTransportadoraSemVinculo(transportadoraLogadaId);
         Page<Agendamento> page;
         if (dataInicio != null && dataFim != null) {
             page = transportadoraLogadaId
@@ -365,6 +367,7 @@ public class AgendamentoService {
 
     private Agendamento obterAgendamento(Long id) {
         Optional<Long> transportadoraLogadaId = obterTransportadoraLogadaId();
+        validarTransportadoraSemVinculo(transportadoraLogadaId);
         return transportadoraLogadaId
                 .map(transportadoraId -> agendamentoRepository.findByIdAndTransportadoraId(id, transportadoraId))
                 .orElseGet(() -> agendamentoRepository.findById(id))
@@ -390,6 +393,13 @@ public class AgendamentoService {
         String normalizedDocumento = documento.replaceAll("[^0-9A-Za-z]", "").toUpperCase(Locale.ROOT);
         return transportadoraRepository.findByDocumento(normalizedDocumento)
                 .map(Transportadora::getId);
+    }
+
+    private void validarTransportadoraSemVinculo(Optional<Long> transportadoraLogadaId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (transportadoraLogadaId.isEmpty() && authentication != null && possuiRoleTransportadora(authentication)) {
+            throw new AccessDeniedException("Transportadora autenticada sem vínculo válido");
+        }
     }
 
     private boolean possuiRoleTransportadora(Authentication authentication) {


### PR DESCRIPTION
### Motivation
- The previous change introduced role-based scoping for transportadora users but could fail open when the JWT lacked `transportadoraDocumento`/`transportadoraCnpj` or the document did not map to a `Transportadora`, allowing broad `findAll`/`findById` access.
- The intent is to ensure transportadora-authenticated users are always scoped to a resolved `Transportadora` and to fail closed when that mapping cannot be established.

### Description
- Added a guard method `validarTransportadoraSemVinculo(Optional<Long>)` that throws `AccessDeniedException` when the authenticated user has `ROLE_TRANSPORTADORA` but no linked `Transportadora` ID was resolved.
- Called the guard from both `buscar(...)` (listing) and `obterAgendamento(...)` (by-id resolution) to prevent fallbacks to unscoped repository queries. 
- Kept the existing behavior unchanged for non-transportadora roles and preserved existing repository usage when a valid transportadora ID is present. 
- Changes are contained to `backend/servico-gate/src/main/java/br/com/cloudport/servicogate/app/cidadao/AgendamentoService.java` and include a new import for `AccessDeniedException`.

### Testing
- Attempted `./mvnw -pl backend/servico-gate -DskipTests compile` to compile the module which detected the modified file but failed due to a missing project wrapper script in the environment. (command executed; wrapper not present)
- Attempted `cd backend/servico-gate && mvn -DskipTests compile` which failed in this environment due to dependency resolution errors (Maven Central returned HTTP 403 for the parent POM), so no module compilation or automated tests were completed here.
- No unit or integration tests were modified; the change is minimal and localized to authorization checks in `AgendamentoService`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd1b1cb6508327a37186c3bccf6f7e)