### PR TITLE
Tela de planejamento de operação de navios (escalas)

### DIFF
--- a/backend/servico-autenticacao/src/main/resources/db/migration/V8__inserir_abas_navegacao_navio.sql
+++ b/backend/servico-autenticacao/src/main/resources/db/migration/V8__inserir_abas_navegacao_navio.sql
@@ -1,0 +1,14 @@
+INSERT INTO configuracoes_navegacao (
+    identificador,
+    rotulo,
+    rota,
+    grupo,
+    roles_permitidos,
+    desabilitado,
+    mensagem_em_breve,
+    ordem,
+    padrao
+) VALUES
+    ('navio/escalas', 'Cronograma de Escalas', 'navio/escalas', 'NAVIO', 'ROLE_ADMIN_PORTO,ROLE_PLANEJADOR', FALSE, NULL, 20, FALSE),
+    ('navio/navios', 'Navios Cadastrados', 'navio/navios', 'NAVIO', 'ROLE_ADMIN_PORTO,ROLE_PLANEJADOR', FALSE, NULL, 21, FALSE)
+ON CONFLICT (identificador) DO NOTHING;

--- a/frontend/cloudport/src/app/app-routing.module.ts
+++ b/frontend/cloudport/src/app/app-routing.module.ts
@@ -52,6 +52,12 @@ const homeChildRoutes: Routes = [
     canActivate: [AuthGuard],
     canLoad: [AuthGuard],
     loadChildren: () => import('./componentes/patio/patio.module').then(m => m.PatioModule)
+  },
+  {
+    path: 'navio',
+    canActivate: [AuthGuard],
+    canLoad: [AuthGuard],
+    loadChildren: () => import('./componentes/navio/navio.module').then(m => m.NavioModule)
   }
 ];
 

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
@@ -68,6 +68,23 @@
         </li>
       </ul>
     </li>
+    <li *ngIf="navioTabs.length" (click)="toggleSubmenu($event)">
+      <button type="button" class="submenu-trigger">Navio</button>
+      <ul>
+        <li *ngFor="let tab of navioTabs">
+          <button
+            type="button"
+            class="submenu-item"
+            [class.coming-soon]="tab.disabled"
+            [disabled]="tab.disabled"
+            (click)="handleTabSelection($event, tab)"
+          >
+            <span>{{ tab.label }}</span>
+            <span *ngIf="tab.disabled" class="submenu-badge">{{ tab.comingSoonMessage || 'Em breve' }}</span>
+          </button>
+        </li>
+      </ul>
+    </li>
     <li *ngIf="userTabs.length" (click)="toggleSubmenu($event)">
       <button type="button" class="submenu-trigger">Usuários</button>
       <ul>

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -19,6 +19,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
   private readonly grupoGate = 'GATE';
   private readonly grupoFerrovia = 'FERROVIA';
   private readonly grupoPatio = 'PATIO';
+  private readonly grupoNavio = 'NAVIO';
 
   constructor(
     private readonly servicoAutenticacao: ServicoAutenticacao,
@@ -57,6 +58,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   get yardTabs(): RegistroAba[] {
     return this.obterAbasPorGrupo(this.grupoPatio);
+  }
+
+  get navioTabs(): RegistroAba[] {
+    return this.obterAbasPorGrupo(this.grupoNavio);
   }
 
   openTab(tab: RegistroAba): void {

--- a/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.css
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.css
@@ -1,0 +1,260 @@
+.detalhe-escala {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  max-width: 960px;
+}
+
+.link-voltar {
+  align-self: flex-start;
+  border: none;
+  background: none;
+  color: #005f9e;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0;
+}
+
+.link-voltar:hover {
+  text-decoration: underline;
+}
+
+.cabecalho {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.cabecalho h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.subtitulo {
+  margin: 4px 0 0;
+  color: #555;
+}
+
+.painel {
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+  border-radius: 6px;
+  padding: 16px;
+}
+
+.painel h2 {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+}
+
+.cabecalho-painel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.botoes-fase {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.botao-fase {
+  padding: 9px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #1b6b3a;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.botao-fase:hover:not(:disabled),
+.botao-fase:focus:not(:disabled) {
+  background-color: #14512c;
+}
+
+.grade-dados {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px 24px;
+  margin: 0;
+}
+
+.grade-dados dt {
+  font-size: 0.82rem;
+  color: #6a7480;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.grade-dados dd {
+  margin: 2px 0 0;
+  font-size: 1rem;
+  color: #1f2933;
+}
+
+.observacoes {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid #eee;
+}
+
+.observacoes dt {
+  font-size: 0.82rem;
+  color: #6a7480;
+  text-transform: uppercase;
+}
+
+.observacoes dd {
+  margin: 4px 0 0;
+  white-space: pre-wrap;
+}
+
+.formulario {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.linha {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.linha .campo {
+  flex: 1 1 200px;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.campo label {
+  font-size: 0.9rem;
+  color: #333;
+  font-weight: 600;
+}
+
+.campo input,
+.campo textarea {
+  padding: 8px 10px;
+  border: 1px solid #c5c5c5;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.campo input:focus,
+.campo textarea:focus {
+  outline: 2px solid #005f9e;
+  outline-offset: -1px;
+  border-color: #005f9e;
+}
+
+.acoes {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.botao-primario {
+  padding: 9px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #005f9e;
+  color: #fff;
+  cursor: pointer;
+}
+
+.botao-primario:hover:not(:disabled),
+.botao-primario:focus:not(:disabled) {
+  background-color: #004b7a;
+}
+
+.botao-secundario {
+  padding: 9px 16px;
+  border: 1px solid #9aa5b1;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #44515f;
+  cursor: pointer;
+}
+
+.botao-secundario:hover:not(:disabled),
+.botao-secundario:focus:not(:disabled) {
+  background-color: #eef1f4;
+}
+
+.zona-perigo {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.botao-perigo {
+  padding: 9px 16px;
+  border: 1px solid #c62828;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #c62828;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.botao-perigo:hover:not(:disabled),
+.botao-perigo:focus:not(:disabled) {
+  background-color: #c62828;
+  color: #fff;
+}
+
+.botao-primario:disabled,
+.botao-secundario:disabled,
+.botao-fase:disabled,
+.botao-perigo:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.estado-informativo {
+  padding: 12px;
+  background-color: #eef5ff;
+  border-left: 4px solid #005f9e;
+  color: #003b63;
+}
+
+.estado-erro {
+  padding: 12px;
+  background-color: #ffecec;
+  border-left: 4px solid #c62828;
+  color: #7f1d1d;
+}
+
+.estado-sucesso {
+  padding: 12px;
+  background-color: #e6f6ec;
+  border-left: 4px solid #1b6b3a;
+  color: #14512c;
+}
+
+.fase-tag {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.fase-prevista { background-color: #e3eefc; color: #1d4e89; }
+.fase-inbound { background-color: #e7f0ff; color: #0b5cad; }
+.fase-atracado { background-color: #fff4d6; color: #8a6100; }
+.fase-operando { background-color: #d8f3e0; color: #1b6b3a; }
+.fase-partiu { background-color: #e6e6e6; color: #444; }
+.fase-encerrada { background-color: #dfe3e8; color: #2c3338; }
+.fase-cancelada { background-color: #ffe0e0; color: #a02020; }

--- a/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.html
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.html
@@ -1,0 +1,114 @@
+<section class="detalhe-escala">
+  <button type="button" class="link-voltar" (click)="voltar()">← Voltar ao cronograma</button>
+
+  <div *ngIf="estaCarregando" class="estado-informativo">Carregando escala...</div>
+  <div *ngIf="erro" class="estado-erro">{{ textoSeguro(erro) }}</div>
+  <div *ngIf="mensagem" class="estado-sucesso">{{ textoSeguro(mensagem) }}</div>
+
+  <ng-container *ngIf="escala && !estaCarregando">
+    <header class="cabecalho">
+      <div>
+        <h1>{{ textoSeguro(escala.nomeNavio) }}</h1>
+        <p class="subtitulo">
+          IMO {{ textoSeguro(escala.codigoImo) }} · Viagem {{ textoSeguro(escala.viagemEntrada) }}
+          <span *ngIf="escala.viagemSaida"> / {{ textoSeguro(escala.viagemSaida) }}</span>
+        </p>
+      </div>
+      <span [class]="classeFase(escala.fase)">{{ rotuloFase(escala.fase) }}</span>
+    </header>
+
+    <div class="painel" *ngIf="transicoesDisponiveis.length > 0">
+      <h2>Avançar operação</h2>
+      <div class="botoes-fase">
+        <button
+          *ngFor="let destino of transicoesDisponiveis"
+          type="button"
+          class="botao-fase"
+          [disabled]="processando"
+          (click)="avancarFase(destino)"
+        >
+          {{ rotuloFase(destino) }}
+        </button>
+      </div>
+    </div>
+
+    <div class="painel" *ngIf="transicoesDisponiveis.length === 0">
+      <p class="estado-informativo">Esta escala está em uma fase final e não admite novas transições.</p>
+    </div>
+
+    <!-- Modo leitura -->
+    <div class="painel" *ngIf="!modoEdicao">
+      <div class="cabecalho-painel">
+        <h2>Tempos e berços</h2>
+        <button type="button" class="botao-secundario" (click)="iniciarEdicao()" [disabled]="processando">Editar</button>
+      </div>
+      <dl class="grade-dados">
+        <div><dt>Chegada prevista (ETA)</dt><dd>{{ (escala.chegadaPrevista | date:'dd/MM/yyyy HH:mm') || '—' }}</dd></div>
+        <div><dt>Atracação prevista (ETB)</dt><dd>{{ (escala.atracacaoPrevista | date:'dd/MM/yyyy HH:mm') || '—' }}</dd></div>
+        <div><dt>Partida prevista (ETD)</dt><dd>{{ (escala.partidaPrevista | date:'dd/MM/yyyy HH:mm') || '—' }}</dd></div>
+        <div><dt>Chegada efetiva (ATA)</dt><dd>{{ (escala.chegadaEfetiva | date:'dd/MM/yyyy HH:mm') || '—' }}</dd></div>
+        <div><dt>Atracação efetiva (ATB)</dt><dd>{{ (escala.atracacaoEfetiva | date:'dd/MM/yyyy HH:mm') || '—' }}</dd></div>
+        <div><dt>Partida efetiva (ATD)</dt><dd>{{ (escala.partidaEfetiva | date:'dd/MM/yyyy HH:mm') || '—' }}</dd></div>
+        <div><dt>Berço previsto</dt><dd>{{ textoSeguro(escala.bercoPrevisto) || '—' }}</dd></div>
+        <div><dt>Berço atual</dt><dd>{{ textoSeguro(escala.bercoAtual) || '—' }}</dd></div>
+      </dl>
+      <div class="observacoes" *ngIf="escala.observacoes">
+        <dt>Observações</dt>
+        <dd>{{ textoSeguro(escala.observacoes) }}</dd>
+      </div>
+    </div>
+
+    <!-- Modo edição -->
+    <form class="painel formulario" *ngIf="modoEdicao" (ngSubmit)="salvarEdicao()">
+      <h2>Editar escala</h2>
+      <div class="linha">
+        <div class="campo">
+          <label for="ed-viagemEntrada">Viagem de entrada</label>
+          <input id="ed-viagemEntrada" name="ed-viagemEntrada" type="text" maxlength="20" [(ngModel)]="edicao.viagemEntrada" />
+        </div>
+        <div class="campo">
+          <label for="ed-viagemSaida">Viagem de saída</label>
+          <input id="ed-viagemSaida" name="ed-viagemSaida" type="text" maxlength="20" [(ngModel)]="edicao.viagemSaida" />
+        </div>
+      </div>
+      <div class="linha">
+        <div class="campo">
+          <label for="ed-chegadaPrevista">Chegada prevista (ETA)</label>
+          <input id="ed-chegadaPrevista" name="ed-chegadaPrevista" type="datetime-local" [(ngModel)]="edicao.chegadaPrevista" />
+        </div>
+        <div class="campo">
+          <label for="ed-atracacaoPrevista">Atracação prevista (ETB)</label>
+          <input id="ed-atracacaoPrevista" name="ed-atracacaoPrevista" type="datetime-local" [(ngModel)]="edicao.atracacaoPrevista" />
+        </div>
+        <div class="campo">
+          <label for="ed-partidaPrevista">Partida prevista (ETD)</label>
+          <input id="ed-partidaPrevista" name="ed-partidaPrevista" type="datetime-local" [(ngModel)]="edicao.partidaPrevista" />
+        </div>
+      </div>
+      <div class="linha">
+        <div class="campo">
+          <label for="ed-bercoPrevisto">Berço previsto</label>
+          <input id="ed-bercoPrevisto" name="ed-bercoPrevisto" type="text" maxlength="20" [(ngModel)]="edicao.bercoPrevisto" />
+        </div>
+        <div class="campo">
+          <label for="ed-bercoAtual">Berço atual</label>
+          <input id="ed-bercoAtual" name="ed-bercoAtual" type="text" maxlength="20" [(ngModel)]="edicao.bercoAtual" />
+        </div>
+      </div>
+      <div class="campo">
+        <label for="ed-observacoes">Observações</label>
+        <textarea id="ed-observacoes" name="ed-observacoes" maxlength="500" rows="3" [(ngModel)]="edicao.observacoes"></textarea>
+      </div>
+      <div class="acoes">
+        <button type="button" class="botao-secundario" (click)="cancelarEdicao()" [disabled]="processando">Cancelar</button>
+        <button type="submit" class="botao-primario" [disabled]="processando">
+          {{ processando ? 'Salvando...' : 'Salvar alterações' }}
+        </button>
+      </div>
+    </form>
+
+    <div class="painel zona-perigo" *ngIf="!modoEdicao">
+      <button type="button" class="botao-perigo" (click)="remover()" [disabled]="processando">Remover escala</button>
+    </div>
+  </ng-container>
+</section>

--- a/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.ts
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.ts
@@ -1,0 +1,243 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ActivatedRoute, Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { SanitizadorConteudoService } from '../../../service/sanitizacao/sanitizador-conteudo.service';
+import {
+  AtualizacaoEscala,
+  EscalaDetalhe,
+  FaseEscala,
+  ROTULOS_FASE,
+  ServicoNavioService,
+  TRANSICOES_FASE
+} from '../../../service/servico-navio/servico-navio.service';
+
+@Component({
+  selector: 'app-detalhe-escala',
+  templateUrl: './detalhe-escala.component.html',
+  styleUrls: ['./detalhe-escala.component.css'],
+  standalone: false
+})
+export class DetalheEscalaComponent implements OnInit {
+  escala?: EscalaDetalhe;
+  estaCarregando = false;
+  processando = false;
+  erro?: string;
+  mensagem?: string;
+  modoEdicao = false;
+
+  edicao: {
+    viagemEntrada: string;
+    viagemSaida: string;
+    chegadaPrevista: string;
+    atracacaoPrevista: string;
+    partidaPrevista: string;
+    bercoPrevisto: string;
+    bercoAtual: string;
+    observacoes: string;
+  } = this.edicaoVazia();
+
+  private escalaId!: number;
+
+  constructor(
+    private readonly servicoNavio: ServicoNavioService,
+    private readonly sanitizadorConteudo: SanitizadorConteudoService,
+    private readonly rota: ActivatedRoute,
+    private readonly router: Router
+  ) {}
+
+  ngOnInit(): void {
+    const idParam = this.rota.snapshot.paramMap.get('id');
+    const id = Number(idParam);
+    if (!idParam || !Number.isInteger(id) || id <= 0) {
+      this.erro = 'Escala inválida.';
+      return;
+    }
+    this.escalaId = id;
+    this.carregarEscala();
+  }
+
+  carregarEscala(): void {
+    this.estaCarregando = true;
+    this.erro = undefined;
+    this.servicoNavio.obterEscala(this.escalaId)
+      .pipe(finalize(() => this.estaCarregando = false))
+      .subscribe({
+        next: (escala) => {
+          this.escala = escala;
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = erro.status === 404
+            ? 'Escala não encontrada.'
+            : 'Não foi possível carregar a escala.';
+          this.escala = undefined;
+        }
+      });
+  }
+
+  get transicoesDisponiveis(): FaseEscala[] {
+    if (!this.escala) {
+      return [];
+    }
+    return TRANSICOES_FASE[this.escala.fase] ?? [];
+  }
+
+  avancarFase(destino: FaseEscala): void {
+    if (!this.escala || this.processando) {
+      return;
+    }
+    this.processando = true;
+    this.erro = undefined;
+    this.mensagem = undefined;
+    this.servicoNavio.avancarFase(this.escala.id, destino)
+      .pipe(finalize(() => this.processando = false))
+      .subscribe({
+        next: (escala) => {
+          this.escala = escala;
+          this.mensagem = `Escala avançada para "${this.rotuloFase(escala.fase)}".`;
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro, 'Não foi possível avançar a fase da escala.');
+        }
+      });
+  }
+
+  iniciarEdicao(): void {
+    if (!this.escala) {
+      return;
+    }
+    this.edicao = {
+      viagemEntrada: this.escala.viagemEntrada ?? '',
+      viagemSaida: this.escala.viagemSaida ?? '',
+      chegadaPrevista: this.paraInputDataHora(this.escala.chegadaPrevista),
+      atracacaoPrevista: this.paraInputDataHora(this.escala.atracacaoPrevista),
+      partidaPrevista: this.paraInputDataHora(this.escala.partidaPrevista),
+      bercoPrevisto: this.escala.bercoPrevisto ?? '',
+      bercoAtual: this.escala.bercoAtual ?? '',
+      observacoes: this.escala.observacoes ?? ''
+    };
+    this.modoEdicao = true;
+    this.mensagem = undefined;
+    this.erro = undefined;
+  }
+
+  cancelarEdicao(): void {
+    this.modoEdicao = false;
+    this.edicao = this.edicaoVazia();
+  }
+
+  salvarEdicao(): void {
+    if (!this.escala || this.processando) {
+      return;
+    }
+    const payload: AtualizacaoEscala = {
+      viagemEntrada: this.normalizarOpcional(this.edicao.viagemEntrada),
+      viagemSaida: this.normalizarOpcional(this.edicao.viagemSaida),
+      chegadaPrevista: this.formatarDataHoraOpcional(this.edicao.chegadaPrevista),
+      atracacaoPrevista: this.formatarDataHoraOpcional(this.edicao.atracacaoPrevista),
+      partidaPrevista: this.formatarDataHoraOpcional(this.edicao.partidaPrevista),
+      bercoPrevisto: this.normalizarOpcional(this.edicao.bercoPrevisto),
+      bercoAtual: this.normalizarOpcional(this.edicao.bercoAtual),
+      observacoes: this.normalizarOpcional(this.edicao.observacoes)
+    };
+
+    this.processando = true;
+    this.erro = undefined;
+    this.servicoNavio.atualizarEscala(this.escala.id, payload)
+      .pipe(finalize(() => this.processando = false))
+      .subscribe({
+        next: (escala) => {
+          this.escala = escala;
+          this.modoEdicao = false;
+          this.mensagem = 'Escala atualizada com sucesso.';
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro, 'Não foi possível atualizar a escala.');
+        }
+      });
+  }
+
+  remover(): void {
+    if (!this.escala || this.processando) {
+      return;
+    }
+    if (!window.confirm('Deseja realmente remover esta escala?')) {
+      return;
+    }
+    this.processando = true;
+    this.servicoNavio.removerEscala(this.escala.id)
+      .pipe(finalize(() => this.processando = false))
+      .subscribe({
+        next: () => {
+          this.router.navigate(['/home', 'navio', 'escalas']);
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro, 'Não foi possível remover a escala.');
+        }
+      });
+  }
+
+  voltar(): void {
+    this.router.navigate(['/home', 'navio', 'escalas']);
+  }
+
+  rotuloFase(fase: FaseEscala): string {
+    return ROTULOS_FASE[fase] ?? fase;
+  }
+
+  classeFase(fase: FaseEscala): string {
+    return `fase-tag fase-${fase.toLowerCase()}`;
+  }
+
+  textoSeguro(valor: string | null | undefined): string {
+    return this.sanitizadorConteudo.sanitizar(valor);
+  }
+
+  private edicaoVazia(): typeof this.edicao {
+    return {
+      viagemEntrada: '',
+      viagemSaida: '',
+      chegadaPrevista: '',
+      atracacaoPrevista: '',
+      partidaPrevista: '',
+      bercoPrevisto: '',
+      bercoAtual: '',
+      observacoes: ''
+    };
+  }
+
+  private normalizarOpcional(valor: string): string | null {
+    const limpo = (valor ?? '').trim();
+    return limpo.length > 0 ? limpo : null;
+  }
+
+  private paraInputDataHora(valor: string | null | undefined): string {
+    if (!valor) {
+      return '';
+    }
+    return valor.length >= 16 ? valor.substring(0, 16) : valor;
+  }
+
+  private formatarDataHoraOpcional(valor: string): string | null {
+    if (!valor) {
+      return null;
+    }
+    return valor.length === 16 ? `${valor}:00` : valor;
+  }
+
+  private extrairMensagemErro(erro: HttpErrorResponse, padrao: string): string {
+    const corpo = erro?.error;
+    if (corpo && typeof corpo === 'object') {
+      if (corpo.erros && typeof corpo.erros === 'object') {
+        const mensagens = Object.values(corpo.erros).filter((m) => typeof m === 'string');
+        if (mensagens.length > 0) {
+          return this.sanitizadorConteudo.sanitizar(mensagens.join(' '));
+        }
+      }
+      if (typeof corpo.mensagem === 'string' && corpo.mensagem.trim().length > 0) {
+        return this.sanitizadorConteudo.sanitizar(corpo.mensagem);
+      }
+    }
+    return padrao;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/navio/componentes/formulario-escala/formulario-escala.component.css
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/formulario-escala/formulario-escala.component.css
@@ -1,0 +1,124 @@
+.formulario-escala {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  max-width: 880px;
+}
+
+.formulario-escala header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.formulario-escala .descricao {
+  margin: 4px 0 0;
+  color: #555;
+}
+
+.formulario {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+  border-radius: 6px;
+  padding: 18px;
+}
+
+.linha {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.linha .campo {
+  flex: 1 1 220px;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.campo label {
+  font-size: 0.9rem;
+  color: #333;
+  font-weight: 600;
+}
+
+.campo input,
+.campo select,
+.campo textarea {
+  padding: 8px 10px;
+  border: 1px solid #c5c5c5;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.campo input:focus,
+.campo select:focus,
+.campo textarea:focus {
+  outline: 2px solid #005f9e;
+  outline-offset: -1px;
+  border-color: #005f9e;
+}
+
+.acoes {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.botao-primario {
+  padding: 9px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #005f9e;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.botao-primario:hover:not(:disabled),
+.botao-primario:focus:not(:disabled) {
+  background-color: #004b7a;
+}
+
+.botao-secundario {
+  padding: 9px 16px;
+  border: 1px solid #9aa5b1;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #44515f;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.botao-secundario:hover:not(:disabled),
+.botao-secundario:focus:not(:disabled) {
+  background-color: #eef1f4;
+}
+
+.botao-primario:disabled,
+.botao-secundario:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.estado-informativo {
+  padding: 12px;
+  background-color: #eef5ff;
+  border-left: 4px solid #005f9e;
+  color: #003b63;
+}
+
+.estado-erro {
+  padding: 12px;
+  background-color: #ffecec;
+  border-left: 4px solid #c62828;
+  color: #7f1d1d;
+}

--- a/frontend/cloudport/src/app/componentes/navio/componentes/formulario-escala/formulario-escala.component.html
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/formulario-escala/formulario-escala.component.html
@@ -1,0 +1,74 @@
+<section class="formulario-escala">
+  <header>
+    <h1>Nova Escala</h1>
+    <p class="descricao">Programe a chamada de um navio ao terminal.</p>
+  </header>
+
+  <div *ngIf="erro" class="estado-erro">{{ textoSeguro(erro) }}</div>
+
+  <div *ngIf="!carregandoNavios && navios.length === 0" class="estado-informativo">
+    Nenhum navio cadastrado. Cadastre um navio antes de criar uma escala.
+  </div>
+
+  <form class="formulario" (ngSubmit)="salvar()" #form="ngForm">
+    <div class="campo">
+      <label for="navio">Navio *</label>
+      <select id="navio" name="navio" [(ngModel)]="navioId" [disabled]="carregandoNavios" required>
+        <option [ngValue]="null" disabled>Selecione o navio</option>
+        <option *ngFor="let navio of navios" [ngValue]="navio.identificador">
+          {{ textoSeguro(navio.nome) }} — {{ textoSeguro(navio.codigoImo) }}
+        </option>
+      </select>
+    </div>
+
+    <div class="linha">
+      <div class="campo">
+        <label for="viagemEntrada">Viagem de entrada *</label>
+        <input id="viagemEntrada" name="viagemEntrada" type="text" maxlength="20"
+               [(ngModel)]="viagemEntrada" required />
+      </div>
+      <div class="campo">
+        <label for="viagemSaida">Viagem de saída</label>
+        <input id="viagemSaida" name="viagemSaida" type="text" maxlength="20"
+               [(ngModel)]="viagemSaida" />
+      </div>
+    </div>
+
+    <div class="linha">
+      <div class="campo">
+        <label for="chegadaPrevista">Chegada prevista (ETA) *</label>
+        <input id="chegadaPrevista" name="chegadaPrevista" type="datetime-local"
+               [(ngModel)]="chegadaPrevista" required />
+      </div>
+      <div class="campo">
+        <label for="atracacaoPrevista">Atracação prevista (ETB)</label>
+        <input id="atracacaoPrevista" name="atracacaoPrevista" type="datetime-local"
+               [(ngModel)]="atracacaoPrevista" />
+      </div>
+      <div class="campo">
+        <label for="partidaPrevista">Partida prevista (ETD)</label>
+        <input id="partidaPrevista" name="partidaPrevista" type="datetime-local"
+               [(ngModel)]="partidaPrevista" />
+      </div>
+    </div>
+
+    <div class="campo">
+      <label for="bercoPrevisto">Berço previsto</label>
+      <input id="bercoPrevisto" name="bercoPrevisto" type="text" maxlength="20"
+             [(ngModel)]="bercoPrevisto" />
+    </div>
+
+    <div class="campo">
+      <label for="observacoes">Observações</label>
+      <textarea id="observacoes" name="observacoes" maxlength="500" rows="3"
+                [(ngModel)]="observacoes"></textarea>
+    </div>
+
+    <div class="acoes">
+      <button type="button" class="botao-secundario" (click)="cancelar()" [disabled]="salvando">Cancelar</button>
+      <button type="submit" class="botao-primario" [disabled]="salvando || navios.length === 0">
+        {{ salvando ? 'Salvando...' : 'Criar escala' }}
+      </button>
+    </div>
+  </form>
+</section>

--- a/frontend/cloudport/src/app/componentes/navio/componentes/formulario-escala/formulario-escala.component.ts
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/formulario-escala/formulario-escala.component.ts
@@ -1,0 +1,136 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { SanitizadorConteudoService } from '../../../service/sanitizacao/sanitizador-conteudo.service';
+import {
+  CadastroEscala,
+  NavioResumo,
+  ServicoNavioService
+} from '../../../service/servico-navio/servico-navio.service';
+
+@Component({
+  selector: 'app-formulario-escala',
+  templateUrl: './formulario-escala.component.html',
+  styleUrls: ['./formulario-escala.component.css'],
+  standalone: false
+})
+export class FormularioEscalaComponent implements OnInit {
+  navios: NavioResumo[] = [];
+  carregandoNavios = false;
+  salvando = false;
+  erro?: string;
+
+  navioId: number | null = null;
+  viagemEntrada = '';
+  viagemSaida = '';
+  chegadaPrevista = '';
+  atracacaoPrevista = '';
+  partidaPrevista = '';
+  bercoPrevisto = '';
+  observacoes = '';
+
+  constructor(
+    private readonly servicoNavio: ServicoNavioService,
+    private readonly sanitizadorConteudo: SanitizadorConteudoService,
+    private readonly router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.carregarNavios();
+  }
+
+  carregarNavios(): void {
+    this.carregandoNavios = true;
+    this.servicoNavio.listarNavios()
+      .pipe(finalize(() => this.carregandoNavios = false))
+      .subscribe({
+        next: (navios) => {
+          this.navios = navios ?? [];
+        },
+        error: () => {
+          this.erro = 'Não foi possível carregar os navios cadastrados. Cadastre um navio antes de criar uma escala.';
+          this.navios = [];
+        }
+      });
+  }
+
+  salvar(): void {
+    this.erro = undefined;
+
+    if (this.navioId === null || this.navioId === undefined) {
+      this.erro = 'Selecione o navio da escala.';
+      return;
+    }
+    if (!this.viagemEntrada.trim()) {
+      this.erro = 'Informe a viagem de entrada.';
+      return;
+    }
+    if (!this.chegadaPrevista) {
+      this.erro = 'Informe a chegada prevista (ETA).';
+      return;
+    }
+
+    const payload: CadastroEscala = {
+      viagemEntrada: this.viagemEntrada.trim(),
+      viagemSaida: this.normalizarOpcional(this.viagemSaida),
+      chegadaPrevista: this.formatarDataHora(this.chegadaPrevista),
+      atracacaoPrevista: this.formatarDataHoraOpcional(this.atracacaoPrevista),
+      partidaPrevista: this.formatarDataHoraOpcional(this.partidaPrevista),
+      bercoPrevisto: this.normalizarOpcional(this.bercoPrevisto),
+      observacoes: this.normalizarOpcional(this.observacoes)
+    };
+
+    this.salvando = true;
+    this.servicoNavio.registrarEscala(this.navioId, payload)
+      .pipe(finalize(() => this.salvando = false))
+      .subscribe({
+        next: (escala) => {
+          this.router.navigate(['/home', 'navio', 'escalas', escala.id]);
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro);
+        }
+      });
+  }
+
+  cancelar(): void {
+    this.router.navigate(['/home', 'navio', 'escalas']);
+  }
+
+  textoSeguro(valor: string | null | undefined): string {
+    return this.sanitizadorConteudo.sanitizar(valor);
+  }
+
+  private normalizarOpcional(valor: string): string | null {
+    const limpo = (valor ?? '').trim();
+    return limpo.length > 0 ? limpo : null;
+  }
+
+  private formatarDataHora(valor: string): string {
+    return valor.length === 16 ? `${valor}:00` : valor;
+  }
+
+  private formatarDataHoraOpcional(valor: string): string | null {
+    if (!valor) {
+      return null;
+    }
+    return this.formatarDataHora(valor);
+  }
+
+  private extrairMensagemErro(erro: HttpErrorResponse): string {
+    const corpo = erro?.error;
+    if (corpo && typeof corpo === 'object') {
+      if (corpo.erros && typeof corpo.erros === 'object') {
+        const mensagens = Object.values(corpo.erros).filter((m) => typeof m === 'string');
+        if (mensagens.length > 0) {
+          return this.sanitizadorConteudo.sanitizar(mensagens.join(' '));
+        }
+      }
+      if (typeof corpo.mensagem === 'string' && corpo.mensagem.trim().length > 0) {
+        return this.sanitizadorConteudo.sanitizar(corpo.mensagem);
+      }
+    }
+    return 'Não foi possível salvar a escala. Verifique os dados e tente novamente.';
+  }
+}

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-escalas/lista-escalas.component.css
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-escalas/lista-escalas.component.css
@@ -1,0 +1,172 @@
+.lista-escalas {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+
+.cabecalho-escalas {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.cabecalho-escalas h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.cabecalho-escalas .descricao {
+  margin: 4px 0 0;
+  color: #555;
+}
+
+.acoes-cabecalho {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.campo-dias {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.campo-dias input {
+  margin-top: 4px;
+  padding: 4px 8px;
+  border: 1px solid #c5c5c5;
+  border-radius: 4px;
+  width: 120px;
+}
+
+.botao-primario {
+  padding: 8px 14px;
+  border: none;
+  border-radius: 4px;
+  background-color: #005f9e;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.botao-primario:hover,
+.botao-primario:focus {
+  background-color: #004b7a;
+}
+
+.botao-secundario {
+  padding: 8px 12px;
+  border: 1px solid #005f9e;
+  border-radius: 4px;
+  background-color: #ffffff;
+  color: #005f9e;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.botao-secundario:hover,
+.botao-secundario:focus {
+  background-color: #005f9e;
+  color: #ffffff;
+}
+
+.estado-informativo {
+  padding: 12px;
+  background-color: #eef5ff;
+  border-left: 4px solid #005f9e;
+  color: #003b63;
+}
+
+.estado-erro {
+  padding: 12px;
+  background-color: #ffecec;
+  border-left: 4px solid #c62828;
+  color: #7f1d1d;
+}
+
+.tabela-escalas {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+}
+
+.tabela-escalas th,
+.tabela-escalas td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #e6e6e6;
+  text-align: left;
+}
+
+.tabela-escalas thead {
+  background-color: #f5f7fa;
+}
+
+.tabela-escalas .coluna-data {
+  min-width: 170px;
+}
+
+.linha-escala {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.linha-escala:hover,
+.linha-escala:focus {
+  background-color: #f0f7ff;
+}
+
+.linha-escala:focus {
+  outline: 2px solid #005f9e;
+  outline-offset: -2px;
+}
+
+.fase-tag {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.fase-prevista {
+  background-color: #e3eefc;
+  color: #1d4e89;
+}
+
+.fase-inbound {
+  background-color: #e7f0ff;
+  color: #0b5cad;
+}
+
+.fase-atracado {
+  background-color: #fff4d6;
+  color: #8a6100;
+}
+
+.fase-operando {
+  background-color: #d8f3e0;
+  color: #1b6b3a;
+}
+
+.fase-partiu {
+  background-color: #e6e6e6;
+  color: #444;
+}
+
+.fase-encerrada {
+  background-color: #dfe3e8;
+  color: #2c3338;
+}
+
+.fase-cancelada {
+  background-color: #ffe0e0;
+  color: #a02020;
+}

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-escalas/lista-escalas.component.html
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-escalas/lista-escalas.component.html
@@ -1,0 +1,70 @@
+<section class="lista-escalas">
+  <header class="cabecalho-escalas">
+    <div>
+      <h1>Cronograma de Escalas</h1>
+      <p class="descricao">Planeje a operação dos navios acompanhando as escalas previstas e em atendimento.</p>
+    </div>
+    <div class="acoes-cabecalho">
+      <label for="filtroDias" class="campo-dias">
+        Período (dias):
+        <input
+          id="filtroDias"
+          type="number"
+          min="1"
+          max="60"
+          [(ngModel)]="diasFiltro"
+          (ngModelChange)="aoAlterarDias()"
+        />
+      </label>
+      <button type="button" class="botao-secundario" (click)="alternarOrdenacao()">
+        Ordenar por ETA {{ ordenacaoAscendente ? '▲' : '▼' }}
+      </button>
+      <button type="button" class="botao-secundario" (click)="abrirNavios()">
+        Navios cadastrados
+      </button>
+      <button type="button" class="botao-primario" (click)="novaEscala()">
+        Nova escala
+      </button>
+    </div>
+  </header>
+
+  <div *ngIf="estaCarregando" class="estado-informativo">Carregando cronograma de escalas...</div>
+
+  <div *ngIf="!estaCarregando && erroCarregamento" class="estado-erro">
+    {{ textoSeguro(erroCarregamento) }}
+  </div>
+
+  <table *ngIf="!estaCarregando && !erroCarregamento && escalas.length > 0" class="tabela-escalas" aria-label="Cronograma de escalas de navio">
+    <thead>
+      <tr>
+        <th scope="col">Navio</th>
+        <th scope="col">IMO</th>
+        <th scope="col">Viagem</th>
+        <th scope="col" class="coluna-data">ETA</th>
+        <th scope="col">Berço</th>
+        <th scope="col">Fase</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        *ngFor="let escala of escalas"
+        (click)="verDetalhes(escala)"
+        tabindex="0"
+        (keyup.enter)="verDetalhes(escala)"
+        class="linha-escala"
+        aria-label="Selecionar escala"
+      >
+        <td>{{ textoSeguro(escala.nomeNavio) }}</td>
+        <td>{{ textoSeguro(escala.codigoImo) }}</td>
+        <td>{{ textoSeguro(escala.viagemEntrada) }}</td>
+        <td>{{ escala.chegadaPrevista | date:'dd/MM/yyyy HH:mm' }}</td>
+        <td>{{ textoSeguro(escala.bercoPrevisto) || '—' }}</td>
+        <td><span [class]="classeFase(escala.fase)">{{ rotuloFase(escala.fase) }}</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div *ngIf="!estaCarregando && !erroCarregamento && escalas.length === 0" class="estado-informativo">
+    Nenhuma escala encontrada para o período selecionado.
+  </div>
+</section>

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-escalas/lista-escalas.component.ts
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-escalas/lista-escalas.component.ts
@@ -1,0 +1,111 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { SanitizadorConteudoService } from '../../../service/sanitizacao/sanitizador-conteudo.service';
+import {
+  EscalaResumo,
+  FaseEscala,
+  ROTULOS_FASE,
+  ServicoNavioService
+} from '../../../service/servico-navio/servico-navio.service';
+
+@Component({
+  selector: 'app-lista-escalas',
+  templateUrl: './lista-escalas.component.html',
+  styleUrls: ['./lista-escalas.component.css'],
+  standalone: false
+})
+export class ListaEscalasComponent implements OnInit {
+  escalas: EscalaResumo[] = [];
+  estaCarregando = false;
+  erroCarregamento?: string;
+  ordenacaoAscendente = true;
+  diasFiltro = 7;
+
+  constructor(
+    private readonly servicoNavio: ServicoNavioService,
+    private readonly sanitizadorConteudo: SanitizadorConteudoService,
+    private readonly router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.carregarEscalas();
+  }
+
+  carregarEscalas(): void {
+    this.estaCarregando = true;
+    this.erroCarregamento = undefined;
+    const dias = this.normalizarDiasFiltro(this.diasFiltro);
+    this.servicoNavio.listarCronograma(dias)
+      .pipe(finalize(() => this.estaCarregando = false))
+      .subscribe({
+        next: (escalas) => {
+          this.escalas = this.ordenarPorEta(escalas, this.ordenacaoAscendente);
+        },
+        error: () => {
+          this.erroCarregamento = 'Não foi possível carregar o cronograma de escalas. Atualize a página ou tente novamente mais tarde.';
+          this.escalas = [];
+        }
+      });
+  }
+
+  alternarOrdenacao(): void {
+    this.ordenacaoAscendente = !this.ordenacaoAscendente;
+    this.escalas = this.ordenarPorEta(this.escalas, this.ordenacaoAscendente);
+  }
+
+  aoAlterarDias(): void {
+    this.diasFiltro = this.normalizarDiasFiltro(this.diasFiltro);
+    this.carregarEscalas();
+  }
+
+  novaEscala(): void {
+    this.router.navigate(['/home', 'navio', 'escalas', 'nova']);
+  }
+
+  abrirNavios(): void {
+    this.router.navigate(['/home', 'navio', 'navios']);
+  }
+
+  verDetalhes(escala: EscalaResumo): void {
+    if (!escala || escala.id === undefined || escala.id === null) {
+      return;
+    }
+    this.router.navigate(['/home', 'navio', 'escalas', escala.id]);
+  }
+
+  rotuloFase(fase: FaseEscala): string {
+    return ROTULOS_FASE[fase] ?? fase;
+  }
+
+  classeFase(fase: FaseEscala): string {
+    return `fase-tag fase-${fase.toLowerCase()}`;
+  }
+
+  textoSeguro(valor: string | null | undefined): string {
+    return this.sanitizadorConteudo.sanitizar(valor);
+  }
+
+  private ordenarPorEta(escalas: EscalaResumo[], ascendente: boolean): EscalaResumo[] {
+    const ordenadas = [...(escalas ?? [])].sort((a, b) => {
+      const tempoA = Date.parse(a?.chegadaPrevista ?? '') || 0;
+      const tempoB = Date.parse(b?.chegadaPrevista ?? '') || 0;
+      return tempoA - tempoB;
+    });
+    return ascendente ? ordenadas : ordenadas.reverse();
+  }
+
+  private normalizarDiasFiltro(valor: number): number {
+    if (!Number.isFinite(valor)) {
+      return 7;
+    }
+    const inteiro = Math.floor(Math.abs(valor));
+    if (inteiro < 1) {
+      return 1;
+    }
+    if (inteiro > 60) {
+      return 60;
+    }
+    return inteiro;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-navios/lista-navios.component.css
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-navios/lista-navios.component.css
@@ -1,0 +1,175 @@
+.lista-navios {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+
+.cabecalho {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.cabecalho h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.cabecalho .descricao {
+  margin: 4px 0 0;
+  color: #555;
+}
+
+.acoes-cabecalho {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.formulario {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+  border-radius: 6px;
+  padding: 18px;
+}
+
+.linha {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.linha .campo {
+  flex: 1 1 200px;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.campo label {
+  font-size: 0.9rem;
+  color: #333;
+  font-weight: 600;
+}
+
+.campo input {
+  padding: 8px 10px;
+  border: 1px solid #c5c5c5;
+  border-radius: 4px;
+  font-size: 0.95rem;
+}
+
+.campo input:focus {
+  outline: 2px solid #005f9e;
+  outline-offset: -1px;
+  border-color: #005f9e;
+}
+
+.acoes {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.botao-primario {
+  padding: 9px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #005f9e;
+  color: #fff;
+  cursor: pointer;
+}
+
+.botao-primario:hover:not(:disabled),
+.botao-primario:focus:not(:disabled) {
+  background-color: #004b7a;
+}
+
+.botao-secundario {
+  padding: 9px 14px;
+  border: 1px solid #005f9e;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #005f9e;
+  cursor: pointer;
+}
+
+.botao-secundario:hover,
+.botao-secundario:focus {
+  background-color: #005f9e;
+  color: #fff;
+}
+
+.botao-primario:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.tabela-navios {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+}
+
+.tabela-navios th,
+.tabela-navios td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #e6e6e6;
+  text-align: left;
+}
+
+.tabela-navios thead {
+  background-color: #f5f7fa;
+}
+
+.coluna-acoes {
+  width: 120px;
+  text-align: right;
+}
+
+.botao-perigo-pequeno {
+  padding: 6px 10px;
+  border: 1px solid #c62828;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #c62828;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.botao-perigo-pequeno:hover,
+.botao-perigo-pequeno:focus {
+  background-color: #c62828;
+  color: #fff;
+}
+
+.estado-informativo {
+  padding: 12px;
+  background-color: #eef5ff;
+  border-left: 4px solid #005f9e;
+  color: #003b63;
+}
+
+.estado-erro {
+  padding: 12px;
+  background-color: #ffecec;
+  border-left: 4px solid #c62828;
+  color: #7f1d1d;
+}
+
+.estado-sucesso {
+  padding: 12px;
+  background-color: #e6f6ec;
+  border-left: 4px solid #1b6b3a;
+  color: #14512c;
+}

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-navios/lista-navios.component.html
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-navios/lista-navios.component.html
@@ -1,0 +1,92 @@
+<section class="lista-navios">
+  <header class="cabecalho">
+    <div>
+      <h1>Navios Cadastrados</h1>
+      <p class="descricao">Cadastro mestre das embarcações usadas no planejamento de escalas.</p>
+    </div>
+    <div class="acoes-cabecalho">
+      <button type="button" class="botao-secundario" (click)="voltarCronograma()">Ir ao cronograma</button>
+      <button type="button" class="botao-primario" (click)="alternarFormulario()">
+        {{ mostrarFormulario ? 'Fechar' : 'Novo navio' }}
+      </button>
+    </div>
+  </header>
+
+  <div *ngIf="erro" class="estado-erro">{{ textoSeguro(erro) }}</div>
+  <div *ngIf="mensagem" class="estado-sucesso">{{ textoSeguro(mensagem) }}</div>
+
+  <form class="formulario" *ngIf="mostrarFormulario" (ngSubmit)="salvar()">
+    <div class="linha">
+      <div class="campo">
+        <label for="nome">Nome *</label>
+        <input id="nome" name="nome" type="text" maxlength="120" [(ngModel)]="novo.nome" required />
+      </div>
+      <div class="campo">
+        <label for="codigoImo">Código IMO *</label>
+        <input id="codigoImo" name="codigoImo" type="text" maxlength="10" placeholder="IMO9999999" [(ngModel)]="novo.codigoImo" required />
+      </div>
+    </div>
+    <div class="linha">
+      <div class="campo">
+        <label for="paisBandeira">País da bandeira *</label>
+        <input id="paisBandeira" name="paisBandeira" type="text" maxlength="60" [(ngModel)]="novo.paisBandeira" required />
+      </div>
+      <div class="campo">
+        <label for="empresaArmadora">Empresa armadora *</label>
+        <input id="empresaArmadora" name="empresaArmadora" type="text" maxlength="80" [(ngModel)]="novo.empresaArmadora" required />
+      </div>
+      <div class="campo">
+        <label for="capacidadeTeu">Capacidade (TEU) *</label>
+        <input id="capacidadeTeu" name="capacidadeTeu" type="number" min="1" [(ngModel)]="novo.capacidadeTeu" required />
+      </div>
+    </div>
+    <div class="linha">
+      <div class="campo">
+        <label for="loaMetros">Comprimento LOA (m)</label>
+        <input id="loaMetros" name="loaMetros" type="number" min="0" step="0.01" [(ngModel)]="novo.loaMetros" />
+      </div>
+      <div class="campo">
+        <label for="caladoMaximoMetros">Calado máximo (m)</label>
+        <input id="caladoMaximoMetros" name="caladoMaximoMetros" type="number" min="0" step="0.01" [(ngModel)]="novo.caladoMaximoMetros" />
+      </div>
+      <div class="campo">
+        <label for="callSign">Call sign</label>
+        <input id="callSign" name="callSign" type="text" maxlength="15" [(ngModel)]="novo.callSign" />
+      </div>
+    </div>
+    <div class="acoes">
+      <button type="submit" class="botao-primario" [disabled]="salvando">
+        {{ salvando ? 'Salvando...' : 'Cadastrar navio' }}
+      </button>
+    </div>
+  </form>
+
+  <div *ngIf="estaCarregando" class="estado-informativo">Carregando navios...</div>
+
+  <table *ngIf="!estaCarregando && navios.length > 0" class="tabela-navios" aria-label="Navios cadastrados">
+    <thead>
+      <tr>
+        <th scope="col">Nome</th>
+        <th scope="col">IMO</th>
+        <th scope="col">Armador</th>
+        <th scope="col">Capacidade (TEU)</th>
+        <th scope="col" class="coluna-acoes">Ações</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let navio of navios">
+        <td>{{ textoSeguro(navio.nome) }}</td>
+        <td>{{ textoSeguro(navio.codigoImo) }}</td>
+        <td>{{ textoSeguro(navio.empresaArmadora) }}</td>
+        <td>{{ navio.capacidadeTeu }}</td>
+        <td class="coluna-acoes">
+          <button type="button" class="botao-perigo-pequeno" (click)="remover(navio)">Remover</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div *ngIf="!estaCarregando && navios.length === 0" class="estado-informativo">
+    Nenhum navio cadastrado. Use "Novo navio" para começar.
+  </div>
+</section>

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-navios/lista-navios.component.ts
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-navios/lista-navios.component.ts
@@ -1,0 +1,180 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { SanitizadorConteudoService } from '../../../service/sanitizacao/sanitizador-conteudo.service';
+import {
+  CadastroNavio,
+  NavioResumo,
+  ServicoNavioService
+} from '../../../service/servico-navio/servico-navio.service';
+
+@Component({
+  selector: 'app-lista-navios',
+  templateUrl: './lista-navios.component.html',
+  styleUrls: ['./lista-navios.component.css'],
+  standalone: false
+})
+export class ListaNaviosComponent implements OnInit {
+  navios: NavioResumo[] = [];
+  estaCarregando = false;
+  salvando = false;
+  erro?: string;
+  mensagem?: string;
+  mostrarFormulario = false;
+
+  novo: {
+    nome: string;
+    codigoImo: string;
+    paisBandeira: string;
+    empresaArmadora: string;
+    capacidadeTeu: number | null;
+    loaMetros: number | null;
+    caladoMaximoMetros: number | null;
+    callSign: string;
+  } = this.formularioVazio();
+
+  constructor(
+    private readonly servicoNavio: ServicoNavioService,
+    private readonly sanitizadorConteudo: SanitizadorConteudoService,
+    private readonly router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.carregarNavios();
+  }
+
+  carregarNavios(): void {
+    this.estaCarregando = true;
+    this.erro = undefined;
+    this.servicoNavio.listarNavios()
+      .pipe(finalize(() => this.estaCarregando = false))
+      .subscribe({
+        next: (navios) => {
+          this.navios = navios ?? [];
+        },
+        error: () => {
+          this.erro = 'Não foi possível carregar os navios cadastrados.';
+          this.navios = [];
+        }
+      });
+  }
+
+  alternarFormulario(): void {
+    this.mostrarFormulario = !this.mostrarFormulario;
+    if (this.mostrarFormulario) {
+      this.novo = this.formularioVazio();
+      this.erro = undefined;
+    }
+  }
+
+  voltarCronograma(): void {
+    this.router.navigate(['/home', 'navio', 'escalas']);
+  }
+
+  salvar(): void {
+    this.erro = undefined;
+    this.mensagem = undefined;
+
+    if (!this.novo.nome.trim()) {
+      this.erro = 'Informe o nome do navio.';
+      return;
+    }
+    if (!/^IMO[0-9]{7}$/.test(this.novo.codigoImo.trim().toUpperCase())) {
+      this.erro = 'O código IMO deve seguir o padrão IMO9999999.';
+      return;
+    }
+    if (!this.novo.paisBandeira.trim()) {
+      this.erro = 'Informe o país da bandeira.';
+      return;
+    }
+    if (!this.novo.empresaArmadora.trim()) {
+      this.erro = 'Informe a empresa armadora.';
+      return;
+    }
+    if (this.novo.capacidadeTeu === null || this.novo.capacidadeTeu <= 0) {
+      this.erro = 'Informe a capacidade em TEU (maior que zero).';
+      return;
+    }
+
+    const payload: CadastroNavio = {
+      nome: this.novo.nome.trim(),
+      codigoImo: this.novo.codigoImo.trim().toUpperCase(),
+      paisBandeira: this.novo.paisBandeira.trim(),
+      empresaArmadora: this.novo.empresaArmadora.trim(),
+      capacidadeTeu: this.novo.capacidadeTeu,
+      loaMetros: this.novo.loaMetros ?? null,
+      caladoMaximoMetros: this.novo.caladoMaximoMetros ?? null,
+      callSign: this.novo.callSign.trim() ? this.novo.callSign.trim() : null
+    };
+
+    this.salvando = true;
+    this.servicoNavio.registrarNavio(payload)
+      .pipe(finalize(() => this.salvando = false))
+      .subscribe({
+        next: () => {
+          this.mensagem = 'Navio cadastrado com sucesso.';
+          this.mostrarFormulario = false;
+          this.novo = this.formularioVazio();
+          this.carregarNavios();
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro, 'Não foi possível cadastrar o navio.');
+        }
+      });
+  }
+
+  remover(navio: NavioResumo): void {
+    if (this.salvando) {
+      return;
+    }
+    if (!window.confirm(`Remover o navio "${navio.nome}"? Escalas vinculadas impedem a remoção.`)) {
+      return;
+    }
+    this.erro = undefined;
+    this.mensagem = undefined;
+    this.servicoNavio.removerNavio(navio.identificador)
+      .subscribe({
+        next: () => {
+          this.mensagem = 'Navio removido com sucesso.';
+          this.carregarNavios();
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro, 'Não foi possível remover o navio. Verifique se há escalas vinculadas.');
+        }
+      });
+  }
+
+  textoSeguro(valor: string | null | undefined): string {
+    return this.sanitizadorConteudo.sanitizar(valor);
+  }
+
+  private formularioVazio(): typeof this.novo {
+    return {
+      nome: '',
+      codigoImo: '',
+      paisBandeira: '',
+      empresaArmadora: '',
+      capacidadeTeu: null,
+      loaMetros: null,
+      caladoMaximoMetros: null,
+      callSign: ''
+    };
+  }
+
+  private extrairMensagemErro(erro: HttpErrorResponse, padrao: string): string {
+    const corpo = erro?.error;
+    if (corpo && typeof corpo === 'object') {
+      if (corpo.erros && typeof corpo.erros === 'object') {
+        const mensagens = Object.values(corpo.erros).filter((m) => typeof m === 'string');
+        if (mensagens.length > 0) {
+          return this.sanitizadorConteudo.sanitizar(mensagens.join(' '));
+        }
+      }
+      if (typeof corpo.mensagem === 'string' && corpo.mensagem.trim().length > 0) {
+        return this.sanitizadorConteudo.sanitizar(corpo.mensagem);
+      }
+    }
+    return padrao;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/navio/navio-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/navio/navio-routing.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ListaEscalasComponent } from './componentes/lista-escalas/lista-escalas.component';
+import { FormularioEscalaComponent } from './componentes/formulario-escala/formulario-escala.component';
+import { DetalheEscalaComponent } from './componentes/detalhe-escala/detalhe-escala.component';
+import { ListaNaviosComponent } from './componentes/lista-navios/lista-navios.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: 'escalas'
+  },
+  {
+    path: 'escalas',
+    component: ListaEscalasComponent
+  },
+  {
+    path: 'escalas/nova',
+    component: FormularioEscalaComponent
+  },
+  {
+    path: 'escalas/:id',
+    component: DetalheEscalaComponent
+  },
+  {
+    path: 'navios',
+    component: ListaNaviosComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class NavioRoutingModule { }

--- a/frontend/cloudport/src/app/componentes/navio/navio.module.ts
+++ b/frontend/cloudport/src/app/componentes/navio/navio.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NavioRoutingModule } from './navio-routing.module';
+import { ListaEscalasComponent } from './componentes/lista-escalas/lista-escalas.component';
+import { FormularioEscalaComponent } from './componentes/formulario-escala/formulario-escala.component';
+import { DetalheEscalaComponent } from './componentes/detalhe-escala/detalhe-escala.component';
+import { ListaNaviosComponent } from './componentes/lista-navios/lista-navios.component';
+
+@NgModule({
+  declarations: [
+    ListaEscalasComponent,
+    FormularioEscalaComponent,
+    DetalheEscalaComponent,
+    ListaNaviosComponent
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    NavioRoutingModule
+  ]
+})
+export class NavioModule { }

--- a/frontend/cloudport/src/app/componentes/service/servico-navio/servico-navio.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-navio/servico-navio.service.ts
@@ -1,0 +1,194 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfiguracaoAplicacaoService } from '../../../configuracao/configuracao-aplicacao.service';
+
+export type FaseEscala =
+  | 'PREVISTA'
+  | 'INBOUND'
+  | 'ATRACADO'
+  | 'OPERANDO'
+  | 'PARTIU'
+  | 'ENCERRADA'
+  | 'CANCELADA';
+
+export interface NavioResumo {
+  identificador: number;
+  nome: string;
+  codigoImo: string;
+  empresaArmadora: string;
+  capacidadeTeu: number;
+}
+
+export interface NavioDetalhe extends NavioResumo {
+  paisBandeira: string;
+  loaMetros?: number | null;
+  caladoMaximoMetros?: number | null;
+  callSign?: string | null;
+}
+
+export interface CadastroNavio {
+  nome: string;
+  codigoImo: string;
+  paisBandeira: string;
+  empresaArmadora: string;
+  capacidadeTeu: number;
+  loaMetros?: number | null;
+  caladoMaximoMetros?: number | null;
+  callSign?: string | null;
+}
+
+export interface EscalaResumo {
+  id: number;
+  navioId: number;
+  nomeNavio: string;
+  codigoImo: string;
+  viagemEntrada: string;
+  fase: FaseEscala;
+  chegadaPrevista: string;
+  bercoPrevisto?: string | null;
+}
+
+export interface EscalaDetalhe {
+  id: number;
+  navioId: number;
+  nomeNavio: string;
+  codigoImo: string;
+  viagemEntrada: string;
+  viagemSaida?: string | null;
+  fase: FaseEscala;
+  chegadaPrevista: string;
+  atracacaoPrevista?: string | null;
+  partidaPrevista?: string | null;
+  chegadaEfetiva?: string | null;
+  atracacaoEfetiva?: string | null;
+  partidaEfetiva?: string | null;
+  bercoPrevisto?: string | null;
+  bercoAtual?: string | null;
+  observacoes?: string | null;
+}
+
+export interface CadastroEscala {
+  viagemEntrada: string;
+  viagemSaida?: string | null;
+  chegadaPrevista: string;
+  atracacaoPrevista?: string | null;
+  partidaPrevista?: string | null;
+  bercoPrevisto?: string | null;
+  observacoes?: string | null;
+}
+
+export interface AtualizacaoEscala {
+  viagemEntrada?: string | null;
+  viagemSaida?: string | null;
+  chegadaPrevista?: string | null;
+  atracacaoPrevista?: string | null;
+  partidaPrevista?: string | null;
+  bercoPrevisto?: string | null;
+  bercoAtual?: string | null;
+  observacoes?: string | null;
+}
+
+/**
+ * Transições de fase permitidas (espelham as regras do EscalaServico no backend).
+ * Inspiradas nas visit phases do Navis N4.
+ */
+export const TRANSICOES_FASE: Record<FaseEscala, FaseEscala[]> = {
+  PREVISTA: ['INBOUND', 'ATRACADO', 'CANCELADA'],
+  INBOUND: ['ATRACADO', 'CANCELADA'],
+  ATRACADO: ['OPERANDO', 'PARTIU', 'CANCELADA'],
+  OPERANDO: ['PARTIU'],
+  PARTIU: ['ENCERRADA'],
+  ENCERRADA: [],
+  CANCELADA: []
+};
+
+export const ROTULOS_FASE: Record<FaseEscala, string> = {
+  PREVISTA: 'Prevista',
+  INBOUND: 'Em aproximação',
+  ATRACADO: 'Atracado',
+  OPERANDO: 'Em operação',
+  PARTIU: 'Partiu',
+  ENCERRADA: 'Encerrada',
+  CANCELADA: 'Cancelada'
+};
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServicoNavioService {
+  private static readonly CAMINHO_NAVIOS = '/navios';
+  private static readonly CAMINHO_ESCALAS = '/escalas';
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly configuracaoAplicacao: ConfiguracaoAplicacaoService
+  ) {}
+
+  listarNavios(): Observable<NavioResumo[]> {
+    return this.http.get<NavioResumo[]>(this.urlNavios(''));
+  }
+
+  obterNavio(id: number): Observable<NavioDetalhe> {
+    return this.http.get<NavioDetalhe>(this.urlNavios(`/${id}`));
+  }
+
+  registrarNavio(payload: CadastroNavio): Observable<NavioDetalhe> {
+    return this.http.post<NavioDetalhe>(this.urlNavios(''), payload);
+  }
+
+  removerNavio(id: number): Observable<void> {
+    return this.http.delete<void>(this.urlNavios(`/${id}`));
+  }
+
+  listarCronograma(dias: number): Observable<EscalaResumo[]> {
+    const params = new HttpParams().set('dias', this.normalizarJanela(dias).toString());
+    return this.http.get<EscalaResumo[]>(this.urlEscalas(''), { params });
+  }
+
+  listarEscalasPorNavio(navioId: number): Observable<EscalaResumo[]> {
+    return this.http.get<EscalaResumo[]>(this.urlNavios(`/${navioId}/escalas`));
+  }
+
+  obterEscala(id: number): Observable<EscalaDetalhe> {
+    return this.http.get<EscalaDetalhe>(this.urlEscalas(`/${id}`));
+  }
+
+  registrarEscala(navioId: number, payload: CadastroEscala): Observable<EscalaDetalhe> {
+    return this.http.post<EscalaDetalhe>(this.urlNavios(`/${navioId}/escalas`), payload);
+  }
+
+  atualizarEscala(id: number, payload: AtualizacaoEscala): Observable<EscalaDetalhe> {
+    return this.http.put<EscalaDetalhe>(this.urlEscalas(`/${id}`), payload);
+  }
+
+  avancarFase(id: number, fase: FaseEscala): Observable<EscalaDetalhe> {
+    return this.http.patch<EscalaDetalhe>(this.urlEscalas(`/${id}/fase`), { fase });
+  }
+
+  removerEscala(id: number): Observable<void> {
+    return this.http.delete<void>(this.urlEscalas(`/${id}`));
+  }
+
+  private urlNavios(caminho: string): string {
+    return this.configuracaoAplicacao.construirUrlApi(`${ServicoNavioService.CAMINHO_NAVIOS}${caminho}`);
+  }
+
+  private urlEscalas(caminho: string): string {
+    return this.configuracaoAplicacao.construirUrlApi(`${ServicoNavioService.CAMINHO_ESCALAS}${caminho}`);
+  }
+
+  private normalizarJanela(dias: number): number {
+    if (!Number.isFinite(dias)) {
+      return 7;
+    }
+    const inteiro = Math.floor(Math.abs(dias));
+    if (inteiro < 1) {
+      return 1;
+    }
+    if (inteiro > 60) {
+      return 60;
+    }
+    return inteiro;
+  }
+}


### PR DESCRIPTION
## Resumo

Adiciona a **parte visual de planejamento de operação de navios** no frontend Angular, consumindo o modelo de Escala (Vessel Visit) do `servico-navio`.

Inspirado no módulo Vessel do Navis N4 e alinhado ao padrão de "Visita" já usado na Ferrovia.

### Novo módulo `navio` (lazy-loaded em `/home/navio`)
- **Cronograma de Escalas** (Vessel Schedule): lista as escalas previstas/ativas com navio, IMO, viagem, ETA, berço e fase; filtro por período e ordenação.
- **Nova Escala**: formulário que seleciona o navio e registra viagem de entrada/saída, ETA/ETB/ETD, berço previsto e observações.
- **Detalhe da Escala**: visão completa (tempos previstos vs. efetivos, berços), **avanço de fase validado** (só mostra transições permitidas: `PREVISTA → INBOUND → ATRACADO → OPERANDO → PARTIU → ENCERRADA`, com `CANCELADA`), edição inline e remoção.
- **Navios Cadastrados**: cadastro mestre (nome, IMO, bandeira, armador, TEU, LOA, calado, call sign) com criação e remoção.

### Integração
- `ServicoNavioService` cobrindo `/navios` e `/escalas` (incluindo `PATCH /escalas/{id}/fase`).
- Item de menu **"Navio"** no navbar + seed das abas de navegação (`Flyway V8` no `servico-autenticacao`), com as roles `ROLE_ADMIN_PORTO` e `ROLE_PLANEJADOR`.

## Base do PR
Aberto **sobre a branch `claude/relaxed-johnson-XKdYu`** (que introduz o backend de Escala), para que o diff fique restrito ao frontend e respeite a dependência da API. Quando aquele PR for mesclado, o GitHub re-aponta este automaticamente para a base principal.

## Test plan
- [x] `npm run build` (AOT) passa; bundle `componentes-navio-navio-module` gerado sem erros.
- [ ] Validar fluxo no navegador com os serviços de navio e autenticação em execução (não foi possível neste ambiente, sem backend rodando).
- [ ] Cadastrar navio → criar escala → avançar fases → editar/remover.


---
_Generated by [Claude Code](https://claude.ai/code/session_0124hSrsgg5JLbWYYC4PeSvP)_