### PR TITLE
Implement vessel scheduling (escala) management system

### DIFF
--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/controlador/EscalaControlador.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/controlador/EscalaControlador.java
@@ -1,0 +1,74 @@
+package br.com.cloudport.serviconavio.escala.controlador;
+
+import br.com.cloudport.serviconavio.escala.dto.AtualizacaoEscalaDTO;
+import br.com.cloudport.serviconavio.escala.dto.AvancarFaseEscalaDTO;
+import br.com.cloudport.serviconavio.escala.dto.CadastroEscalaDTO;
+import br.com.cloudport.serviconavio.escala.dto.EscalaDetalheDTO;
+import br.com.cloudport.serviconavio.escala.dto.EscalaResumoDTO;
+import br.com.cloudport.serviconavio.escala.servico.EscalaServico;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@Validated
+public class EscalaControlador {
+
+    private final EscalaServico escalaServico;
+
+    public EscalaControlador(EscalaServico escalaServico) {
+        this.escalaServico = escalaServico;
+    }
+
+    @GetMapping("/escalas")
+    public List<EscalaResumoDTO> listarCronograma(@RequestParam(name = "dias", defaultValue = "7") int dias) {
+        return escalaServico.listarCronograma(dias);
+    }
+
+    @GetMapping("/escalas/{id}")
+    public EscalaDetalheDTO detalhar(@PathVariable Long id) {
+        return escalaServico.buscarDetalhe(id);
+    }
+
+    @PutMapping("/escalas/{id}")
+    public EscalaDetalheDTO atualizar(@PathVariable Long id,
+                                      @Valid @RequestBody AtualizacaoEscalaDTO dto) {
+        return escalaServico.atualizar(id, dto);
+    }
+
+    @PatchMapping("/escalas/{id}/fase")
+    public EscalaDetalheDTO avancarFase(@PathVariable Long id,
+                                        @Valid @RequestBody AvancarFaseEscalaDTO dto) {
+        return escalaServico.avancarFase(id, dto.getFase());
+    }
+
+    @DeleteMapping("/escalas/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void remover(@PathVariable Long id) {
+        escalaServico.remover(id);
+    }
+
+    @GetMapping("/navios/{navioId}/escalas")
+    public List<EscalaResumoDTO> listarPorNavio(@PathVariable Long navioId) {
+        return escalaServico.listarPorNavio(navioId);
+    }
+
+    @PostMapping("/navios/{navioId}/escalas")
+    @ResponseStatus(HttpStatus.CREATED)
+    public EscalaDetalheDTO registrar(@PathVariable Long navioId,
+                                      @Valid @RequestBody CadastroEscalaDTO dto) {
+        return escalaServico.registrar(navioId, dto);
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/AtualizacaoEscalaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/AtualizacaoEscalaDTO.java
@@ -1,0 +1,100 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public class AtualizacaoEscalaDTO {
+
+    @Size(max = 20, message = "A viagem de entrada deve ter no máximo 20 caracteres.")
+    private String viagemEntrada;
+
+    @Size(max = 20, message = "A viagem de saída deve ter no máximo 20 caracteres.")
+    private String viagemSaida;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime chegadaPrevista;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime atracacaoPrevista;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime partidaPrevista;
+
+    @Size(max = 20, message = "O berço previsto deve ter no máximo 20 caracteres.")
+    private String bercoPrevisto;
+
+    @Size(max = 20, message = "O berço atual deve ter no máximo 20 caracteres.")
+    private String bercoAtual;
+
+    @Size(max = 500, message = "As observações devem ter no máximo 500 caracteres.")
+    private String observacoes;
+
+    public AtualizacaoEscalaDTO() {
+    }
+
+    public String getViagemEntrada() {
+        return viagemEntrada;
+    }
+
+    public void setViagemEntrada(String viagemEntrada) {
+        this.viagemEntrada = viagemEntrada;
+    }
+
+    public String getViagemSaida() {
+        return viagemSaida;
+    }
+
+    public void setViagemSaida(String viagemSaida) {
+        this.viagemSaida = viagemSaida;
+    }
+
+    public LocalDateTime getChegadaPrevista() {
+        return chegadaPrevista;
+    }
+
+    public void setChegadaPrevista(LocalDateTime chegadaPrevista) {
+        this.chegadaPrevista = chegadaPrevista;
+    }
+
+    public LocalDateTime getAtracacaoPrevista() {
+        return atracacaoPrevista;
+    }
+
+    public void setAtracacaoPrevista(LocalDateTime atracacaoPrevista) {
+        this.atracacaoPrevista = atracacaoPrevista;
+    }
+
+    public LocalDateTime getPartidaPrevista() {
+        return partidaPrevista;
+    }
+
+    public void setPartidaPrevista(LocalDateTime partidaPrevista) {
+        this.partidaPrevista = partidaPrevista;
+    }
+
+    public String getBercoPrevisto() {
+        return bercoPrevisto;
+    }
+
+    public void setBercoPrevisto(String bercoPrevisto) {
+        this.bercoPrevisto = bercoPrevisto;
+    }
+
+    public String getBercoAtual() {
+        return bercoAtual;
+    }
+
+    public void setBercoAtual(String bercoAtual) {
+        this.bercoAtual = bercoAtual;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/AvancarFaseEscalaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/AvancarFaseEscalaDTO.java
@@ -1,0 +1,22 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
+
+import javax.validation.constraints.NotNull;
+
+public class AvancarFaseEscalaDTO {
+
+    @NotNull(message = "Informe a fase de destino da escala.")
+    private FaseEscala fase;
+
+    public AvancarFaseEscalaDTO() {
+    }
+
+    public FaseEscala getFase() {
+        return fase;
+    }
+
+    public void setFase(FaseEscala fase) {
+        this.fase = fase;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/CadastroEscalaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/CadastroEscalaDTO.java
@@ -1,0 +1,93 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public class CadastroEscalaDTO {
+
+    @NotBlank(message = "Informe a viagem de entrada (inbound voyage).")
+    @Size(max = 20, message = "A viagem de entrada deve ter no máximo 20 caracteres.")
+    private String viagemEntrada;
+
+    @Size(max = 20, message = "A viagem de saída deve ter no máximo 20 caracteres.")
+    private String viagemSaida;
+
+    @NotNull(message = "Informe a chegada prevista (ETA).")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime chegadaPrevista;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime atracacaoPrevista;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime partidaPrevista;
+
+    @Size(max = 20, message = "O berço previsto deve ter no máximo 20 caracteres.")
+    private String bercoPrevisto;
+
+    @Size(max = 500, message = "As observações devem ter no máximo 500 caracteres.")
+    private String observacoes;
+
+    public CadastroEscalaDTO() {
+    }
+
+    public String getViagemEntrada() {
+        return viagemEntrada;
+    }
+
+    public void setViagemEntrada(String viagemEntrada) {
+        this.viagemEntrada = viagemEntrada;
+    }
+
+    public String getViagemSaida() {
+        return viagemSaida;
+    }
+
+    public void setViagemSaida(String viagemSaida) {
+        this.viagemSaida = viagemSaida;
+    }
+
+    public LocalDateTime getChegadaPrevista() {
+        return chegadaPrevista;
+    }
+
+    public void setChegadaPrevista(LocalDateTime chegadaPrevista) {
+        this.chegadaPrevista = chegadaPrevista;
+    }
+
+    public LocalDateTime getAtracacaoPrevista() {
+        return atracacaoPrevista;
+    }
+
+    public void setAtracacaoPrevista(LocalDateTime atracacaoPrevista) {
+        this.atracacaoPrevista = atracacaoPrevista;
+    }
+
+    public LocalDateTime getPartidaPrevista() {
+        return partidaPrevista;
+    }
+
+    public void setPartidaPrevista(LocalDateTime partidaPrevista) {
+        this.partidaPrevista = partidaPrevista;
+    }
+
+    public String getBercoPrevisto() {
+        return bercoPrevisto;
+    }
+
+    public void setBercoPrevisto(String bercoPrevisto) {
+        this.bercoPrevisto = bercoPrevisto;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/EscalaDetalheDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/EscalaDetalheDTO.java
@@ -1,0 +1,152 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public class EscalaDetalheDTO {
+
+    private final Long id;
+    private final Long navioId;
+    private final String nomeNavio;
+    private final String codigoImo;
+    private final String viagemEntrada;
+    private final String viagemSaida;
+    private final FaseEscala fase;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime chegadaPrevista;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime atracacaoPrevista;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime partidaPrevista;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime chegadaEfetiva;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime atracacaoEfetiva;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime partidaEfetiva;
+    private final String bercoPrevisto;
+    private final String bercoAtual;
+    private final String observacoes;
+
+    public EscalaDetalheDTO(Long id,
+                            Long navioId,
+                            String nomeNavio,
+                            String codigoImo,
+                            String viagemEntrada,
+                            String viagemSaida,
+                            FaseEscala fase,
+                            LocalDateTime chegadaPrevista,
+                            LocalDateTime atracacaoPrevista,
+                            LocalDateTime partidaPrevista,
+                            LocalDateTime chegadaEfetiva,
+                            LocalDateTime atracacaoEfetiva,
+                            LocalDateTime partidaEfetiva,
+                            String bercoPrevisto,
+                            String bercoAtual,
+                            String observacoes) {
+        this.id = id;
+        this.navioId = navioId;
+        this.nomeNavio = nomeNavio;
+        this.codigoImo = codigoImo;
+        this.viagemEntrada = viagemEntrada;
+        this.viagemSaida = viagemSaida;
+        this.fase = fase;
+        this.chegadaPrevista = chegadaPrevista;
+        this.atracacaoPrevista = atracacaoPrevista;
+        this.partidaPrevista = partidaPrevista;
+        this.chegadaEfetiva = chegadaEfetiva;
+        this.atracacaoEfetiva = atracacaoEfetiva;
+        this.partidaEfetiva = partidaEfetiva;
+        this.bercoPrevisto = bercoPrevisto;
+        this.bercoAtual = bercoAtual;
+        this.observacoes = observacoes;
+    }
+
+    public static EscalaDetalheDTO deEntidade(Escala escala) {
+        return new EscalaDetalheDTO(
+                escala.getId(),
+                escala.getNavio().getIdentificador(),
+                escala.getNavio().getNome(),
+                escala.getNavio().getCodigoImo(),
+                escala.getViagemEntrada(),
+                escala.getViagemSaida(),
+                escala.getFase(),
+                escala.getChegadaPrevista(),
+                escala.getAtracacaoPrevista(),
+                escala.getPartidaPrevista(),
+                escala.getChegadaEfetiva(),
+                escala.getAtracacaoEfetiva(),
+                escala.getPartidaEfetiva(),
+                escala.getBercoPrevisto(),
+                escala.getBercoAtual(),
+                escala.getObservacoes()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getNavioId() {
+        return navioId;
+    }
+
+    public String getNomeNavio() {
+        return nomeNavio;
+    }
+
+    public String getCodigoImo() {
+        return codigoImo;
+    }
+
+    public String getViagemEntrada() {
+        return viagemEntrada;
+    }
+
+    public String getViagemSaida() {
+        return viagemSaida;
+    }
+
+    public FaseEscala getFase() {
+        return fase;
+    }
+
+    public LocalDateTime getChegadaPrevista() {
+        return chegadaPrevista;
+    }
+
+    public LocalDateTime getAtracacaoPrevista() {
+        return atracacaoPrevista;
+    }
+
+    public LocalDateTime getPartidaPrevista() {
+        return partidaPrevista;
+    }
+
+    public LocalDateTime getChegadaEfetiva() {
+        return chegadaEfetiva;
+    }
+
+    public LocalDateTime getAtracacaoEfetiva() {
+        return atracacaoEfetiva;
+    }
+
+    public LocalDateTime getPartidaEfetiva() {
+        return partidaEfetiva;
+    }
+
+    public String getBercoPrevisto() {
+        return bercoPrevisto;
+    }
+
+    public String getBercoAtual() {
+        return bercoAtual;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/EscalaResumoDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/EscalaResumoDTO.java
@@ -1,0 +1,69 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public class EscalaResumoDTO {
+
+    private final Long id;
+    private final Long navioId;
+    private final String nomeNavio;
+    private final String codigoImo;
+    private final String viagemEntrada;
+    private final FaseEscala fase;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime chegadaPrevista;
+    private final String bercoPrevisto;
+
+    public EscalaResumoDTO(Long id,
+                           Long navioId,
+                           String nomeNavio,
+                           String codigoImo,
+                           String viagemEntrada,
+                           FaseEscala fase,
+                           LocalDateTime chegadaPrevista,
+                           String bercoPrevisto) {
+        this.id = id;
+        this.navioId = navioId;
+        this.nomeNavio = nomeNavio;
+        this.codigoImo = codigoImo;
+        this.viagemEntrada = viagemEntrada;
+        this.fase = fase;
+        this.chegadaPrevista = chegadaPrevista;
+        this.bercoPrevisto = bercoPrevisto;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getNavioId() {
+        return navioId;
+    }
+
+    public String getNomeNavio() {
+        return nomeNavio;
+    }
+
+    public String getCodigoImo() {
+        return codigoImo;
+    }
+
+    public String getViagemEntrada() {
+        return viagemEntrada;
+    }
+
+    public FaseEscala getFase() {
+        return fase;
+    }
+
+    public LocalDateTime getChegadaPrevista() {
+        return chegadaPrevista;
+    }
+
+    public String getBercoPrevisto() {
+        return bercoPrevisto;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/Escala.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/Escala.java
@@ -1,0 +1,213 @@
+package br.com.cloudport.serviconavio.escala.entidade;
+
+import br.com.cloudport.serviconavio.navio.entidade.Navio;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "escala")
+public class Escala {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "navio_id", nullable = false)
+    private Navio navio;
+
+    @Column(name = "viagem_entrada", nullable = false, length = 20)
+    private String viagemEntrada;
+
+    @Column(name = "viagem_saida", length = 20)
+    private String viagemSaida;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "fase", nullable = false, length = 20)
+    private FaseEscala fase;
+
+    @Column(name = "chegada_prevista", nullable = false)
+    private LocalDateTime chegadaPrevista;
+
+    @Column(name = "atracacao_prevista")
+    private LocalDateTime atracacaoPrevista;
+
+    @Column(name = "partida_prevista")
+    private LocalDateTime partidaPrevista;
+
+    @Column(name = "chegada_efetiva")
+    private LocalDateTime chegadaEfetiva;
+
+    @Column(name = "atracacao_efetiva")
+    private LocalDateTime atracacaoEfetiva;
+
+    @Column(name = "partida_efetiva")
+    private LocalDateTime partidaEfetiva;
+
+    @Column(name = "berco_previsto", length = 20)
+    private String bercoPrevisto;
+
+    @Column(name = "berco_atual", length = 20)
+    private String bercoAtual;
+
+    @Column(name = "observacoes", length = 500)
+    private String observacoes;
+
+    @Column(name = "criado_em", nullable = false)
+    private LocalDateTime criadoEm;
+
+    @Column(name = "atualizado_em", nullable = false)
+    private LocalDateTime atualizadoEm;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Navio getNavio() {
+        return navio;
+    }
+
+    public void setNavio(Navio navio) {
+        this.navio = navio;
+    }
+
+    public String getViagemEntrada() {
+        return viagemEntrada;
+    }
+
+    public void setViagemEntrada(String viagemEntrada) {
+        this.viagemEntrada = viagemEntrada;
+    }
+
+    public String getViagemSaida() {
+        return viagemSaida;
+    }
+
+    public void setViagemSaida(String viagemSaida) {
+        this.viagemSaida = viagemSaida;
+    }
+
+    public FaseEscala getFase() {
+        return fase;
+    }
+
+    public void setFase(FaseEscala fase) {
+        this.fase = fase;
+    }
+
+    public LocalDateTime getChegadaPrevista() {
+        return chegadaPrevista;
+    }
+
+    public void setChegadaPrevista(LocalDateTime chegadaPrevista) {
+        this.chegadaPrevista = chegadaPrevista;
+    }
+
+    public LocalDateTime getAtracacaoPrevista() {
+        return atracacaoPrevista;
+    }
+
+    public void setAtracacaoPrevista(LocalDateTime atracacaoPrevista) {
+        this.atracacaoPrevista = atracacaoPrevista;
+    }
+
+    public LocalDateTime getPartidaPrevista() {
+        return partidaPrevista;
+    }
+
+    public void setPartidaPrevista(LocalDateTime partidaPrevista) {
+        this.partidaPrevista = partidaPrevista;
+    }
+
+    public LocalDateTime getChegadaEfetiva() {
+        return chegadaEfetiva;
+    }
+
+    public void setChegadaEfetiva(LocalDateTime chegadaEfetiva) {
+        this.chegadaEfetiva = chegadaEfetiva;
+    }
+
+    public LocalDateTime getAtracacaoEfetiva() {
+        return atracacaoEfetiva;
+    }
+
+    public void setAtracacaoEfetiva(LocalDateTime atracacaoEfetiva) {
+        this.atracacaoEfetiva = atracacaoEfetiva;
+    }
+
+    public LocalDateTime getPartidaEfetiva() {
+        return partidaEfetiva;
+    }
+
+    public void setPartidaEfetiva(LocalDateTime partidaEfetiva) {
+        this.partidaEfetiva = partidaEfetiva;
+    }
+
+    public String getBercoPrevisto() {
+        return bercoPrevisto;
+    }
+
+    public void setBercoPrevisto(String bercoPrevisto) {
+        this.bercoPrevisto = bercoPrevisto;
+    }
+
+    public String getBercoAtual() {
+        return bercoAtual;
+    }
+
+    public void setBercoAtual(String bercoAtual) {
+        this.bercoAtual = bercoAtual;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public void setCriadoEm(LocalDateTime criadoEm) {
+        this.criadoEm = criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+
+    public void setAtualizadoEm(LocalDateTime atualizadoEm) {
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    @PrePersist
+    public void aoCriar() {
+        LocalDateTime agora = LocalDateTime.now();
+        this.criadoEm = agora;
+        this.atualizadoEm = agora;
+    }
+
+    @PreUpdate
+    public void aoAtualizar() {
+        this.atualizadoEm = LocalDateTime.now();
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/FaseEscala.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/FaseEscala.java
@@ -1,0 +1,44 @@
+package br.com.cloudport.serviconavio.escala.entidade;
+
+import java.util.Set;
+
+/**
+ * Fases de uma escala (vessel visit) inspiradas nas visit phases do Navis N4:
+ * Created -> Inbound -> Arrived/Working -> Departed -> Closed (e Canceled).
+ */
+public enum FaseEscala {
+    PREVISTA,
+    INBOUND,
+    ATRACADO,
+    OPERANDO,
+    PARTIU,
+    ENCERRADA,
+    CANCELADA;
+
+    private static Set<FaseEscala> transicoesPermitidas(FaseEscala fase) {
+        switch (fase) {
+            case PREVISTA:
+                return Set.of(INBOUND, ATRACADO, CANCELADA);
+            case INBOUND:
+                return Set.of(ATRACADO, CANCELADA);
+            case ATRACADO:
+                return Set.of(OPERANDO, PARTIU, CANCELADA);
+            case OPERANDO:
+                return Set.of(PARTIU);
+            case PARTIU:
+                return Set.of(ENCERRADA);
+            case ENCERRADA:
+            case CANCELADA:
+            default:
+                return Set.of();
+        }
+    }
+
+    public boolean podeTransicionarPara(FaseEscala destino) {
+        return destino != null && transicoesPermitidas(this).contains(destino);
+    }
+
+    public boolean isTerminal() {
+        return this == ENCERRADA || this == CANCELADA;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/repositorio/EscalaRepositorio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/repositorio/EscalaRepositorio.java
@@ -1,0 +1,22 @@
+package br.com.cloudport.serviconavio.escala.repositorio;
+
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EscalaRepositorio extends JpaRepository<Escala, Long> {
+
+    List<Escala> findByNavioIdentificadorOrderByChegadaPrevistaAsc(Long navioId);
+
+    @Query("SELECT e FROM Escala e "
+            + "WHERE e.chegadaPrevista BETWEEN :inicio AND :limite "
+            + "AND e.fase NOT IN :fasesExcluidas "
+            + "ORDER BY e.chegadaPrevista ASC")
+    List<Escala> buscarCronograma(@Param("inicio") LocalDateTime inicio,
+                                  @Param("limite") LocalDateTime limite,
+                                  @Param("fasesExcluidas") List<FaseEscala> fasesExcluidas);
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/servico/EscalaServico.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/servico/EscalaServico.java
@@ -1,0 +1,235 @@
+package br.com.cloudport.serviconavio.escala.servico;
+
+import br.com.cloudport.serviconavio.comum.validacao.SanitizadorEntrada;
+import br.com.cloudport.serviconavio.escala.dto.AtualizacaoEscalaDTO;
+import br.com.cloudport.serviconavio.escala.dto.CadastroEscalaDTO;
+import br.com.cloudport.serviconavio.escala.dto.EscalaDetalheDTO;
+import br.com.cloudport.serviconavio.escala.dto.EscalaResumoDTO;
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
+import br.com.cloudport.serviconavio.escala.repositorio.EscalaRepositorio;
+import br.com.cloudport.serviconavio.navio.entidade.Navio;
+import br.com.cloudport.serviconavio.navio.repositorio.NavioRepositorio;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+@Service
+public class EscalaServico {
+
+    private static final int DIAS_MAXIMO_CONSULTA = 60;
+    private static final List<FaseEscala> FASES_FORA_CRONOGRAMA =
+            List.of(FaseEscala.ENCERRADA, FaseEscala.CANCELADA);
+
+    private final EscalaRepositorio escalaRepositorio;
+    private final NavioRepositorio navioRepositorio;
+    private final SanitizadorEntrada sanitizadorEntrada;
+
+    public EscalaServico(EscalaRepositorio escalaRepositorio,
+                         NavioRepositorio navioRepositorio,
+                         SanitizadorEntrada sanitizadorEntrada) {
+        this.escalaRepositorio = escalaRepositorio;
+        this.navioRepositorio = navioRepositorio;
+        this.sanitizadorEntrada = sanitizadorEntrada;
+    }
+
+    @Transactional(readOnly = true)
+    public List<EscalaResumoDTO> listarCronograma(int dias) {
+        if (dias < 1 || dias > DIAS_MAXIMO_CONSULTA) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format(Locale.ROOT, "O intervalo de consulta deve estar entre 1 e %d dias.", DIAS_MAXIMO_CONSULTA));
+        }
+        LocalDateTime agora = LocalDateTime.now();
+        LocalDateTime inicio = agora.minusDays(1);
+        LocalDateTime limite = agora.plusDays(dias);
+        return escalaRepositorio.buscarCronograma(inicio, limite, FASES_FORA_CRONOGRAMA).stream()
+                .map(this::mapearResumo)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<EscalaResumoDTO> listarPorNavio(Long navioId) {
+        garantirNavioExiste(navioId);
+        return escalaRepositorio.findByNavioIdentificadorOrderByChegadaPrevistaAsc(navioId).stream()
+                .map(this::mapearResumo)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public EscalaDetalheDTO buscarDetalhe(Long id) {
+        return EscalaDetalheDTO.deEntidade(obterEscala(id));
+    }
+
+    @Transactional
+    public EscalaDetalheDTO registrar(Long navioId, CadastroEscalaDTO dto) {
+        Navio navio = obterNavio(navioId);
+        LocalDateTime chegada = dto.getChegadaPrevista();
+        validarOrdemTempos(chegada, dto.getAtracacaoPrevista(), dto.getPartidaPrevista());
+
+        Escala escala = new Escala();
+        escala.setNavio(navio);
+        escala.setFase(FaseEscala.PREVISTA);
+        escala.setViagemEntrada(sanitizadorEntrada
+                .limparTextoObrigatorio(dto.getViagemEntrada(), "viagem de entrada").toUpperCase(Locale.ROOT));
+        escala.setViagemSaida(tratarViagemOpcional(dto.getViagemSaida()));
+        escala.setChegadaPrevista(chegada);
+        escala.setAtracacaoPrevista(dto.getAtracacaoPrevista());
+        escala.setPartidaPrevista(dto.getPartidaPrevista());
+        escala.setBercoPrevisto(tratarTextoOpcional(dto.getBercoPrevisto()));
+        escala.setObservacoes(tratarTextoOpcional(dto.getObservacoes()));
+
+        return EscalaDetalheDTO.deEntidade(escalaRepositorio.save(escala));
+    }
+
+    @Transactional
+    public EscalaDetalheDTO atualizar(Long id, AtualizacaoEscalaDTO dto) {
+        Escala escala = obterEscala(id);
+        if (escala.getFase().isTerminal()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Não é possível alterar uma escala já encerrada ou cancelada.");
+        }
+
+        if (StringUtils.hasText(dto.getViagemEntrada())) {
+            escala.setViagemEntrada(sanitizadorEntrada
+                    .limparTextoObrigatorio(dto.getViagemEntrada(), "viagem de entrada").toUpperCase(Locale.ROOT));
+        }
+        if (dto.getViagemSaida() != null) {
+            escala.setViagemSaida(tratarViagemOpcional(dto.getViagemSaida()));
+        }
+        if (dto.getChegadaPrevista() != null) {
+            escala.setChegadaPrevista(dto.getChegadaPrevista());
+        }
+        if (dto.getAtracacaoPrevista() != null) {
+            escala.setAtracacaoPrevista(dto.getAtracacaoPrevista());
+        }
+        if (dto.getPartidaPrevista() != null) {
+            escala.setPartidaPrevista(dto.getPartidaPrevista());
+        }
+        if (dto.getBercoPrevisto() != null) {
+            escala.setBercoPrevisto(tratarTextoOpcional(dto.getBercoPrevisto()));
+        }
+        if (dto.getBercoAtual() != null) {
+            escala.setBercoAtual(tratarTextoOpcional(dto.getBercoAtual()));
+        }
+        if (dto.getObservacoes() != null) {
+            escala.setObservacoes(tratarTextoOpcional(dto.getObservacoes()));
+        }
+
+        validarOrdemTempos(escala.getChegadaPrevista(), escala.getAtracacaoPrevista(), escala.getPartidaPrevista());
+
+        return EscalaDetalheDTO.deEntidade(escalaRepositorio.save(escala));
+    }
+
+    @Transactional
+    public EscalaDetalheDTO avancarFase(Long id, FaseEscala destino) {
+        Escala escala = obterEscala(id);
+        if (destino == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe a fase de destino.");
+        }
+        if (escala.getFase() == destino) {
+            return EscalaDetalheDTO.deEntidade(escala);
+        }
+        if (!escala.getFase().podeTransicionarPara(destino)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    String.format(Locale.ROOT, "Transição de fase inválida: de %s para %s.",
+                            escala.getFase(), destino));
+        }
+
+        LocalDateTime agora = LocalDateTime.now();
+        carimbarTemposEfetivos(escala, destino, agora);
+        escala.setFase(destino);
+        return EscalaDetalheDTO.deEntidade(escalaRepositorio.save(escala));
+    }
+
+    @Transactional
+    public void remover(Long id) {
+        escalaRepositorio.delete(obterEscala(id));
+    }
+
+    private void carimbarTemposEfetivos(Escala escala, FaseEscala destino, LocalDateTime agora) {
+        if (destino == FaseEscala.ATRACADO) {
+            if (escala.getChegadaEfetiva() == null) {
+                escala.setChegadaEfetiva(agora);
+            }
+            if (escala.getAtracacaoEfetiva() == null) {
+                escala.setAtracacaoEfetiva(agora);
+            }
+        } else if (destino == FaseEscala.OPERANDO) {
+            if (escala.getChegadaEfetiva() == null) {
+                escala.setChegadaEfetiva(agora);
+            }
+            if (escala.getAtracacaoEfetiva() == null) {
+                escala.setAtracacaoEfetiva(agora);
+            }
+        } else if (destino == FaseEscala.PARTIU && escala.getPartidaEfetiva() == null) {
+            escala.setPartidaEfetiva(agora);
+        }
+    }
+
+    private void validarOrdemTempos(LocalDateTime chegada,
+                                    LocalDateTime atracacao,
+                                    LocalDateTime partida) {
+        if (chegada == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A chegada prevista é obrigatória.");
+        }
+        if (atracacao != null && atracacao.isBefore(chegada)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "A atracação prevista não pode ser anterior à chegada prevista.");
+        }
+        if (partida != null && partida.isBefore(chegada)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "A partida prevista não pode ser anterior à chegada prevista.");
+        }
+        if (partida != null && atracacao != null && partida.isBefore(atracacao)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "A partida prevista não pode ser anterior à atracação prevista.");
+        }
+    }
+
+    private void garantirNavioExiste(Long navioId) {
+        if (!navioRepositorio.existsById(navioId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Navio não encontrado.");
+        }
+    }
+
+    private Navio obterNavio(Long navioId) {
+        return navioRepositorio.findById(navioId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Navio não encontrado."));
+    }
+
+    private Escala obterEscala(Long id) {
+        return escalaRepositorio.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Escala não encontrada."));
+    }
+
+    private String tratarViagemOpcional(String valor) {
+        String limpo = tratarTextoOpcional(valor);
+        return limpo == null ? null : limpo.toUpperCase(Locale.ROOT);
+    }
+
+    private String tratarTextoOpcional(String valor) {
+        String limpo = sanitizadorEntrada.limparTexto(valor);
+        return StringUtils.hasText(limpo) ? limpo : null;
+    }
+
+    private EscalaResumoDTO mapearResumo(Escala escala) {
+        Navio navio = escala.getNavio();
+        return new EscalaResumoDTO(
+                escala.getId(),
+                navio.getIdentificador(),
+                navio.getNome(),
+                navio.getCodigoImo(),
+                escala.getViagemEntrada(),
+                escala.getFase(),
+                escala.getChegadaPrevista(),
+                escala.getBercoPrevisto()
+        );
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/dto/AtualizacaoNavioDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/dto/AtualizacaoNavioDTO.java
@@ -1,13 +1,11 @@
 package br.com.cloudport.serviconavio.navio.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import br.com.cloudport.serviconavio.navio.entidade.StatusOperacaoNavio;
-
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
 
 public class AtualizacaoNavioDTO {
 
@@ -26,26 +24,16 @@ public class AtualizacaoNavioDTO {
     @Positive(message = "A capacidade em TEU deve ser maior que zero.")
     private Integer capacidadeTeu;
 
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime dataPrevistaAtracacao;
+    @DecimalMin(value = "0.0", inclusive = false, message = "O comprimento (LOA) deve ser maior que zero.")
+    @Digits(integer = 4, fraction = 2, message = "O comprimento (LOA) deve ter no máximo 4 dígitos inteiros e 2 decimais.")
+    private BigDecimal loaMetros;
 
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime dataEfetivaAtracacao;
+    @DecimalMin(value = "0.0", inclusive = false, message = "O calado máximo deve ser maior que zero.")
+    @Digits(integer = 3, fraction = 2, message = "O calado máximo deve ter no máximo 3 dígitos inteiros e 2 decimais.")
+    private BigDecimal caladoMaximoMetros;
 
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime dataEfetivaDesatracacao;
-
-    @Size(max = 20, message = "O berço previsto deve ter no máximo 20 caracteres.")
-    private String bercoPrevisto;
-
-    @Size(max = 20, message = "O berço atual deve ter no máximo 20 caracteres.")
-    private String bercoAtual;
-
-    @Size(max = 500, message = "As observações devem ter no máximo 500 caracteres.")
-    private String observacoes;
-
-    @NotNull(message = "Informe o status da operação do navio.")
-    private StatusOperacaoNavio statusOperacao;
+    @Size(max = 15, message = "O call sign deve ter no máximo 15 caracteres.")
+    private String callSign;
 
     public AtualizacaoNavioDTO() {
     }
@@ -90,59 +78,27 @@ public class AtualizacaoNavioDTO {
         this.capacidadeTeu = capacidadeTeu;
     }
 
-    public LocalDateTime getDataPrevistaAtracacao() {
-        return dataPrevistaAtracacao;
+    public BigDecimal getLoaMetros() {
+        return loaMetros;
     }
 
-    public void setDataPrevistaAtracacao(LocalDateTime dataPrevistaAtracacao) {
-        this.dataPrevistaAtracacao = dataPrevistaAtracacao;
+    public void setLoaMetros(BigDecimal loaMetros) {
+        this.loaMetros = loaMetros;
     }
 
-    public LocalDateTime getDataEfetivaAtracacao() {
-        return dataEfetivaAtracacao;
+    public BigDecimal getCaladoMaximoMetros() {
+        return caladoMaximoMetros;
     }
 
-    public void setDataEfetivaAtracacao(LocalDateTime dataEfetivaAtracacao) {
-        this.dataEfetivaAtracacao = dataEfetivaAtracacao;
+    public void setCaladoMaximoMetros(BigDecimal caladoMaximoMetros) {
+        this.caladoMaximoMetros = caladoMaximoMetros;
     }
 
-    public LocalDateTime getDataEfetivaDesatracacao() {
-        return dataEfetivaDesatracacao;
+    public String getCallSign() {
+        return callSign;
     }
 
-    public void setDataEfetivaDesatracacao(LocalDateTime dataEfetivaDesatracacao) {
-        this.dataEfetivaDesatracacao = dataEfetivaDesatracacao;
-    }
-
-    public String getBercoPrevisto() {
-        return bercoPrevisto;
-    }
-
-    public void setBercoPrevisto(String bercoPrevisto) {
-        this.bercoPrevisto = bercoPrevisto;
-    }
-
-    public String getBercoAtual() {
-        return bercoAtual;
-    }
-
-    public void setBercoAtual(String bercoAtual) {
-        this.bercoAtual = bercoAtual;
-    }
-
-    public String getObservacoes() {
-        return observacoes;
-    }
-
-    public void setObservacoes(String observacoes) {
-        this.observacoes = observacoes;
-    }
-
-    public StatusOperacaoNavio getStatusOperacao() {
-        return statusOperacao;
-    }
-
-    public void setStatusOperacao(StatusOperacaoNavio statusOperacao) {
-        this.statusOperacao = statusOperacao;
+    public void setCallSign(String callSign) {
+        this.callSign = callSign;
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/dto/CadastroNavioDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/dto/CadastroNavioDTO.java
@@ -1,13 +1,13 @@
 package br.com.cloudport.serviconavio.navio.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
 
 public class CadastroNavioDTO {
 
@@ -31,15 +31,16 @@ public class CadastroNavioDTO {
     @Positive(message = "A capacidade em TEU deve ser maior que zero.")
     private Integer capacidadeTeu;
 
-    @NotNull(message = "Informe a data prevista de atracação.")
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime dataPrevistaAtracacao;
+    @DecimalMin(value = "0.0", inclusive = false, message = "O comprimento (LOA) deve ser maior que zero.")
+    @Digits(integer = 4, fraction = 2, message = "O comprimento (LOA) deve ter no máximo 4 dígitos inteiros e 2 decimais.")
+    private BigDecimal loaMetros;
 
-    @Size(max = 20, message = "O berço previsto deve ter no máximo 20 caracteres.")
-    private String bercoPrevisto;
+    @DecimalMin(value = "0.0", inclusive = false, message = "O calado máximo deve ser maior que zero.")
+    @Digits(integer = 3, fraction = 2, message = "O calado máximo deve ter no máximo 3 dígitos inteiros e 2 decimais.")
+    private BigDecimal caladoMaximoMetros;
 
-    @Size(max = 500, message = "As observações devem ter no máximo 500 caracteres.")
-    private String observacoes;
+    @Size(max = 15, message = "O call sign deve ter no máximo 15 caracteres.")
+    private String callSign;
 
     public CadastroNavioDTO() {
     }
@@ -84,27 +85,27 @@ public class CadastroNavioDTO {
         this.capacidadeTeu = capacidadeTeu;
     }
 
-    public LocalDateTime getDataPrevistaAtracacao() {
-        return dataPrevistaAtracacao;
+    public BigDecimal getLoaMetros() {
+        return loaMetros;
     }
 
-    public void setDataPrevistaAtracacao(LocalDateTime dataPrevistaAtracacao) {
-        this.dataPrevistaAtracacao = dataPrevistaAtracacao;
+    public void setLoaMetros(BigDecimal loaMetros) {
+        this.loaMetros = loaMetros;
     }
 
-    public String getBercoPrevisto() {
-        return bercoPrevisto;
+    public BigDecimal getCaladoMaximoMetros() {
+        return caladoMaximoMetros;
     }
 
-    public void setBercoPrevisto(String bercoPrevisto) {
-        this.bercoPrevisto = bercoPrevisto;
+    public void setCaladoMaximoMetros(BigDecimal caladoMaximoMetros) {
+        this.caladoMaximoMetros = caladoMaximoMetros;
     }
 
-    public String getObservacoes() {
-        return observacoes;
+    public String getCallSign() {
+        return callSign;
     }
 
-    public void setObservacoes(String observacoes) {
-        this.observacoes = observacoes;
+    public void setCallSign(String callSign) {
+        this.callSign = callSign;
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/dto/NavioDetalheDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/dto/NavioDetalheDTO.java
@@ -1,9 +1,6 @@
 package br.com.cloudport.serviconavio.navio.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import br.com.cloudport.serviconavio.navio.entidade.StatusOperacaoNavio;
-
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
 
 public class NavioDetalheDTO {
 
@@ -13,16 +10,9 @@ public class NavioDetalheDTO {
     private final String paisBandeira;
     private final String empresaArmadora;
     private final Integer capacidadeTeu;
-    private final StatusOperacaoNavio statusOperacao;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private final LocalDateTime dataPrevistaAtracacao;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private final LocalDateTime dataEfetivaAtracacao;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private final LocalDateTime dataEfetivaDesatracacao;
-    private final String bercoPrevisto;
-    private final String bercoAtual;
-    private final String observacoes;
+    private final BigDecimal loaMetros;
+    private final BigDecimal caladoMaximoMetros;
+    private final String callSign;
 
     public NavioDetalheDTO(Long identificador,
                            String nome,
@@ -30,26 +20,18 @@ public class NavioDetalheDTO {
                            String paisBandeira,
                            String empresaArmadora,
                            Integer capacidadeTeu,
-                           StatusOperacaoNavio statusOperacao,
-                           LocalDateTime dataPrevistaAtracacao,
-                           LocalDateTime dataEfetivaAtracacao,
-                           LocalDateTime dataEfetivaDesatracacao,
-                           String bercoPrevisto,
-                           String bercoAtual,
-                           String observacoes) {
+                           BigDecimal loaMetros,
+                           BigDecimal caladoMaximoMetros,
+                           String callSign) {
         this.identificador = identificador;
         this.nome = nome;
         this.codigoImo = codigoImo;
         this.paisBandeira = paisBandeira;
         this.empresaArmadora = empresaArmadora;
         this.capacidadeTeu = capacidadeTeu;
-        this.statusOperacao = statusOperacao;
-        this.dataPrevistaAtracacao = dataPrevistaAtracacao;
-        this.dataEfetivaAtracacao = dataEfetivaAtracacao;
-        this.dataEfetivaDesatracacao = dataEfetivaDesatracacao;
-        this.bercoPrevisto = bercoPrevisto;
-        this.bercoAtual = bercoAtual;
-        this.observacoes = observacoes;
+        this.loaMetros = loaMetros;
+        this.caladoMaximoMetros = caladoMaximoMetros;
+        this.callSign = callSign;
     }
 
     public Long getIdentificador() {
@@ -76,31 +58,15 @@ public class NavioDetalheDTO {
         return capacidadeTeu;
     }
 
-    public StatusOperacaoNavio getStatusOperacao() {
-        return statusOperacao;
+    public BigDecimal getLoaMetros() {
+        return loaMetros;
     }
 
-    public LocalDateTime getDataPrevistaAtracacao() {
-        return dataPrevistaAtracacao;
+    public BigDecimal getCaladoMaximoMetros() {
+        return caladoMaximoMetros;
     }
 
-    public LocalDateTime getDataEfetivaAtracacao() {
-        return dataEfetivaAtracacao;
-    }
-
-    public LocalDateTime getDataEfetivaDesatracacao() {
-        return dataEfetivaDesatracacao;
-    }
-
-    public String getBercoPrevisto() {
-        return bercoPrevisto;
-    }
-
-    public String getBercoAtual() {
-        return bercoAtual;
-    }
-
-    public String getObservacoes() {
-        return observacoes;
+    public String getCallSign() {
+        return callSign;
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/dto/NavioResumoDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/dto/NavioResumoDTO.java
@@ -1,32 +1,23 @@
 package br.com.cloudport.serviconavio.navio.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import br.com.cloudport.serviconavio.navio.entidade.StatusOperacaoNavio;
-
-import java.time.LocalDateTime;
-
 public class NavioResumoDTO {
 
     private final Long identificador;
     private final String nome;
     private final String codigoImo;
-    private final StatusOperacaoNavio statusOperacao;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private final LocalDateTime dataPrevistaAtracacao;
-    private final String bercoPrevisto;
+    private final String empresaArmadora;
+    private final Integer capacidadeTeu;
 
     public NavioResumoDTO(Long identificador,
                           String nome,
                           String codigoImo,
-                          StatusOperacaoNavio statusOperacao,
-                          LocalDateTime dataPrevistaAtracacao,
-                          String bercoPrevisto) {
+                          String empresaArmadora,
+                          Integer capacidadeTeu) {
         this.identificador = identificador;
         this.nome = nome;
         this.codigoImo = codigoImo;
-        this.statusOperacao = statusOperacao;
-        this.dataPrevistaAtracacao = dataPrevistaAtracacao;
-        this.bercoPrevisto = bercoPrevisto;
+        this.empresaArmadora = empresaArmadora;
+        this.capacidadeTeu = capacidadeTeu;
     }
 
     public Long getIdentificador() {
@@ -41,15 +32,11 @@ public class NavioResumoDTO {
         return codigoImo;
     }
 
-    public StatusOperacaoNavio getStatusOperacao() {
-        return statusOperacao;
+    public String getEmpresaArmadora() {
+        return empresaArmadora;
     }
 
-    public LocalDateTime getDataPrevistaAtracacao() {
-        return dataPrevistaAtracacao;
-    }
-
-    public String getBercoPrevisto() {
-        return bercoPrevisto;
+    public Integer getCapacidadeTeu() {
+        return capacidadeTeu;
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/entidade/Navio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/entidade/Navio.java
@@ -2,13 +2,11 @@ package br.com.cloudport.serviconavio.navio.entidade;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
 
 @Entity
 @Table(name = "navio")
@@ -34,27 +32,14 @@ public class Navio {
     @Column(name = "capacidade_teu", nullable = false)
     private Integer capacidadeTeu;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status_operacao", nullable = false, length = 30)
-    private StatusOperacaoNavio statusOperacao;
+    @Column(name = "loa_metros", precision = 6, scale = 2)
+    private BigDecimal loaMetros;
 
-    @Column(name = "data_prevista_atracacao", nullable = false)
-    private LocalDateTime dataPrevistaAtracacao;
+    @Column(name = "calado_maximo_metros", precision = 5, scale = 2)
+    private BigDecimal caladoMaximoMetros;
 
-    @Column(name = "data_efetiva_atracacao")
-    private LocalDateTime dataEfetivaAtracacao;
-
-    @Column(name = "data_efetiva_desatracacao")
-    private LocalDateTime dataEfetivaDesatracacao;
-
-    @Column(name = "berco_previsto", length = 20)
-    private String bercoPrevisto;
-
-    @Column(name = "berco_atual", length = 20)
-    private String bercoAtual;
-
-    @Column(name = "observacoes", length = 500)
-    private String observacoes;
+    @Column(name = "call_sign", length = 15)
+    private String callSign;
 
     public Long getIdentificador() {
         return identificador;
@@ -104,59 +89,27 @@ public class Navio {
         this.capacidadeTeu = capacidadeTeu;
     }
 
-    public StatusOperacaoNavio getStatusOperacao() {
-        return statusOperacao;
+    public BigDecimal getLoaMetros() {
+        return loaMetros;
     }
 
-    public void setStatusOperacao(StatusOperacaoNavio statusOperacao) {
-        this.statusOperacao = statusOperacao;
+    public void setLoaMetros(BigDecimal loaMetros) {
+        this.loaMetros = loaMetros;
     }
 
-    public LocalDateTime getDataPrevistaAtracacao() {
-        return dataPrevistaAtracacao;
+    public BigDecimal getCaladoMaximoMetros() {
+        return caladoMaximoMetros;
     }
 
-    public void setDataPrevistaAtracacao(LocalDateTime dataPrevistaAtracacao) {
-        this.dataPrevistaAtracacao = dataPrevistaAtracacao;
+    public void setCaladoMaximoMetros(BigDecimal caladoMaximoMetros) {
+        this.caladoMaximoMetros = caladoMaximoMetros;
     }
 
-    public LocalDateTime getDataEfetivaAtracacao() {
-        return dataEfetivaAtracacao;
+    public String getCallSign() {
+        return callSign;
     }
 
-    public void setDataEfetivaAtracacao(LocalDateTime dataEfetivaAtracacao) {
-        this.dataEfetivaAtracacao = dataEfetivaAtracacao;
-    }
-
-    public LocalDateTime getDataEfetivaDesatracacao() {
-        return dataEfetivaDesatracacao;
-    }
-
-    public void setDataEfetivaDesatracacao(LocalDateTime dataEfetivaDesatracacao) {
-        this.dataEfetivaDesatracacao = dataEfetivaDesatracacao;
-    }
-
-    public String getBercoPrevisto() {
-        return bercoPrevisto;
-    }
-
-    public void setBercoPrevisto(String bercoPrevisto) {
-        this.bercoPrevisto = bercoPrevisto;
-    }
-
-    public String getBercoAtual() {
-        return bercoAtual;
-    }
-
-    public void setBercoAtual(String bercoAtual) {
-        this.bercoAtual = bercoAtual;
-    }
-
-    public String getObservacoes() {
-        return observacoes;
-    }
-
-    public void setObservacoes(String observacoes) {
-        this.observacoes = observacoes;
+    public void setCallSign(String callSign) {
+        this.callSign = callSign;
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/entidade/StatusOperacaoNavio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/entidade/StatusOperacaoNavio.java
@@ -1,9 +1,0 @@
-package br.com.cloudport.serviconavio.navio.entidade;
-
-public enum StatusOperacaoNavio {
-    AGENDADO,
-    ATRACADO,
-    EM_OPERACAO,
-    CONCLUIDO,
-    CANCELADO
-}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/servico/NavioServico.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/navio/servico/NavioServico.java
@@ -6,7 +6,6 @@ import br.com.cloudport.serviconavio.navio.dto.CadastroNavioDTO;
 import br.com.cloudport.serviconavio.navio.dto.NavioDetalheDTO;
 import br.com.cloudport.serviconavio.navio.dto.NavioResumoDTO;
 import br.com.cloudport.serviconavio.navio.entidade.Navio;
-import br.com.cloudport.serviconavio.navio.entidade.StatusOperacaoNavio;
 import br.com.cloudport.serviconavio.navio.repositorio.NavioRepositorio;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +32,7 @@ public class NavioServico {
 
     @Transactional(readOnly = true)
     public List<NavioResumoDTO> listarResumo() {
-        return navioRepositorio.findAll(Sort.by(Sort.Direction.ASC, "dataPrevistaAtracacao")).stream()
+        return navioRepositorio.findAll(Sort.by(Sort.Direction.ASC, "nome")).stream()
                 .map(this::mapearResumo)
                 .collect(Collectors.toList());
     }
@@ -48,9 +47,9 @@ public class NavioServico {
     public NavioDetalheDTO registrar(CadastroNavioDTO dto) {
         Navio navio = new Navio();
         preencherDadosObrigatorios(dto, navio);
-        navio.setStatusOperacao(StatusOperacaoNavio.AGENDADO);
-        navio.setObservacoes(tratarTextoOpcional(dto.getObservacoes()));
-        navio.setBercoPrevisto(tratarTextoOpcional(dto.getBercoPrevisto()));
+        navio.setLoaMetros(dto.getLoaMetros());
+        navio.setCaladoMaximoMetros(dto.getCaladoMaximoMetros());
+        navio.setCallSign(tratarTextoOpcional(dto.getCallSign()));
         validarCodigoImoDisponivel(navio.getCodigoImo(), null);
         Navio salvo = navioRepositorio.save(navio);
         return mapearDetalhe(salvo);
@@ -77,26 +76,14 @@ public class NavioServico {
         if (dto.getCapacidadeTeu() != null) {
             navio.setCapacidadeTeu(dto.getCapacidadeTeu());
         }
-        if (dto.getDataPrevistaAtracacao() != null) {
-            navio.setDataPrevistaAtracacao(dto.getDataPrevistaAtracacao());
+        if (dto.getLoaMetros() != null) {
+            navio.setLoaMetros(dto.getLoaMetros());
         }
-        if (dto.getDataEfetivaAtracacao() != null) {
-            navio.setDataEfetivaAtracacao(dto.getDataEfetivaAtracacao());
+        if (dto.getCaladoMaximoMetros() != null) {
+            navio.setCaladoMaximoMetros(dto.getCaladoMaximoMetros());
         }
-        if (dto.getDataEfetivaDesatracacao() != null) {
-            navio.setDataEfetivaDesatracacao(dto.getDataEfetivaDesatracacao());
-        }
-        if (dto.getBercoPrevisto() != null) {
-            navio.setBercoPrevisto(tratarTextoOpcional(dto.getBercoPrevisto()));
-        }
-        if (dto.getBercoAtual() != null) {
-            navio.setBercoAtual(tratarTextoOpcional(dto.getBercoAtual()));
-        }
-        if (dto.getObservacoes() != null) {
-            navio.setObservacoes(tratarTextoOpcional(dto.getObservacoes()));
-        }
-        if (dto.getStatusOperacao() != null) {
-            navio.setStatusOperacao(dto.getStatusOperacao());
+        if (dto.getCallSign() != null) {
+            navio.setCallSign(tratarTextoOpcional(dto.getCallSign()));
         }
         Navio salvo = navioRepositorio.save(navio);
         return mapearDetalhe(salvo);
@@ -120,7 +107,6 @@ public class NavioServico {
         navio.setPaisBandeira(sanitizadorEntrada.limparTextoObrigatorio(dto.getPaisBandeira(), "país da bandeira"));
         navio.setEmpresaArmadora(sanitizadorEntrada.limparTextoObrigatorio(dto.getEmpresaArmadora(), "empresa armadora"));
         navio.setCapacidadeTeu(dto.getCapacidadeTeu());
-        navio.setDataPrevistaAtracacao(dto.getDataPrevistaAtracacao());
     }
 
     private void validarCodigoImoDisponivel(String codigoImo, Long identificadorAtual) {
@@ -143,9 +129,8 @@ public class NavioServico {
                 navio.getIdentificador(),
                 navio.getNome(),
                 navio.getCodigoImo(),
-                navio.getStatusOperacao(),
-                navio.getDataPrevistaAtracacao(),
-                navio.getBercoPrevisto()
+                navio.getEmpresaArmadora(),
+                navio.getCapacidadeTeu()
         );
     }
 
@@ -157,13 +142,9 @@ public class NavioServico {
                 navio.getPaisBandeira(),
                 navio.getEmpresaArmadora(),
                 navio.getCapacidadeTeu(),
-                navio.getStatusOperacao(),
-                navio.getDataPrevistaAtracacao(),
-                navio.getDataEfetivaAtracacao(),
-                navio.getDataEfetivaDesatracacao(),
-                navio.getBercoPrevisto(),
-                navio.getBercoAtual(),
-                navio.getObservacoes()
+                navio.getLoaMetros(),
+                navio.getCaladoMaximoMetros(),
+                navio.getCallSign()
         );
     }
 }

--- a/backend/servico-navio/src/main/resources/db/migration/V2__criar_tabela_escala.sql
+++ b/backend/servico-navio/src/main/resources/db/migration/V2__criar_tabela_escala.sql
@@ -1,0 +1,75 @@
+CREATE TABLE IF NOT EXISTS escala (
+    id BIGSERIAL PRIMARY KEY,
+    navio_id BIGINT NOT NULL REFERENCES navio (identificador),
+    viagem_entrada VARCHAR(20) NOT NULL,
+    viagem_saida VARCHAR(20),
+    fase VARCHAR(20) NOT NULL,
+    chegada_prevista TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    atracacao_prevista TIMESTAMP WITHOUT TIME ZONE,
+    partida_prevista TIMESTAMP WITHOUT TIME ZONE,
+    chegada_efetiva TIMESTAMP WITHOUT TIME ZONE,
+    atracacao_efetiva TIMESTAMP WITHOUT TIME ZONE,
+    partida_efetiva TIMESTAMP WITHOUT TIME ZONE,
+    berco_previsto VARCHAR(20),
+    berco_atual VARCHAR(20),
+    observacoes VARCHAR(500),
+    criado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    atualizado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_escala_fase ON escala (fase);
+CREATE INDEX IF NOT EXISTS idx_escala_chegada_prevista ON escala (chegada_prevista);
+CREATE INDEX IF NOT EXISTS idx_escala_navio ON escala (navio_id);
+
+-- Migra os dados de escala que hoje residem na tabela navio para uma escala inicial por navio.
+INSERT INTO escala (
+    navio_id,
+    viagem_entrada,
+    fase,
+    chegada_prevista,
+    atracacao_prevista,
+    chegada_efetiva,
+    atracacao_efetiva,
+    partida_efetiva,
+    berco_previsto,
+    berco_atual,
+    observacoes,
+    criado_em,
+    atualizado_em
+)
+SELECT
+    identificador,
+    'MIGRACAO',
+    CASE status_operacao
+        WHEN 'AGENDADO' THEN 'PREVISTA'
+        WHEN 'ATRACADO' THEN 'ATRACADO'
+        WHEN 'EM_OPERACAO' THEN 'OPERANDO'
+        WHEN 'CONCLUIDO' THEN 'ENCERRADA'
+        WHEN 'CANCELADO' THEN 'CANCELADA'
+        ELSE 'PREVISTA'
+    END,
+    data_prevista_atracacao,
+    data_prevista_atracacao,
+    data_efetiva_atracacao,
+    data_efetiva_atracacao,
+    data_efetiva_desatracacao,
+    berco_previsto,
+    berco_atual,
+    observacoes,
+    NOW(),
+    NOW()
+FROM navio;
+
+-- Acrescenta atributos físicos do navio (vessel master) inspirados no Vessel Class do Navis N4.
+ALTER TABLE navio ADD COLUMN IF NOT EXISTS loa_metros NUMERIC(6, 2);
+ALTER TABLE navio ADD COLUMN IF NOT EXISTS calado_maximo_metros NUMERIC(5, 2);
+ALTER TABLE navio ADD COLUMN IF NOT EXISTS call_sign VARCHAR(15);
+
+-- Remove os campos de escala que passam a pertencer à tabela escala.
+ALTER TABLE navio DROP COLUMN IF EXISTS status_operacao;
+ALTER TABLE navio DROP COLUMN IF EXISTS data_prevista_atracacao;
+ALTER TABLE navio DROP COLUMN IF EXISTS data_efetiva_atracacao;
+ALTER TABLE navio DROP COLUMN IF EXISTS data_efetiva_desatracacao;
+ALTER TABLE navio DROP COLUMN IF EXISTS berco_previsto;
+ALTER TABLE navio DROP COLUMN IF EXISTS berco_atual;
+ALTER TABLE navio DROP COLUMN IF EXISTS observacoes;

--- a/backend/servico-navio/src/test/java/br/com/cloudport/serviconavio/escala/servico/EscalaServicoTest.java
+++ b/backend/servico-navio/src/test/java/br/com/cloudport/serviconavio/escala/servico/EscalaServicoTest.java
@@ -1,0 +1,146 @@
+package br.com.cloudport.serviconavio.escala.servico;
+
+import br.com.cloudport.serviconavio.comum.validacao.SanitizadorEntrada;
+import br.com.cloudport.serviconavio.escala.dto.AtualizacaoEscalaDTO;
+import br.com.cloudport.serviconavio.escala.dto.CadastroEscalaDTO;
+import br.com.cloudport.serviconavio.escala.dto.EscalaDetalheDTO;
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
+import br.com.cloudport.serviconavio.escala.repositorio.EscalaRepositorio;
+import br.com.cloudport.serviconavio.navio.entidade.Navio;
+import br.com.cloudport.serviconavio.navio.repositorio.NavioRepositorio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EscalaServicoTest {
+
+    private EscalaRepositorio escalaRepositorio;
+    private NavioRepositorio navioRepositorio;
+    private SanitizadorEntrada sanitizadorEntrada;
+    private EscalaServico escalaServico;
+
+    @BeforeEach
+    void preparar() {
+        escalaRepositorio = mock(EscalaRepositorio.class);
+        navioRepositorio = mock(NavioRepositorio.class);
+        sanitizadorEntrada = mock(SanitizadorEntrada.class);
+        when(sanitizadorEntrada.limparTextoObrigatorio(anyString(), anyString()))
+                .thenAnswer(invocacao -> invocacao.getArgument(0));
+        when(sanitizadorEntrada.limparTexto(anyString()))
+                .thenAnswer(invocacao -> invocacao.getArgument(0));
+        when(escalaRepositorio.save(any(Escala.class))).thenAnswer(invocacao -> invocacao.getArgument(0));
+        escalaServico = new EscalaServico(escalaRepositorio, navioRepositorio, sanitizadorEntrada);
+    }
+
+    private Navio navio() {
+        Navio navio = new Navio();
+        navio.setIdentificador(10L);
+        navio.setNome("Navio Teste");
+        navio.setCodigoImo("IMO1234567");
+        return navio;
+    }
+
+    private Escala escalaComFase(FaseEscala fase) {
+        Escala escala = new Escala();
+        escala.setId(1L);
+        escala.setNavio(navio());
+        escala.setViagemEntrada("V001N");
+        escala.setFase(fase);
+        escala.setChegadaPrevista(LocalDateTime.of(2026, 5, 23, 8, 0));
+        return escala;
+    }
+
+    @Test
+    void registrarIniciaFasePrevistaENormalizaViagem() {
+        when(navioRepositorio.findById(10L)).thenReturn(Optional.of(navio()));
+        CadastroEscalaDTO dto = new CadastroEscalaDTO();
+        dto.setViagemEntrada("v001n");
+        dto.setChegadaPrevista(LocalDateTime.of(2026, 5, 23, 8, 0));
+        dto.setPartidaPrevista(LocalDateTime.of(2026, 5, 24, 8, 0));
+
+        EscalaDetalheDTO resultado = escalaServico.registrar(10L, dto);
+
+        assertThat(resultado.getFase()).isEqualTo(FaseEscala.PREVISTA);
+        assertThat(resultado.getViagemEntrada()).isEqualTo("V001N");
+    }
+
+    @Test
+    void registrarRejeitaPartidaAnteriorAChegada() {
+        when(navioRepositorio.findById(10L)).thenReturn(Optional.of(navio()));
+        CadastroEscalaDTO dto = new CadastroEscalaDTO();
+        dto.setViagemEntrada("V001N");
+        dto.setChegadaPrevista(LocalDateTime.of(2026, 5, 23, 8, 0));
+        dto.setPartidaPrevista(LocalDateTime.of(2026, 5, 22, 8, 0));
+
+        assertThatThrownBy(() -> escalaServico.registrar(10L, dto))
+                .isInstanceOf(ResponseStatusException.class);
+
+        verify(escalaRepositorio, never()).save(any());
+    }
+
+    @Test
+    void registrarRejeitaNavioInexistente() {
+        when(navioRepositorio.findById(99L)).thenReturn(Optional.empty());
+        CadastroEscalaDTO dto = new CadastroEscalaDTO();
+        dto.setViagemEntrada("V001N");
+        dto.setChegadaPrevista(LocalDateTime.of(2026, 5, 23, 8, 0));
+
+        assertThatThrownBy(() -> escalaServico.registrar(99L, dto))
+                .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void avancarFaseParaAtracadoCarimbaTemposEfetivos() {
+        when(escalaRepositorio.findById(1L)).thenReturn(Optional.of(escalaComFase(FaseEscala.PREVISTA)));
+
+        EscalaDetalheDTO resultado = escalaServico.avancarFase(1L, FaseEscala.ATRACADO);
+
+        assertThat(resultado.getFase()).isEqualTo(FaseEscala.ATRACADO);
+        assertThat(resultado.getChegadaEfetiva()).isNotNull();
+        assertThat(resultado.getAtracacaoEfetiva()).isNotNull();
+        assertThat(resultado.getPartidaEfetiva()).isNull();
+    }
+
+    @Test
+    void avancarFaseParaPartiuCarimbaPartidaEfetiva() {
+        when(escalaRepositorio.findById(1L)).thenReturn(Optional.of(escalaComFase(FaseEscala.OPERANDO)));
+
+        EscalaDetalheDTO resultado = escalaServico.avancarFase(1L, FaseEscala.PARTIU);
+
+        assertThat(resultado.getFase()).isEqualTo(FaseEscala.PARTIU);
+        assertThat(resultado.getPartidaEfetiva()).isNotNull();
+    }
+
+    @Test
+    void avancarFaseRejeitaTransicaoInvalida() {
+        when(escalaRepositorio.findById(1L)).thenReturn(Optional.of(escalaComFase(FaseEscala.PREVISTA)));
+
+        assertThatThrownBy(() -> escalaServico.avancarFase(1L, FaseEscala.OPERANDO))
+                .isInstanceOf(ResponseStatusException.class);
+
+        verify(escalaRepositorio, never()).save(any());
+    }
+
+    @Test
+    void atualizarRejeitaEscalaTerminal() {
+        when(escalaRepositorio.findById(1L)).thenReturn(Optional.of(escalaComFase(FaseEscala.ENCERRADA)));
+
+        assertThatThrownBy(() -> escalaServico.atualizar(1L, new AtualizacaoEscalaDTO()))
+                .isInstanceOf(ResponseStatusException.class);
+
+        verify(escalaRepositorio, never()).save(any());
+    }
+}

--- a/backend/servico-navio/src/test/java/br/com/cloudport/serviconavio/navio/servico/NavioServicoTest.java
+++ b/backend/servico-navio/src/test/java/br/com/cloudport/serviconavio/navio/servico/NavioServicoTest.java
@@ -4,14 +4,13 @@ import br.com.cloudport.serviconavio.comum.validacao.SanitizadorEntrada;
 import br.com.cloudport.serviconavio.navio.dto.CadastroNavioDTO;
 import br.com.cloudport.serviconavio.navio.dto.NavioDetalheDTO;
 import br.com.cloudport.serviconavio.navio.entidade.Navio;
-import br.com.cloudport.serviconavio.navio.entidade.StatusOperacaoNavio;
 import br.com.cloudport.serviconavio.navio.repositorio.NavioRepositorio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,12 +46,14 @@ class NavioServicoTest {
         dto.setPaisBandeira("Brasil");
         dto.setEmpresaArmadora("Armadora X");
         dto.setCapacidadeTeu(5000);
-        dto.setDataPrevistaAtracacao(LocalDateTime.of(2026, 5, 23, 8, 0));
+        dto.setLoaMetros(new BigDecimal("294.00"));
+        dto.setCaladoMaximoMetros(new BigDecimal("14.50"));
+        dto.setCallSign("PWXY");
         return dto;
     }
 
     @Test
-    void registrarDefineStatusAgendadoeNormalizaCodigoImo() {
+    void registrarNormalizaCodigoImoEPreservaAtributosFisicos() {
         when(navioRepositorio.existsByCodigoImoIgnoreCase(anyString())).thenReturn(false);
         when(navioRepositorio.save(any(Navio.class))).thenAnswer(invocacao -> {
             Navio navio = invocacao.getArgument(0);
@@ -66,9 +67,11 @@ class NavioServicoTest {
         ArgumentCaptor<Navio> capturado = ArgumentCaptor.forClass(Navio.class);
         verify(navioRepositorio).save(capturado.capture());
         Navio salvo = capturado.getValue();
-        assertThat(salvo.getStatusOperacao()).isEqualTo(StatusOperacaoNavio.AGENDADO);
         assertThat(salvo.getCodigoImo()).isEqualTo("IMO1234567");
         assertThat(salvo.getNome()).isEqualTo("Navio Teste");
+        assertThat(salvo.getLoaMetros()).isEqualByComparingTo("294.00");
+        assertThat(salvo.getCaladoMaximoMetros()).isEqualByComparingTo("14.50");
+        assertThat(salvo.getCallSign()).isEqualTo("PWXY");
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR introduces a complete vessel scheduling (escala) management system to track ship visits to port, including their phases, arrival/departure times, and berth assignments. It also refactors the Navio entity to separate vessel master data from operational scheduling concerns.

## Key Changes

### New Escala (Vessel Schedule) Module
- **EscalaServico**: Core business logic for managing vessel schedules with support for:
  - Listing schedules by date range (cronograma) with configurable day limits (max 60 days)
  - Filtering schedules by vessel
  - Creating and updating schedules with validation
  - Phase transitions with state machine validation
  - Automatic timestamp stamping for actual arrival/departure/berthing times
  
- **Escala Entity**: JPA entity representing a vessel visit with:
  - Planned times (chegada_prevista, atracacao_prevista, partida_prevista)
  - Actual times (chegada_efetiva, atracacao_efetiva, partida_efetiva)
  - Berth information (planned and current)
  - Voyage identifiers (inbound/outbound)
  - Audit timestamps (criado_em, atualizado_em)

- **FaseEscala Enum**: State machine for schedule phases:
  - PREVISTA → INBOUND → ATRACADO → OPERANDO → PARTIU → ENCERRADA
  - CANCELADA as terminal state from any non-terminal phase
  - Validates allowed transitions

- **EscalaControlador**: REST endpoints for:
  - GET /escalas - List schedules with configurable date range
  - GET /escalas/{id} - Get schedule details
  - POST /escalas/{navioId} - Create new schedule
  - PUT /escalas/{id} - Update schedule
  - PATCH /escalas/{id}/avancar-fase - Advance schedule phase
  - DELETE /escalas/{id} - Remove schedule

- **DTOs**: CadastroEscalaDTO, AtualizacaoEscalaDTO, EscalaDetalheDTO, EscalaResumoDTO with proper validation annotations

### Navio Entity Refactoring
- **Removed operational fields** from Navio (moved to Escala):
  - statusOperacao, dataPrevistaAtracacao, dataEfetivaAtracacao, dataEfetivaDesatracacao
  - bercoPrevisto, bercoAtual, observacoes
  
- **Added vessel master data fields**:
  - loaMetros (Length Overall) - BigDecimal with precision 6,2
  - caladoMaximoMetros (Maximum Draft) - BigDecimal with precision 5,2
  - callSign - vessel radio call sign (max 15 chars)

- **Updated DTOs** (CadastroNavioDTO, AtualizacaoNavioDTO, NavioDetalheDTO, NavioResumoDTO) to reflect new fields and remove scheduling concerns

- **Removed StatusOperacaoNavio enum** - no longer needed as scheduling is now in Escala

### Database Migration
- **V2__criar_tabela_escala.sql**: Creates escala table with proper indexes on fase, chegada_prevista, and navio_id
- Migrates existing vessel data from navio table to escala table with phase mapping
- Adds new physical vessel attributes to navio table
- Removes obsolete scheduling columns from navio table

### Testing
- **EscalaServicoTest**: Comprehensive unit tests covering:
  - Schedule registration with phase initialization and voyage normalization
  - Time validation (departure cannot be before arrival)
  - Non-existent vessel rejection
  - Phase advancement with state machine validation
  - Terminal phase protection against updates

## Notable Implementation Details
- Input sanitization via SanitizadorEntrada for voyage identifiers (uppercase normalization)
- Transactional boundaries with @Transactional annotations
- Lazy loading for Navio relationship in Escala
- Automatic timestamp management via @PrePersist and @PreUpdate
- Comprehensive validation with custom error messages
- Separation of concerns: vessel master data vs. operational scheduling

https://claude.ai/code/session_0124hSrsgg5JLbWYYC4PeSvP