### PR TITLE
Planejamento de pátio para o navio (descarga/carga e lista de trabalho)

### DIFF
--- a/backend/servico-navio/pom.xml
+++ b/backend/servico-navio/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/configuracao/RabbitConfiguracao.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/configuracao/RabbitConfiguracao.java
@@ -1,0 +1,15 @@
+package br.com.cloudport.serviconavio.configuracao;
+
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitConfiguracao {
+
+    @Bean
+    public MessageConverter conversorMensagemJson() {
+        return new Jackson2JsonMessageConverter();
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/controlador/EscalaControlador.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/controlador/EscalaControlador.java
@@ -1,10 +1,12 @@
 package br.com.cloudport.serviconavio.escala.controlador;
 
 import br.com.cloudport.serviconavio.escala.dto.AtualizacaoEscalaDTO;
+import br.com.cloudport.serviconavio.escala.dto.AtualizacaoStatusConteinerEscalaDTO;
 import br.com.cloudport.serviconavio.escala.dto.AvancarFaseEscalaDTO;
 import br.com.cloudport.serviconavio.escala.dto.CadastroEscalaDTO;
 import br.com.cloudport.serviconavio.escala.dto.EscalaDetalheDTO;
 import br.com.cloudport.serviconavio.escala.dto.EscalaResumoDTO;
+import br.com.cloudport.serviconavio.escala.dto.OperacaoConteinerEscalaDTO;
 import br.com.cloudport.serviconavio.escala.servico.EscalaServico;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -70,5 +72,43 @@ public class EscalaControlador {
     public EscalaDetalheDTO registrar(@PathVariable Long navioId,
                                       @Valid @RequestBody CadastroEscalaDTO dto) {
         return escalaServico.registrar(navioId, dto);
+    }
+
+    @PostMapping("/escalas/{id}/descarga")
+    public EscalaDetalheDTO adicionarDescarga(@PathVariable Long id,
+                                              @Valid @RequestBody OperacaoConteinerEscalaDTO dto) {
+        return escalaServico.adicionarConteinerDescarga(id, dto);
+    }
+
+    @PostMapping("/escalas/{id}/carga")
+    public EscalaDetalheDTO adicionarCarga(@PathVariable Long id,
+                                           @Valid @RequestBody OperacaoConteinerEscalaDTO dto) {
+        return escalaServico.adicionarConteinerCarga(id, dto);
+    }
+
+    @DeleteMapping("/escalas/{id}/descarga/{codigoConteiner}")
+    public EscalaDetalheDTO removerDescarga(@PathVariable Long id,
+                                            @PathVariable String codigoConteiner) {
+        return escalaServico.removerConteinerDescarga(id, codigoConteiner);
+    }
+
+    @DeleteMapping("/escalas/{id}/carga/{codigoConteiner}")
+    public EscalaDetalheDTO removerCarga(@PathVariable Long id,
+                                         @PathVariable String codigoConteiner) {
+        return escalaServico.removerConteinerCarga(id, codigoConteiner);
+    }
+
+    @PatchMapping("/escalas/{id}/descarga/{codigoConteiner}/status")
+    public EscalaDetalheDTO atualizarStatusDescarga(@PathVariable Long id,
+                                                    @PathVariable String codigoConteiner,
+                                                    @Valid @RequestBody AtualizacaoStatusConteinerEscalaDTO dto) {
+        return escalaServico.atualizarStatusConteinerDescarga(id, codigoConteiner, dto.getStatusOperacao());
+    }
+
+    @PatchMapping("/escalas/{id}/carga/{codigoConteiner}/status")
+    public EscalaDetalheDTO atualizarStatusCarga(@PathVariable Long id,
+                                                 @PathVariable String codigoConteiner,
+                                                 @Valid @RequestBody AtualizacaoStatusConteinerEscalaDTO dto) {
+        return escalaServico.atualizarStatusConteinerCarga(id, codigoConteiner, dto.getStatusOperacao());
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/AtualizacaoStatusConteinerEscalaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/AtualizacaoStatusConteinerEscalaDTO.java
@@ -1,0 +1,18 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import br.com.cloudport.serviconavio.escala.entidade.StatusOperacaoConteinerEscala;
+import javax.validation.constraints.NotNull;
+
+public class AtualizacaoStatusConteinerEscalaDTO {
+
+    @NotNull(message = "Informe o status da operação do contêiner.")
+    private StatusOperacaoConteinerEscala statusOperacao;
+
+    public StatusOperacaoConteinerEscala getStatusOperacao() {
+        return statusOperacao;
+    }
+
+    public void setStatusOperacao(StatusOperacaoConteinerEscala statusOperacao) {
+        this.statusOperacao = statusOperacao;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/EscalaDetalheDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/EscalaDetalheDTO.java
@@ -5,6 +5,9 @@ import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class EscalaDetalheDTO {
 
@@ -30,6 +33,8 @@ public class EscalaDetalheDTO {
     private final String bercoPrevisto;
     private final String bercoAtual;
     private final String observacoes;
+    private final List<OperacaoConteinerEscalaResumoDTO> listaDescarga;
+    private final List<OperacaoConteinerEscalaResumoDTO> listaCarga;
 
     public EscalaDetalheDTO(Long id,
                             Long navioId,
@@ -46,7 +51,9 @@ public class EscalaDetalheDTO {
                             LocalDateTime partidaEfetiva,
                             String bercoPrevisto,
                             String bercoAtual,
-                            String observacoes) {
+                            String observacoes,
+                            List<OperacaoConteinerEscalaResumoDTO> listaDescarga,
+                            List<OperacaoConteinerEscalaResumoDTO> listaCarga) {
         this.id = id;
         this.navioId = navioId;
         this.nomeNavio = nomeNavio;
@@ -63,6 +70,8 @@ public class EscalaDetalheDTO {
         this.bercoPrevisto = bercoPrevisto;
         this.bercoAtual = bercoAtual;
         this.observacoes = observacoes;
+        this.listaDescarga = listaDescarga;
+        this.listaCarga = listaCarga;
     }
 
     public static EscalaDetalheDTO deEntidade(Escala escala) {
@@ -82,8 +91,17 @@ public class EscalaDetalheDTO {
                 escala.getPartidaEfetiva(),
                 escala.getBercoPrevisto(),
                 escala.getBercoAtual(),
-                escala.getObservacoes()
+                escala.getObservacoes(),
+                mapearLista(escala.getListaDescarga()),
+                mapearLista(escala.getListaCarga())
         );
+    }
+
+    private static List<OperacaoConteinerEscalaResumoDTO> mapearLista(
+            List<br.com.cloudport.serviconavio.escala.entidade.OperacaoConteinerEscala> lista) {
+        return Optional.ofNullable(lista).orElseGet(List::of).stream()
+                .map(OperacaoConteinerEscalaResumoDTO::deEntidade)
+                .collect(Collectors.toList());
     }
 
     public Long getId() {
@@ -148,5 +166,13 @@ public class EscalaDetalheDTO {
 
     public String getObservacoes() {
         return observacoes;
+    }
+
+    public List<OperacaoConteinerEscalaResumoDTO> getListaDescarga() {
+        return listaDescarga;
+    }
+
+    public List<OperacaoConteinerEscalaResumoDTO> getListaCarga() {
+        return listaCarga;
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/EventoMovimentacaoNavioConcluidaDto.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/EventoMovimentacaoNavioConcluidaDto.java
@@ -1,0 +1,78 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import java.time.OffsetDateTime;
+
+public class EventoMovimentacaoNavioConcluidaDto {
+
+    private Long idEscala;
+    private Long idOrdemMovimentacao;
+    private String codigoConteiner;
+    private String tipoMovimentacao;
+    private OffsetDateTime concluidoEm;
+    private String statusEvento;
+
+    public EventoMovimentacaoNavioConcluidaDto() {
+    }
+
+    public EventoMovimentacaoNavioConcluidaDto(Long idEscala,
+                                               Long idOrdemMovimentacao,
+                                               String codigoConteiner,
+                                               String tipoMovimentacao,
+                                               OffsetDateTime concluidoEm,
+                                               String statusEvento) {
+        this.idEscala = idEscala;
+        this.idOrdemMovimentacao = idOrdemMovimentacao;
+        this.codigoConteiner = codigoConteiner;
+        this.tipoMovimentacao = tipoMovimentacao;
+        this.concluidoEm = concluidoEm;
+        this.statusEvento = statusEvento;
+    }
+
+    public Long getIdEscala() {
+        return idEscala;
+    }
+
+    public void setIdEscala(Long idEscala) {
+        this.idEscala = idEscala;
+    }
+
+    public Long getIdOrdemMovimentacao() {
+        return idOrdemMovimentacao;
+    }
+
+    public void setIdOrdemMovimentacao(Long idOrdemMovimentacao) {
+        this.idOrdemMovimentacao = idOrdemMovimentacao;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public String getTipoMovimentacao() {
+        return tipoMovimentacao;
+    }
+
+    public void setTipoMovimentacao(String tipoMovimentacao) {
+        this.tipoMovimentacao = tipoMovimentacao;
+    }
+
+    public OffsetDateTime getConcluidoEm() {
+        return concluidoEm;
+    }
+
+    public void setConcluidoEm(OffsetDateTime concluidoEm) {
+        this.concluidoEm = concluidoEm;
+    }
+
+    public String getStatusEvento() {
+        return statusEvento;
+    }
+
+    public void setStatusEvento(String statusEvento) {
+        this.statusEvento = statusEvento;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/OperacaoConteinerEscalaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/OperacaoConteinerEscalaDTO.java
@@ -1,0 +1,30 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import br.com.cloudport.serviconavio.escala.entidade.StatusOperacaoConteinerEscala;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public class OperacaoConteinerEscalaDTO {
+
+    @NotBlank(message = "Informe o código do contêiner.")
+    @Size(max = 20, message = "O código do contêiner deve ter no máximo 20 caracteres.")
+    private String codigoConteiner;
+
+    private StatusOperacaoConteinerEscala statusOperacao;
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public StatusOperacaoConteinerEscala getStatusOperacao() {
+        return statusOperacao;
+    }
+
+    public void setStatusOperacao(StatusOperacaoConteinerEscala statusOperacao) {
+        this.statusOperacao = statusOperacao;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/OperacaoConteinerEscalaResumoDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/dto/OperacaoConteinerEscalaResumoDTO.java
@@ -1,0 +1,31 @@
+package br.com.cloudport.serviconavio.escala.dto;
+
+import br.com.cloudport.serviconavio.escala.entidade.OperacaoConteinerEscala;
+import br.com.cloudport.serviconavio.escala.entidade.StatusOperacaoConteinerEscala;
+import org.springframework.web.util.HtmlUtils;
+
+public class OperacaoConteinerEscalaResumoDTO {
+
+    private final String codigoConteiner;
+    private final StatusOperacaoConteinerEscala statusOperacao;
+
+    public OperacaoConteinerEscalaResumoDTO(String codigoConteiner, StatusOperacaoConteinerEscala statusOperacao) {
+        this.codigoConteiner = codigoConteiner;
+        this.statusOperacao = statusOperacao;
+    }
+
+    public static OperacaoConteinerEscalaResumoDTO deEntidade(OperacaoConteinerEscala operacao) {
+        return new OperacaoConteinerEscalaResumoDTO(
+                HtmlUtils.htmlEscape(operacao.getCodigoConteiner()),
+                operacao.getStatusOperacao()
+        );
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public StatusOperacaoConteinerEscala getStatusOperacao() {
+        return statusOperacao;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/Escala.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/Escala.java
@@ -1,7 +1,9 @@
 package br.com.cloudport.serviconavio.escala.entidade;
 
 import br.com.cloudport.serviconavio.navio.entidade.Navio;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -11,10 +13,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OrderColumn;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "escala")
@@ -70,6 +76,22 @@ public class Escala {
 
     @Column(name = "atualizado_em", nullable = false)
     private LocalDateTime atualizadoEm;
+
+    @ElementCollection
+    @CollectionTable(name = "escala_descarga",
+            joinColumns = @JoinColumn(name = "escala_id"),
+            uniqueConstraints = @UniqueConstraint(name = "uk_escala_descarga_conteiner",
+                    columnNames = {"escala_id", "codigo_conteiner"}))
+    @OrderColumn(name = "ordem_descarga")
+    private List<OperacaoConteinerEscala> listaDescarga = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "escala_carga",
+            joinColumns = @JoinColumn(name = "escala_id"),
+            uniqueConstraints = @UniqueConstraint(name = "uk_escala_carga_conteiner",
+                    columnNames = {"escala_id", "codigo_conteiner"}))
+    @OrderColumn(name = "ordem_carga")
+    private List<OperacaoConteinerEscala> listaCarga = new ArrayList<>();
 
     public Long getId() {
         return id;
@@ -197,6 +219,28 @@ public class Escala {
 
     public void setAtualizadoEm(LocalDateTime atualizadoEm) {
         this.atualizadoEm = atualizadoEm;
+    }
+
+    public List<OperacaoConteinerEscala> getListaDescarga() {
+        return listaDescarga;
+    }
+
+    public void definirListaDescarga(List<OperacaoConteinerEscala> listaDescarga) {
+        this.listaDescarga.clear();
+        if (listaDescarga != null) {
+            this.listaDescarga.addAll(listaDescarga);
+        }
+    }
+
+    public List<OperacaoConteinerEscala> getListaCarga() {
+        return listaCarga;
+    }
+
+    public void definirListaCarga(List<OperacaoConteinerEscala> listaCarga) {
+        this.listaCarga.clear();
+        if (listaCarga != null) {
+            this.listaCarga.addAll(listaCarga);
+        }
     }
 
     @PrePersist

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/FaseEscala.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/FaseEscala.java
@@ -41,4 +41,12 @@ public enum FaseEscala {
     public boolean isTerminal() {
         return this == ENCERRADA || this == CANCELADA;
     }
+
+    /**
+     * Fases em que o navio está disponível no berço para gerar ordens de movimentação
+     * (descarga/carga) — análogo ao estado "Working" do Navis N4.
+     */
+    public boolean permiteOperacaoConteiner() {
+        return this == ATRACADO || this == OPERANDO;
+    }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/OperacaoConteinerEscala.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/OperacaoConteinerEscala.java
@@ -1,0 +1,60 @@
+package br.com.cloudport.serviconavio.escala.entidade;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Embeddable
+public class OperacaoConteinerEscala {
+
+    @Column(name = "codigo_conteiner", nullable = false, length = 20)
+    private String codigoConteiner;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status_operacao", nullable = false, length = 20)
+    private StatusOperacaoConteinerEscala statusOperacao = StatusOperacaoConteinerEscala.PENDENTE;
+
+    public OperacaoConteinerEscala() {
+    }
+
+    public OperacaoConteinerEscala(String codigoConteiner, StatusOperacaoConteinerEscala statusOperacao) {
+        this.codigoConteiner = codigoConteiner;
+        this.statusOperacao = statusOperacao;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public StatusOperacaoConteinerEscala getStatusOperacao() {
+        return statusOperacao;
+    }
+
+    public void setStatusOperacao(StatusOperacaoConteinerEscala statusOperacao) {
+        this.statusOperacao = statusOperacao;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OperacaoConteinerEscala that = (OperacaoConteinerEscala) o;
+        return Objects.equals(codigoConteiner, that.codigoConteiner)
+                && statusOperacao == that.statusOperacao;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(codigoConteiner, statusOperacao);
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/StatusOperacaoConteinerEscala.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/entidade/StatusOperacaoConteinerEscala.java
@@ -1,0 +1,6 @@
+package br.com.cloudport.serviconavio.escala.entidade;
+
+public enum StatusOperacaoConteinerEscala {
+    PENDENTE,
+    CONCLUIDO
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/evento/PublicadorEventoMovimentacaoNavio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/evento/PublicadorEventoMovimentacaoNavio.java
@@ -1,0 +1,35 @@
+package br.com.cloudport.serviconavio.escala.evento;
+
+import br.com.cloudport.serviconavio.escala.dto.EventoMovimentacaoNavioConcluidaDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class PublicadorEventoMovimentacaoNavio {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PublicadorEventoMovimentacaoNavio.class);
+
+    private final RabbitTemplate rabbitTemplate;
+    private final String exchange;
+    private final String routingKey;
+
+    public PublicadorEventoMovimentacaoNavio(RabbitTemplate rabbitTemplate,
+                                             @Value("${cloudport.navio.eventos.exchange}") String exchange,
+                                             @Value("${cloudport.navio.eventos.routing-movimentacao}") String routingKey) {
+        this.rabbitTemplate = rabbitTemplate;
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+    }
+
+    public void publicar(EventoMovimentacaoNavioConcluidaDto evento) {
+        Assert.notNull(evento, "Evento da movimentação do navio não pode ser nulo");
+        LOGGER.info("event=movimentacao_navio.publicada ordem={} escala={} conteiner={} tipo={}",
+                evento.getIdOrdemMovimentacao(), evento.getIdEscala(), evento.getCodigoConteiner(),
+                evento.getTipoMovimentacao());
+        rabbitTemplate.convertAndSend(exchange, routingKey, evento);
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/controlador/ListaTrabalhoEscalaControlador.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/controlador/ListaTrabalhoEscalaControlador.java
@@ -1,0 +1,43 @@
+package br.com.cloudport.serviconavio.escala.listatrabalho.controlador;
+
+import br.com.cloudport.serviconavio.escala.listatrabalho.dto.AtualizacaoStatusOrdemNavioDTO;
+import br.com.cloudport.serviconavio.escala.listatrabalho.dto.OrdemMovimentacaoNavioRespostaDTO;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.StatusOrdemMovimentacaoNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.servico.OrdemMovimentacaoNavioServico;
+import java.util.List;
+import javax.validation.Valid;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/escalas/{idEscala}/ordens")
+@Validated
+public class ListaTrabalhoEscalaControlador {
+
+    private final OrdemMovimentacaoNavioServico ordemServico;
+
+    public ListaTrabalhoEscalaControlador(OrdemMovimentacaoNavioServico ordemServico) {
+        this.ordemServico = ordemServico;
+    }
+
+    @GetMapping
+    public List<OrdemMovimentacaoNavioRespostaDTO> listarOrdens(
+            @PathVariable("idEscala") Long idEscala,
+            @RequestParam(name = "status", required = false) StatusOrdemMovimentacaoNavio status) {
+        return ordemServico.listarOrdensParaExecucao(idEscala, status);
+    }
+
+    @PatchMapping("/{idOrdem}/status")
+    public OrdemMovimentacaoNavioRespostaDTO atualizarStatus(
+            @PathVariable("idEscala") Long idEscala,
+            @PathVariable("idOrdem") Long idOrdem,
+            @Valid @RequestBody AtualizacaoStatusOrdemNavioDTO dto) {
+        return ordemServico.atualizarStatus(idEscala, idOrdem, dto.getStatusMovimentacao());
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/dto/AtualizacaoStatusOrdemNavioDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/dto/AtualizacaoStatusOrdemNavioDTO.java
@@ -1,0 +1,18 @@
+package br.com.cloudport.serviconavio.escala.listatrabalho.dto;
+
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.StatusOrdemMovimentacaoNavio;
+import javax.validation.constraints.NotNull;
+
+public class AtualizacaoStatusOrdemNavioDTO {
+
+    @NotNull(message = "Informe o status da movimentação.")
+    private StatusOrdemMovimentacaoNavio statusMovimentacao;
+
+    public StatusOrdemMovimentacaoNavio getStatusMovimentacao() {
+        return statusMovimentacao;
+    }
+
+    public void setStatusMovimentacao(StatusOrdemMovimentacaoNavio statusMovimentacao) {
+        this.statusMovimentacao = statusMovimentacao;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/dto/OrdemMovimentacaoNavioRespostaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/dto/OrdemMovimentacaoNavioRespostaDTO.java
@@ -1,0 +1,74 @@
+package br.com.cloudport.serviconavio.escala.listatrabalho.dto;
+
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.OrdemMovimentacaoNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.StatusOrdemMovimentacaoNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.TipoMovimentacaoOrdemNavio;
+import java.time.LocalDateTime;
+import org.springframework.web.util.HtmlUtils;
+
+public class OrdemMovimentacaoNavioRespostaDTO {
+
+    private final Long id;
+    private final Long idEscala;
+    private final String codigoConteiner;
+    private final TipoMovimentacaoOrdemNavio tipoMovimentacao;
+    private final StatusOrdemMovimentacaoNavio statusMovimentacao;
+    private final LocalDateTime criadoEm;
+    private final LocalDateTime atualizadoEm;
+
+    public OrdemMovimentacaoNavioRespostaDTO(Long id,
+                                             Long idEscala,
+                                             String codigoConteiner,
+                                             TipoMovimentacaoOrdemNavio tipoMovimentacao,
+                                             StatusOrdemMovimentacaoNavio statusMovimentacao,
+                                             LocalDateTime criadoEm,
+                                             LocalDateTime atualizadoEm) {
+        this.id = id;
+        this.idEscala = idEscala;
+        this.codigoConteiner = codigoConteiner;
+        this.tipoMovimentacao = tipoMovimentacao;
+        this.statusMovimentacao = statusMovimentacao;
+        this.criadoEm = criadoEm;
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    public static OrdemMovimentacaoNavioRespostaDTO deEntidade(OrdemMovimentacaoNavio entidade) {
+        return new OrdemMovimentacaoNavioRespostaDTO(
+                entidade.getId(),
+                entidade.getEscala() != null ? entidade.getEscala().getId() : null,
+                HtmlUtils.htmlEscape(entidade.getCodigoConteiner()),
+                entidade.getTipoMovimentacao(),
+                entidade.getStatusMovimentacao(),
+                entidade.getCriadoEm(),
+                entidade.getAtualizadoEm()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getIdEscala() {
+        return idEscala;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public TipoMovimentacaoOrdemNavio getTipoMovimentacao() {
+        return tipoMovimentacao;
+    }
+
+    public StatusOrdemMovimentacaoNavio getStatusMovimentacao() {
+        return statusMovimentacao;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/modelo/OrdemMovimentacaoNavio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/modelo/OrdemMovimentacaoNavio.java
@@ -1,0 +1,123 @@
+package br.com.cloudport.serviconavio.escala.listatrabalho.modelo;
+
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "ordem_movimentacao_navio",
+        uniqueConstraints = @UniqueConstraint(name = "uk_ordem_navio_escala_conteiner_tipo",
+                columnNames = {"escala_id", "codigo_conteiner", "tipo_movimentacao"}))
+public class OrdemMovimentacaoNavio {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "escala_id", nullable = false)
+    private Escala escala;
+
+    @Column(name = "codigo_conteiner", nullable = false, length = 20)
+    private String codigoConteiner;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_movimentacao", nullable = false, length = 20)
+    private TipoMovimentacaoOrdemNavio tipoMovimentacao;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status_movimentacao", nullable = false, length = 20)
+    private StatusOrdemMovimentacaoNavio statusMovimentacao = StatusOrdemMovimentacaoNavio.PENDENTE;
+
+    @Column(name = "criado_em", nullable = false)
+    private LocalDateTime criadoEm;
+
+    @Column(name = "atualizado_em", nullable = false)
+    private LocalDateTime atualizadoEm;
+
+    public OrdemMovimentacaoNavio() {
+    }
+
+    public OrdemMovimentacaoNavio(Escala escala,
+                                  String codigoConteiner,
+                                  TipoMovimentacaoOrdemNavio tipoMovimentacao,
+                                  StatusOrdemMovimentacaoNavio statusMovimentacao) {
+        this.escala = escala;
+        definirCodigoConteiner(codigoConteiner);
+        this.tipoMovimentacao = tipoMovimentacao;
+        this.statusMovimentacao = statusMovimentacao;
+    }
+
+    @PrePersist
+    public void aoCriar() {
+        LocalDateTime agora = LocalDateTime.now();
+        this.criadoEm = agora;
+        this.atualizadoEm = agora;
+    }
+
+    @PreUpdate
+    public void aoAtualizar() {
+        this.atualizadoEm = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Escala getEscala() {
+        return escala;
+    }
+
+    public void setEscala(Escala escala) {
+        this.escala = escala;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        definirCodigoConteiner(codigoConteiner);
+    }
+
+    public TipoMovimentacaoOrdemNavio getTipoMovimentacao() {
+        return tipoMovimentacao;
+    }
+
+    public void setTipoMovimentacao(TipoMovimentacaoOrdemNavio tipoMovimentacao) {
+        this.tipoMovimentacao = tipoMovimentacao;
+    }
+
+    public StatusOrdemMovimentacaoNavio getStatusMovimentacao() {
+        return statusMovimentacao;
+    }
+
+    public void setStatusMovimentacao(StatusOrdemMovimentacaoNavio statusMovimentacao) {
+        this.statusMovimentacao = statusMovimentacao;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+
+    private void definirCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner != null ? codigoConteiner.trim().toUpperCase() : null;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/modelo/StatusOrdemMovimentacaoNavio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/modelo/StatusOrdemMovimentacaoNavio.java
@@ -1,0 +1,7 @@
+package br.com.cloudport.serviconavio.escala.listatrabalho.modelo;
+
+public enum StatusOrdemMovimentacaoNavio {
+    PENDENTE,
+    EM_EXECUCAO,
+    CONCLUIDA
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/modelo/TipoMovimentacaoOrdemNavio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/modelo/TipoMovimentacaoOrdemNavio.java
@@ -1,0 +1,6 @@
+package br.com.cloudport.serviconavio.escala.listatrabalho.modelo;
+
+public enum TipoMovimentacaoOrdemNavio {
+    DESCARGA_NAVIO,
+    CARGA_NAVIO
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/repositorio/OrdemMovimentacaoNavioRepositorio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/repositorio/OrdemMovimentacaoNavioRepositorio.java
@@ -1,0 +1,25 @@
+package br.com.cloudport.serviconavio.escala.listatrabalho.repositorio;
+
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.OrdemMovimentacaoNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.StatusOrdemMovimentacaoNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.TipoMovimentacaoOrdemNavio;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrdemMovimentacaoNavioRepositorio extends JpaRepository<OrdemMovimentacaoNavio, Long> {
+
+    List<OrdemMovimentacaoNavio> findByEscalaIdAndStatusMovimentacaoInOrderByCriadoEmAsc(
+            Long idEscala, Collection<StatusOrdemMovimentacaoNavio> status);
+
+    List<OrdemMovimentacaoNavio> findByEscalaId(Long idEscala);
+
+    Optional<OrdemMovimentacaoNavio> findByEscalaIdAndCodigoConteinerIgnoreCaseAndTipoMovimentacao(
+            Long idEscala, String codigoConteiner, TipoMovimentacaoOrdemNavio tipoMovimentacao);
+
+    Optional<OrdemMovimentacaoNavio> findByIdAndEscalaId(Long idOrdem, Long idEscala);
+
+    boolean existsByEscalaIdAndCodigoConteinerIgnoreCaseAndTipoMovimentacao(
+            Long idEscala, String codigoConteiner, TipoMovimentacaoOrdemNavio tipoMovimentacao);
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/servico/OrdemMovimentacaoNavioServico.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/listatrabalho/servico/OrdemMovimentacaoNavioServico.java
@@ -1,0 +1,219 @@
+package br.com.cloudport.serviconavio.escala.listatrabalho.servico;
+
+import br.com.cloudport.serviconavio.escala.dto.EventoMovimentacaoNavioConcluidaDto;
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import br.com.cloudport.serviconavio.escala.entidade.OperacaoConteinerEscala;
+import br.com.cloudport.serviconavio.escala.evento.PublicadorEventoMovimentacaoNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.dto.OrdemMovimentacaoNavioRespostaDTO;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.OrdemMovimentacaoNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.StatusOrdemMovimentacaoNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.TipoMovimentacaoOrdemNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.repositorio.OrdemMovimentacaoNavioRepositorio;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class OrdemMovimentacaoNavioServico {
+
+    private final OrdemMovimentacaoNavioRepositorio ordemRepositorio;
+    private final PublicadorEventoMovimentacaoNavio publicador;
+
+    public OrdemMovimentacaoNavioServico(OrdemMovimentacaoNavioRepositorio ordemRepositorio,
+                                         PublicadorEventoMovimentacaoNavio publicador) {
+        this.ordemRepositorio = ordemRepositorio;
+        this.publicador = publicador;
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrdemMovimentacaoNavioRespostaDTO> listarOrdensParaExecucao(Long idEscala,
+                                                                            StatusOrdemMovimentacaoNavio statusFiltro) {
+        if (idEscala == null || idEscala <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Identificador da escala inválido.");
+        }
+        List<StatusOrdemMovimentacaoNavio> filtros = statusFiltro != null
+                ? List.of(statusFiltro)
+                : new ArrayList<>(EnumSet.of(StatusOrdemMovimentacaoNavio.PENDENTE,
+                StatusOrdemMovimentacaoNavio.EM_EXECUCAO));
+        return ordemRepositorio.findByEscalaIdAndStatusMovimentacaoInOrderByCriadoEmAsc(idEscala, filtros).stream()
+                .map(OrdemMovimentacaoNavioRespostaDTO::deEntidade)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public OrdemMovimentacaoNavioRespostaDTO atualizarStatus(Long idEscala,
+                                                             Long idOrdem,
+                                                             StatusOrdemMovimentacaoNavio novoStatus) {
+        if (idEscala == null || idEscala <= 0 || idOrdem == null || idOrdem <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Identificador informado é inválido.");
+        }
+        StatusOrdemMovimentacaoNavio statusValidado = Optional.ofNullable(novoStatus)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "O status da movimentação deve ser informado."));
+        OrdemMovimentacaoNavio ordem = ordemRepositorio.findByIdAndEscalaId(idOrdem, idEscala)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Ordem de movimentação não encontrada para a escala informada."));
+        StatusOrdemMovimentacaoNavio statusAnterior = ordem.getStatusMovimentacao();
+        validarTransicaoStatus(statusAnterior, statusValidado);
+        ordem.setStatusMovimentacao(statusValidado);
+        OrdemMovimentacaoNavio atualizada = ordemRepositorio.save(ordem);
+        if (statusValidado == StatusOrdemMovimentacaoNavio.CONCLUIDA
+                && statusAnterior != StatusOrdemMovimentacaoNavio.CONCLUIDA) {
+            publicarEventoConclusao(atualizada);
+        }
+        return OrdemMovimentacaoNavioRespostaDTO.deEntidade(atualizada);
+    }
+
+    @Transactional
+    public void gerarOrdensPendentesParaEscala(Escala escala) {
+        if (escala == null || escala.getId() == null) {
+            return;
+        }
+        if (!escala.getFase().permiteOperacaoConteiner()) {
+            return;
+        }
+        List<OperacaoConteinerEscala> descarga = Optional.ofNullable(escala.getListaDescarga()).orElseGet(List::of);
+        List<OperacaoConteinerEscala> carga = Optional.ofNullable(escala.getListaCarga()).orElseGet(List::of);
+
+        Set<ChaveOrdem> chavesExistentes = ordemRepositorio.findByEscalaId(escala.getId()).stream()
+                .map(ordem -> new ChaveOrdem(ordem.getCodigoConteiner(), ordem.getTipoMovimentacao()))
+                .collect(Collectors.toCollection(HashSet::new));
+
+        List<OrdemMovimentacaoNavio> novasOrdens = new ArrayList<>();
+        adicionarOrdens(escala, descarga, TipoMovimentacaoOrdemNavio.DESCARGA_NAVIO, chavesExistentes, novasOrdens);
+        adicionarOrdens(escala, carga, TipoMovimentacaoOrdemNavio.CARGA_NAVIO, chavesExistentes, novasOrdens);
+
+        if (!novasOrdens.isEmpty()) {
+            ordemRepositorio.saveAll(novasOrdens);
+        }
+    }
+
+    @Transactional
+    public void registrarOrdemSeNecessario(Escala escala,
+                                           String codigoConteiner,
+                                           TipoMovimentacaoOrdemNavio tipoMovimentacao) {
+        if (escala == null || escala.getId() == null || !escala.getFase().permiteOperacaoConteiner()) {
+            return;
+        }
+        if (!StringUtils.hasText(codigoConteiner)) {
+            return;
+        }
+        boolean existe = ordemRepositorio
+                .existsByEscalaIdAndCodigoConteinerIgnoreCaseAndTipoMovimentacao(escala.getId(),
+                        codigoConteiner, tipoMovimentacao);
+        if (!existe) {
+            ordemRepositorio.save(new OrdemMovimentacaoNavio(escala, codigoConteiner, tipoMovimentacao,
+                    StatusOrdemMovimentacaoNavio.PENDENTE));
+        }
+    }
+
+    @Transactional
+    public void removerOrdemSeExistir(Long idEscala,
+                                      String codigoConteiner,
+                                      TipoMovimentacaoOrdemNavio tipoMovimentacao) {
+        if (idEscala == null || idEscala <= 0 || !StringUtils.hasText(codigoConteiner)) {
+            return;
+        }
+        ordemRepositorio
+                .findByEscalaIdAndCodigoConteinerIgnoreCaseAndTipoMovimentacao(idEscala, codigoConteiner, tipoMovimentacao)
+                .filter(ordem -> ordem.getStatusMovimentacao() != StatusOrdemMovimentacaoNavio.CONCLUIDA)
+                .ifPresent(ordemRepositorio::delete);
+    }
+
+    private void adicionarOrdens(Escala escala,
+                                 List<OperacaoConteinerEscala> operacoes,
+                                 TipoMovimentacaoOrdemNavio tipoMovimentacao,
+                                 Set<ChaveOrdem> chavesExistentes,
+                                 List<OrdemMovimentacaoNavio> novasOrdens) {
+        if (CollectionUtils.isEmpty(operacoes)) {
+            return;
+        }
+        for (OperacaoConteinerEscala operacao : operacoes) {
+            if (operacao == null || !StringUtils.hasText(operacao.getCodigoConteiner())) {
+                continue;
+            }
+            ChaveOrdem chave = new ChaveOrdem(operacao.getCodigoConteiner(), tipoMovimentacao);
+            if (chavesExistentes.contains(chave)) {
+                continue;
+            }
+            chavesExistentes.add(chave);
+            novasOrdens.add(new OrdemMovimentacaoNavio(escala, operacao.getCodigoConteiner(), tipoMovimentacao,
+                    StatusOrdemMovimentacaoNavio.PENDENTE));
+        }
+    }
+
+    private void validarTransicaoStatus(StatusOrdemMovimentacaoNavio statusAtual,
+                                        StatusOrdemMovimentacaoNavio novoStatus) {
+        if (Objects.equals(statusAtual, novoStatus)) {
+            return;
+        }
+        if (statusAtual == StatusOrdemMovimentacaoNavio.PENDENTE
+                && (novoStatus == StatusOrdemMovimentacaoNavio.EM_EXECUCAO
+                || novoStatus == StatusOrdemMovimentacaoNavio.CONCLUIDA)) {
+            return;
+        }
+        if (statusAtual == StatusOrdemMovimentacaoNavio.EM_EXECUCAO
+                && novoStatus == StatusOrdemMovimentacaoNavio.CONCLUIDA) {
+            return;
+        }
+        throw new ResponseStatusException(HttpStatus.CONFLICT,
+                String.format(Locale.ROOT,
+                        "A transição de status de %s para %s não é permitida.", statusAtual, novoStatus));
+    }
+
+    private void publicarEventoConclusao(OrdemMovimentacaoNavio ordem) {
+        if (ordem == null) {
+            return;
+        }
+        EventoMovimentacaoNavioConcluidaDto evento = new EventoMovimentacaoNavioConcluidaDto(
+                ordem.getEscala() != null ? ordem.getEscala().getId() : null,
+                ordem.getId(),
+                ordem.getCodigoConteiner(),
+                ordem.getTipoMovimentacao() != null ? ordem.getTipoMovimentacao().name() : null,
+                OffsetDateTime.now(ZoneOffset.UTC),
+                "MovimentacaoNavioConcluidaEvent");
+        publicador.publicar(evento);
+    }
+
+    private static final class ChaveOrdem {
+        private final String codigoConteiner;
+        private final TipoMovimentacaoOrdemNavio tipoMovimentacao;
+
+        private ChaveOrdem(String codigoConteiner, TipoMovimentacaoOrdemNavio tipoMovimentacao) {
+            this.codigoConteiner = codigoConteiner != null ? codigoConteiner.trim().toUpperCase() : null;
+            this.tipoMovimentacao = tipoMovimentacao;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            ChaveOrdem outra = (ChaveOrdem) obj;
+            return Objects.equals(codigoConteiner, outra.codigoConteiner)
+                    && tipoMovimentacao == outra.tipoMovimentacao;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(codigoConteiner, tipoMovimentacao);
+        }
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/servico/EscalaServico.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/escala/servico/EscalaServico.java
@@ -5,8 +5,13 @@ import br.com.cloudport.serviconavio.escala.dto.AtualizacaoEscalaDTO;
 import br.com.cloudport.serviconavio.escala.dto.CadastroEscalaDTO;
 import br.com.cloudport.serviconavio.escala.dto.EscalaDetalheDTO;
 import br.com.cloudport.serviconavio.escala.dto.EscalaResumoDTO;
+import br.com.cloudport.serviconavio.escala.dto.OperacaoConteinerEscalaDTO;
 import br.com.cloudport.serviconavio.escala.entidade.Escala;
 import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
+import br.com.cloudport.serviconavio.escala.entidade.OperacaoConteinerEscala;
+import br.com.cloudport.serviconavio.escala.entidade.StatusOperacaoConteinerEscala;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.TipoMovimentacaoOrdemNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.servico.OrdemMovimentacaoNavioServico;
 import br.com.cloudport.serviconavio.escala.repositorio.EscalaRepositorio;
 import br.com.cloudport.serviconavio.navio.entidade.Navio;
 import br.com.cloudport.serviconavio.navio.repositorio.NavioRepositorio;
@@ -19,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,13 +37,31 @@ public class EscalaServico {
     private final EscalaRepositorio escalaRepositorio;
     private final NavioRepositorio navioRepositorio;
     private final SanitizadorEntrada sanitizadorEntrada;
+    private final OrdemMovimentacaoNavioServico ordemMovimentacaoServico;
 
     public EscalaServico(EscalaRepositorio escalaRepositorio,
                          NavioRepositorio navioRepositorio,
-                         SanitizadorEntrada sanitizadorEntrada) {
+                         SanitizadorEntrada sanitizadorEntrada,
+                         OrdemMovimentacaoNavioServico ordemMovimentacaoServico) {
         this.escalaRepositorio = escalaRepositorio;
         this.navioRepositorio = navioRepositorio;
         this.sanitizadorEntrada = sanitizadorEntrada;
+        this.ordemMovimentacaoServico = ordemMovimentacaoServico;
+    }
+
+    private enum TipoLista {
+        DESCARGA,
+        CARGA;
+
+        TipoLista inverso() {
+            return this == DESCARGA ? CARGA : DESCARGA;
+        }
+
+        TipoMovimentacaoOrdemNavio tipoMovimentacao() {
+            return this == DESCARGA
+                    ? TipoMovimentacaoOrdemNavio.DESCARGA_NAVIO
+                    : TipoMovimentacaoOrdemNavio.CARGA_NAVIO;
+        }
     }
 
     @Transactional(readOnly = true)
@@ -145,7 +169,122 @@ public class EscalaServico {
         LocalDateTime agora = LocalDateTime.now();
         carimbarTemposEfetivos(escala, destino, agora);
         escala.setFase(destino);
-        return EscalaDetalheDTO.deEntidade(escalaRepositorio.save(escala));
+        Escala salvo = escalaRepositorio.save(escala);
+        if (destino.permiteOperacaoConteiner()) {
+            ordemMovimentacaoServico.gerarOrdensPendentesParaEscala(salvo);
+        }
+        return EscalaDetalheDTO.deEntidade(salvo);
+    }
+
+    @Transactional
+    public EscalaDetalheDTO adicionarConteinerDescarga(Long idEscala, OperacaoConteinerEscalaDTO dto) {
+        return adicionarConteiner(idEscala, dto, TipoLista.DESCARGA);
+    }
+
+    @Transactional
+    public EscalaDetalheDTO adicionarConteinerCarga(Long idEscala, OperacaoConteinerEscalaDTO dto) {
+        return adicionarConteiner(idEscala, dto, TipoLista.CARGA);
+    }
+
+    @Transactional
+    public EscalaDetalheDTO removerConteinerDescarga(Long idEscala, String codigoConteiner) {
+        return removerConteiner(idEscala, codigoConteiner, TipoLista.DESCARGA);
+    }
+
+    @Transactional
+    public EscalaDetalheDTO removerConteinerCarga(Long idEscala, String codigoConteiner) {
+        return removerConteiner(idEscala, codigoConteiner, TipoLista.CARGA);
+    }
+
+    @Transactional
+    public EscalaDetalheDTO atualizarStatusConteinerDescarga(Long idEscala,
+                                                             String codigoConteiner,
+                                                             StatusOperacaoConteinerEscala status) {
+        return atualizarStatusConteiner(idEscala, codigoConteiner, status, TipoLista.DESCARGA);
+    }
+
+    @Transactional
+    public EscalaDetalheDTO atualizarStatusConteinerCarga(Long idEscala,
+                                                          String codigoConteiner,
+                                                          StatusOperacaoConteinerEscala status) {
+        return atualizarStatusConteiner(idEscala, codigoConteiner, status, TipoLista.CARGA);
+    }
+
+    private EscalaDetalheDTO adicionarConteiner(Long idEscala, OperacaoConteinerEscalaDTO dto, TipoLista tipoLista) {
+        Escala escala = obterEscala(idEscala);
+        if (escala.getFase().isTerminal()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Não é possível alterar as listas de uma escala encerrada ou cancelada.");
+        }
+        String codigo = sanitizarCodigoConteiner(dto != null ? dto.getCodigoConteiner() : null);
+        StatusOperacaoConteinerEscala status = Optional.ofNullable(dto != null ? dto.getStatusOperacao() : null)
+                .orElse(StatusOperacaoConteinerEscala.PENDENTE);
+
+        List<OperacaoConteinerEscala> listaAlvo = obterLista(escala, tipoLista);
+        if (listaAlvo.stream().anyMatch(item -> codigo.equals(item.getCodigoConteiner()))) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "O contêiner informado já está planejado nesta lista da escala.");
+        }
+        List<OperacaoConteinerEscala> listaOposta = obterLista(escala, tipoLista.inverso());
+        if (listaOposta.stream().anyMatch(item -> codigo.equals(item.getCodigoConteiner()))) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "O contêiner informado já está associado à outra lista desta escala.");
+        }
+
+        listaAlvo.add(new OperacaoConteinerEscala(codigo, status));
+        Escala salvo = escalaRepositorio.save(escala);
+        ordemMovimentacaoServico.registrarOrdemSeNecessario(salvo, codigo, tipoLista.tipoMovimentacao());
+        return EscalaDetalheDTO.deEntidade(salvo);
+    }
+
+    private EscalaDetalheDTO removerConteiner(Long idEscala, String codigoConteiner, TipoLista tipoLista) {
+        Escala escala = obterEscala(idEscala);
+        String codigo = sanitizarCodigoConteiner(codigoConteiner);
+        List<OperacaoConteinerEscala> listaAlvo = obterLista(escala, tipoLista);
+        boolean removido = listaAlvo.removeIf(item -> codigo.equals(item.getCodigoConteiner()));
+        if (!removido) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "O contêiner informado não está relacionado a esta lista da escala.");
+        }
+        Escala salvo = escalaRepositorio.save(escala);
+        ordemMovimentacaoServico.removerOrdemSeExistir(salvo.getId(), codigo, tipoLista.tipoMovimentacao());
+        return EscalaDetalheDTO.deEntidade(salvo);
+    }
+
+    private EscalaDetalheDTO atualizarStatusConteiner(Long idEscala,
+                                                      String codigoConteiner,
+                                                      StatusOperacaoConteinerEscala status,
+                                                      TipoLista tipoLista) {
+        Escala escala = obterEscala(idEscala);
+        String codigo = sanitizarCodigoConteiner(codigoConteiner);
+        StatusOperacaoConteinerEscala statusValidado = Optional.ofNullable(status)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "O status da operação deve ser informado."));
+        OperacaoConteinerEscala operacao = obterLista(escala, tipoLista).stream()
+                .filter(item -> codigo.equals(item.getCodigoConteiner()))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "O contêiner informado não está relacionado a esta lista da escala."));
+        operacao.setStatusOperacao(statusValidado);
+        Escala salvo = escalaRepositorio.save(escala);
+        return EscalaDetalheDTO.deEntidade(salvo);
+    }
+
+    private List<OperacaoConteinerEscala> obterLista(Escala escala, TipoLista tipoLista) {
+        return tipoLista == TipoLista.DESCARGA ? escala.getListaDescarga() : escala.getListaCarga();
+    }
+
+    private String sanitizarCodigoConteiner(String codigoConteiner) {
+        String limpo = sanitizadorEntrada.limparTexto(codigoConteiner);
+        if (!StringUtils.hasText(limpo)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "O código do contêiner deve ser informado.");
+        }
+        String normalizado = limpo.trim().toUpperCase(Locale.ROOT);
+        if (normalizado.length() > 20) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "O código do contêiner deve ter no máximo 20 caracteres.");
+        }
+        return normalizado;
     }
 
     @Transactional

--- a/backend/servico-navio/src/main/resources/application.properties
+++ b/backend/servico-navio/src/main/resources/application.properties
@@ -16,6 +16,14 @@ spring.flyway.locations=classpath:db/migration
 spring.flyway.default-schema=${NAVIO_FLYWAY_SCHEMA:cloudport_navio}
 spring.flyway.schemas=${NAVIO_FLYWAY_SCHEMA:cloudport_navio}
 
+spring.rabbitmq.host=${NAVIO_RABBIT_HOST:localhost}
+spring.rabbitmq.port=${NAVIO_RABBIT_PORT:5672}
+spring.rabbitmq.username=${NAVIO_RABBIT_USERNAME:guest}
+spring.rabbitmq.password=${NAVIO_RABBIT_PASSWORD:guest}
+
 # Segurança: valida o token JWT emitido pelo serviço de autenticação (segredo compartilhado)
 cloudport.security.jwt.secret=${JWT_SECRET}
 cloudport.security.cors.allowed-origins=${SECURITY_CORS_ALLOWED_ORIGINS:http://localhost:4200}
+
+cloudport.navio.eventos.exchange=${NAVIO_EVENTOS_EXCHANGE:navio.eventos}
+cloudport.navio.eventos.routing-movimentacao=${NAVIO_EVENTOS_ROUTING_MOVIMENTACAO:navio.movimentacao.concluida}

--- a/backend/servico-navio/src/main/resources/db/migration/V3__criar_listas_e_ordens_escala.sql
+++ b/backend/servico-navio/src/main/resources/db/migration/V3__criar_listas_e_ordens_escala.sql
@@ -1,0 +1,36 @@
+CREATE TABLE escala_descarga (
+    escala_id BIGINT NOT NULL,
+    codigo_conteiner VARCHAR(20) NOT NULL,
+    status_operacao VARCHAR(20) NOT NULL,
+    ordem_descarga INTEGER NOT NULL,
+    CONSTRAINT fk_escala_descarga FOREIGN KEY (escala_id)
+        REFERENCES escala (id) ON DELETE CASCADE
+);
+
+CREATE TABLE escala_carga (
+    escala_id BIGINT NOT NULL,
+    codigo_conteiner VARCHAR(20) NOT NULL,
+    status_operacao VARCHAR(20) NOT NULL,
+    ordem_carga INTEGER NOT NULL,
+    CONSTRAINT fk_escala_carga FOREIGN KEY (escala_id)
+        REFERENCES escala (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX uk_escala_descarga_conteiner ON escala_descarga (escala_id, codigo_conteiner);
+CREATE UNIQUE INDEX uk_escala_carga_conteiner ON escala_carga (escala_id, codigo_conteiner);
+
+CREATE TABLE ordem_movimentacao_navio (
+    id BIGSERIAL PRIMARY KEY,
+    escala_id BIGINT NOT NULL,
+    codigo_conteiner VARCHAR(20) NOT NULL,
+    tipo_movimentacao VARCHAR(20) NOT NULL,
+    status_movimentacao VARCHAR(20) NOT NULL,
+    criado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    atualizado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    CONSTRAINT fk_ordem_navio_escala FOREIGN KEY (escala_id)
+        REFERENCES escala (id) ON DELETE CASCADE,
+    CONSTRAINT uk_ordem_navio_escala_conteiner_tipo
+        UNIQUE (escala_id, codigo_conteiner, tipo_movimentacao)
+);
+
+CREATE INDEX idx_ordem_navio_escala_status ON ordem_movimentacao_navio (escala_id, status_movimentacao);

--- a/backend/servico-navio/src/test/java/br/com/cloudport/serviconavio/escala/servico/EscalaServicoTest.java
+++ b/backend/servico-navio/src/test/java/br/com/cloudport/serviconavio/escala/servico/EscalaServicoTest.java
@@ -4,8 +4,11 @@ import br.com.cloudport.serviconavio.comum.validacao.SanitizadorEntrada;
 import br.com.cloudport.serviconavio.escala.dto.AtualizacaoEscalaDTO;
 import br.com.cloudport.serviconavio.escala.dto.CadastroEscalaDTO;
 import br.com.cloudport.serviconavio.escala.dto.EscalaDetalheDTO;
+import br.com.cloudport.serviconavio.escala.dto.OperacaoConteinerEscalaDTO;
 import br.com.cloudport.serviconavio.escala.entidade.Escala;
 import br.com.cloudport.serviconavio.escala.entidade.FaseEscala;
+import br.com.cloudport.serviconavio.escala.listatrabalho.modelo.TipoMovimentacaoOrdemNavio;
+import br.com.cloudport.serviconavio.escala.listatrabalho.servico.OrdemMovimentacaoNavioServico;
 import br.com.cloudport.serviconavio.escala.repositorio.EscalaRepositorio;
 import br.com.cloudport.serviconavio.navio.entidade.Navio;
 import br.com.cloudport.serviconavio.navio.repositorio.NavioRepositorio;
@@ -30,6 +33,7 @@ class EscalaServicoTest {
     private EscalaRepositorio escalaRepositorio;
     private NavioRepositorio navioRepositorio;
     private SanitizadorEntrada sanitizadorEntrada;
+    private OrdemMovimentacaoNavioServico ordemMovimentacaoServico;
     private EscalaServico escalaServico;
 
     @BeforeEach
@@ -37,12 +41,14 @@ class EscalaServicoTest {
         escalaRepositorio = mock(EscalaRepositorio.class);
         navioRepositorio = mock(NavioRepositorio.class);
         sanitizadorEntrada = mock(SanitizadorEntrada.class);
+        ordemMovimentacaoServico = mock(OrdemMovimentacaoNavioServico.class);
         when(sanitizadorEntrada.limparTextoObrigatorio(anyString(), anyString()))
                 .thenAnswer(invocacao -> invocacao.getArgument(0));
         when(sanitizadorEntrada.limparTexto(anyString()))
                 .thenAnswer(invocacao -> invocacao.getArgument(0));
         when(escalaRepositorio.save(any(Escala.class))).thenAnswer(invocacao -> invocacao.getArgument(0));
-        escalaServico = new EscalaServico(escalaRepositorio, navioRepositorio, sanitizadorEntrada);
+        escalaServico = new EscalaServico(escalaRepositorio, navioRepositorio, sanitizadorEntrada,
+                ordemMovimentacaoServico);
     }
 
     private Navio navio() {
@@ -139,6 +145,40 @@ class EscalaServicoTest {
         when(escalaRepositorio.findById(1L)).thenReturn(Optional.of(escalaComFase(FaseEscala.ENCERRADA)));
 
         assertThatThrownBy(() -> escalaServico.atualizar(1L, new AtualizacaoEscalaDTO()))
+                .isInstanceOf(ResponseStatusException.class);
+
+        verify(escalaRepositorio, never()).save(any());
+    }
+
+    @Test
+    void avancarFaseParaAtracadoGeraOrdensDeMovimentacao() {
+        when(escalaRepositorio.findById(1L)).thenReturn(Optional.of(escalaComFase(FaseEscala.PREVISTA)));
+
+        escalaServico.avancarFase(1L, FaseEscala.ATRACADO);
+
+        verify(ordemMovimentacaoServico).gerarOrdensPendentesParaEscala(any(Escala.class));
+    }
+
+    @Test
+    void adicionarConteinerDescargaRegistraOrdemQuandoEmOperacao() {
+        when(escalaRepositorio.findById(1L)).thenReturn(Optional.of(escalaComFase(FaseEscala.OPERANDO)));
+        OperacaoConteinerEscalaDTO dto = new OperacaoConteinerEscalaDTO();
+        dto.setCodigoConteiner("msku1234567");
+
+        escalaServico.adicionarConteinerDescarga(1L, dto);
+
+        verify(ordemMovimentacaoServico)
+                .registrarOrdemSeNecessario(any(Escala.class), org.mockito.ArgumentMatchers.eq("MSKU1234567"),
+                        org.mockito.ArgumentMatchers.eq(TipoMovimentacaoOrdemNavio.DESCARGA_NAVIO));
+    }
+
+    @Test
+    void adicionarConteinerRejeitaEscalaTerminal() {
+        when(escalaRepositorio.findById(1L)).thenReturn(Optional.of(escalaComFase(FaseEscala.ENCERRADA)));
+        OperacaoConteinerEscalaDTO dto = new OperacaoConteinerEscalaDTO();
+        dto.setCodigoConteiner("MSKU1234567");
+
+        assertThatThrownBy(() -> escalaServico.adicionarConteinerDescarga(1L, dto))
                 .isInstanceOf(ResponseStatusException.class);
 
         verify(escalaRepositorio, never()).save(any());

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/configuracao/IntegracaoNavioRabbitConfiguracao.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/configuracao/IntegracaoNavioRabbitConfiguracao.java
@@ -1,0 +1,34 @@
+package br.com.cloudport.servicoyard.configuracao;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IntegracaoNavioRabbitConfiguracao {
+
+    @Bean
+    public TopicExchange exchangeMovimentacaoNavio(
+            @Value("${cloudport.yard.integracoes.navio.exchange}") String exchange) {
+        return new TopicExchange(exchange, true, false);
+    }
+
+    @Bean
+    public Queue filaMovimentacaoNavio(
+            @Value("${cloudport.yard.integracoes.navio.queue}") String queue) {
+        return new Queue(queue, true);
+    }
+
+    @Bean
+    public Binding bindingMovimentacaoNavio(Queue filaMovimentacaoNavio,
+                                            TopicExchange exchangeMovimentacaoNavio,
+                                            @Value("${cloudport.yard.integracoes.navio.routing}") String routingKey) {
+        return BindingBuilder.bind(filaMovimentacaoNavio)
+                .to(exchangeMovimentacaoNavio)
+                .with(routingKey);
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/dto/MovimentacaoNavioConcluidaEventoDto.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/dto/MovimentacaoNavioConcluidaEventoDto.java
@@ -1,0 +1,64 @@
+package br.com.cloudport.servicoyard.container.dto;
+
+import java.time.OffsetDateTime;
+
+public class MovimentacaoNavioConcluidaEventoDto {
+
+    private Long idEscala;
+    private Long idOrdemMovimentacao;
+    private String codigoConteiner;
+    private String tipoMovimentacao;
+    private OffsetDateTime concluidoEm;
+    private String statusEvento;
+
+    public MovimentacaoNavioConcluidaEventoDto() {
+    }
+
+    public Long getIdEscala() {
+        return idEscala;
+    }
+
+    public void setIdEscala(Long idEscala) {
+        this.idEscala = idEscala;
+    }
+
+    public Long getIdOrdemMovimentacao() {
+        return idOrdemMovimentacao;
+    }
+
+    public void setIdOrdemMovimentacao(Long idOrdemMovimentacao) {
+        this.idOrdemMovimentacao = idOrdemMovimentacao;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public String getTipoMovimentacao() {
+        return tipoMovimentacao;
+    }
+
+    public void setTipoMovimentacao(String tipoMovimentacao) {
+        this.tipoMovimentacao = tipoMovimentacao;
+    }
+
+    public OffsetDateTime getConcluidoEm() {
+        return concluidoEm;
+    }
+
+    public void setConcluidoEm(OffsetDateTime concluidoEm) {
+        this.concluidoEm = concluidoEm;
+    }
+
+    public String getStatusEvento() {
+        return statusEvento;
+    }
+
+    public void setStatusEvento(String statusEvento) {
+        this.statusEvento = statusEvento;
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/entidade/TipoOperacaoConteiner.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/entidade/TipoOperacaoConteiner.java
@@ -7,5 +7,7 @@ public enum TipoOperacaoConteiner {
     LIBERACAO,
     ATUALIZACAO_CADASTRAL,
     DESCARGA_TREM,
-    CARGA_TREM
+    CARGA_TREM,
+    DESCARGA_NAVIO,
+    CARGA_NAVIO
 }

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/enumeracao/TipoMovimentacaoNavioEnum.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/enumeracao/TipoMovimentacaoNavioEnum.java
@@ -1,0 +1,88 @@
+package br.com.cloudport.servicoyard.container.enumeracao;
+
+import br.com.cloudport.servicoyard.container.entidade.StatusOperacionalConteiner;
+import br.com.cloudport.servicoyard.container.entidade.TipoOperacaoConteiner;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public enum TipoMovimentacaoNavioEnum {
+    DESCARGA_NAVIO(
+            "Descarga do navio",
+            TipoOperacaoConteiner.DESCARGA_NAVIO,
+            "Descarga do navio concluída e contêiner disponível no pátio.",
+            StatusOperacionalConteiner.ALOCADO
+    ),
+    CARGA_NAVIO(
+            "Carga no navio",
+            TipoOperacaoConteiner.CARGA_NAVIO,
+            "Carga no navio concluída e contêiner embarcado.",
+            StatusOperacionalConteiner.EM_TRANSFERENCIA
+    );
+
+    private static final Map<String, TipoMovimentacaoNavioEnum> NOME_PARA_ENUM_MAP;
+    private static final Map<String, TipoMovimentacaoNavioEnum> DESCRICAO_PARA_ENUM_MAP;
+
+    static {
+        Map<String, TipoMovimentacaoNavioEnum> mapaNome = new HashMap<>();
+        Map<String, TipoMovimentacaoNavioEnum> mapaDescricao = new HashMap<>();
+        for (TipoMovimentacaoNavioEnum tipo : values()) {
+            mapaNome.put(tipo.name().toLowerCase(Locale.ROOT), tipo);
+            mapaDescricao.put(tipo.descricao.toLowerCase(Locale.ROOT), tipo);
+        }
+        NOME_PARA_ENUM_MAP = Collections.unmodifiableMap(mapaNome);
+        DESCRICAO_PARA_ENUM_MAP = Collections.unmodifiableMap(mapaDescricao);
+    }
+
+    private final String descricao;
+    private final TipoOperacaoConteiner tipoOperacaoConteiner;
+    private final String descricaoHistorico;
+    private final StatusOperacionalConteiner novoStatus;
+
+    TipoMovimentacaoNavioEnum(String descricao,
+                              TipoOperacaoConteiner tipoOperacaoConteiner,
+                              String descricaoHistorico,
+                              StatusOperacionalConteiner novoStatus) {
+        this.descricao = descricao;
+        this.tipoOperacaoConteiner = tipoOperacaoConteiner;
+        this.descricaoHistorico = descricaoHistorico;
+        this.novoStatus = novoStatus;
+    }
+
+    @JsonValue
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public TipoOperacaoConteiner getTipoOperacaoConteiner() {
+        return tipoOperacaoConteiner;
+    }
+
+    public String getDescricaoHistorico() {
+        return descricaoHistorico;
+    }
+
+    public StatusOperacionalConteiner getNovoStatus() {
+        return novoStatus;
+    }
+
+    @JsonCreator
+    public static TipoMovimentacaoNavioEnum fromString(String valor) {
+        if (valor == null) {
+            return null;
+        }
+        String chaveNormalizada = valor.trim().toLowerCase(Locale.ROOT);
+        TipoMovimentacaoNavioEnum porNome = NOME_PARA_ENUM_MAP.get(chaveNormalizada);
+        if (porNome != null) {
+            return porNome;
+        }
+        TipoMovimentacaoNavioEnum porDescricao = DESCRICAO_PARA_ENUM_MAP.get(chaveNormalizada);
+        if (porDescricao != null) {
+            return porDescricao;
+        }
+        throw new IllegalArgumentException("Valor inválido para TipoMovimentacaoNavioEnum: '" + valor + "'");
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/servico/MovimentacaoNavioListener.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/servico/MovimentacaoNavioListener.java
@@ -1,0 +1,28 @@
+package br.com.cloudport.servicoyard.container.servico;
+
+import br.com.cloudport.servicoyard.container.dto.MovimentacaoNavioConcluidaEventoDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MovimentacaoNavioListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MovimentacaoNavioListener.class);
+
+    private final ProcessadorMovimentacaoNavioService processadorMovimentacaoNavioService;
+
+    public MovimentacaoNavioListener(ProcessadorMovimentacaoNavioService processadorMovimentacaoNavioService) {
+        this.processadorMovimentacaoNavioService = processadorMovimentacaoNavioService;
+    }
+
+    @RabbitListener(queues = "${cloudport.yard.integracoes.navio.queue}")
+    public void aoReceberMovimentacao(MovimentacaoNavioConcluidaEventoDto evento) {
+        LOGGER.info("event=movimentacao_navio.recebida ordem={} escala={} conteiner={}",
+                evento != null ? evento.getIdOrdemMovimentacao() : null,
+                evento != null ? evento.getIdEscala() : null,
+                evento != null ? evento.getCodigoConteiner() : null);
+        processadorMovimentacaoNavioService.processar(evento);
+    }
+}

--- a/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/servico/ProcessadorMovimentacaoNavioService.java
+++ b/backend/servico-yard/src/main/java/br/com/cloudport/servicoyard/container/servico/ProcessadorMovimentacaoNavioService.java
@@ -1,0 +1,130 @@
+package br.com.cloudport.servicoyard.container.servico;
+
+import br.com.cloudport.servicoyard.container.dto.MovimentacaoNavioConcluidaEventoDto;
+import br.com.cloudport.servicoyard.container.entidade.Conteiner;
+import br.com.cloudport.servicoyard.container.entidade.HistoricoOperacaoConteiner;
+import br.com.cloudport.servicoyard.container.entidade.StatusOperacionalConteiner;
+import br.com.cloudport.servicoyard.container.entidade.TipoOperacaoConteiner;
+import br.com.cloudport.servicoyard.container.enumeracao.TipoMovimentacaoNavioEnum;
+import br.com.cloudport.servicoyard.container.repositorio.ConteinerRepositorio;
+import br.com.cloudport.servicoyard.container.repositorio.HistoricoOperacaoConteinerRepositorio;
+import br.com.cloudport.servicoyard.container.validacao.SanitizadorEntrada;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class ProcessadorMovimentacaoNavioService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessadorMovimentacaoNavioService.class);
+    private static final String RESPONSAVEL_INTEGRACAO = "Integração Navio";
+
+    private final ConteinerRepositorio conteinerRepositorio;
+    private final HistoricoOperacaoConteinerRepositorio historicoRepositorio;
+    private final SanitizadorEntrada sanitizadorEntrada;
+
+    public ProcessadorMovimentacaoNavioService(ConteinerRepositorio conteinerRepositorio,
+                                               HistoricoOperacaoConteinerRepositorio historicoRepositorio,
+                                               SanitizadorEntrada sanitizadorEntrada) {
+        this.conteinerRepositorio = conteinerRepositorio;
+        this.historicoRepositorio = historicoRepositorio;
+        this.sanitizadorEntrada = sanitizadorEntrada;
+    }
+
+    @Transactional
+    public void processar(MovimentacaoNavioConcluidaEventoDto evento) {
+        if (evento == null) {
+            LOGGER.warn("event=movimentacao_navio.evento_nulo");
+            return;
+        }
+        String codigoConteiner = Optional.ofNullable(evento.getCodigoConteiner())
+                .map(sanitizadorEntrada::limparTexto)
+                .map(valor -> valor.toUpperCase(Locale.ROOT))
+                .orElse(null);
+        if (!StringUtils.hasText(codigoConteiner)) {
+            LOGGER.warn("event=movimentacao_navio.codigo_ausente ordem={} escala={}",
+                    evento.getIdOrdemMovimentacao(), evento.getIdEscala());
+            return;
+        }
+        if (!StringUtils.hasText(evento.getTipoMovimentacao())) {
+            LOGGER.warn("event=movimentacao_navio.tipo_ausente ordem={} escala={}",
+                    evento.getIdOrdemMovimentacao(), evento.getIdEscala());
+            return;
+        }
+        TipoMovimentacaoNavioEnum tipoMovimentacao;
+        try {
+            tipoMovimentacao = TipoMovimentacaoNavioEnum.fromString(evento.getTipoMovimentacao());
+        } catch (IllegalArgumentException ex) {
+            LOGGER.warn("event=movimentacao_navio.tipo_invalido tipo={} ordem={} escala={}",
+                    evento.getTipoMovimentacao(), evento.getIdOrdemMovimentacao(), evento.getIdEscala(), ex);
+            return;
+        }
+        if (tipoMovimentacao == null) {
+            LOGGER.warn("event=movimentacao_navio.tipo_desconhecido tipo={} ordem={} escala={}",
+                    evento.getTipoMovimentacao(), evento.getIdOrdemMovimentacao(), evento.getIdEscala());
+            return;
+        }
+        TipoOperacaoConteiner tipoOperacao = tipoMovimentacao.getTipoOperacaoConteiner();
+        Conteiner conteiner = conteinerRepositorio.findByIdentificacaoIgnoreCase(codigoConteiner)
+                .orElse(null);
+        if (conteiner == null) {
+            LOGGER.warn("event=movimentacao_navio.conteiner_nao_localizado codigo={} ordem={} escala={}",
+                    codigoConteiner, evento.getIdOrdemMovimentacao(), evento.getIdEscala());
+            return;
+        }
+        StatusOperacionalConteiner statusAnterior = conteiner.getStatusOperacional();
+        StatusOperacionalConteiner novoStatus = definirStatusPosMovimentacao(tipoMovimentacao, statusAnterior);
+        if (novoStatus != null && novoStatus != statusAnterior) {
+            conteiner.setStatusOperacional(novoStatus);
+            conteinerRepositorio.save(conteiner);
+        }
+        registrarHistorico(conteiner, tipoMovimentacao, tipoOperacao, evento, statusAnterior, novoStatus);
+    }
+
+    private void registrarHistorico(Conteiner conteiner,
+                                    TipoMovimentacaoNavioEnum tipoMovimentacao,
+                                    TipoOperacaoConteiner tipoOperacao,
+                                    MovimentacaoNavioConcluidaEventoDto evento,
+                                    StatusOperacionalConteiner statusAnterior,
+                                    StatusOperacionalConteiner novoStatus) {
+        HistoricoOperacaoConteiner historico = new HistoricoOperacaoConteiner();
+        historico.setConteiner(conteiner);
+        historico.setTipoOperacao(tipoOperacao);
+        historico.setDescricao(montarDescricao(tipoMovimentacao, statusAnterior, novoStatus));
+        historico.setPosicaoAnterior(null);
+        historico.setPosicaoAtual(conteiner.getPosicaoPatio());
+        historico.setResponsavel(sanitizadorEntrada.limparTexto(RESPONSAVEL_INTEGRACAO));
+        OffsetDateTime dataRegistro = Optional.ofNullable(evento.getConcluidoEm())
+                .orElse(OffsetDateTime.now(ZoneOffset.UTC));
+        historico.setDataRegistro(dataRegistro);
+        historicoRepositorio.save(historico);
+    }
+
+    private StatusOperacionalConteiner definirStatusPosMovimentacao(TipoMovimentacaoNavioEnum tipoMovimentacao,
+                                                                    StatusOperacionalConteiner statusAtual) {
+        if (tipoMovimentacao == null) {
+            return statusAtual;
+        }
+        StatusOperacionalConteiner novoStatus = tipoMovimentacao.getNovoStatus();
+        if (novoStatus != null) {
+            return novoStatus;
+        }
+        return statusAtual;
+    }
+
+    private String montarDescricao(TipoMovimentacaoNavioEnum tipoMovimentacao,
+                                   StatusOperacionalConteiner statusAnterior,
+                                   StatusOperacionalConteiner novoStatus) {
+        if (tipoMovimentacao != null) {
+            return tipoMovimentacao.getDescricaoHistorico();
+        }
+        return String.format(Locale.ROOT,
+                "Movimentação atualizada de %s para %s.", statusAnterior, novoStatus);
+    }
+}

--- a/backend/servico-yard/src/main/resources/application.properties
+++ b/backend/servico-yard/src/main/resources/application.properties
@@ -30,3 +30,6 @@ cloudport.yard.eventos.routing-movimento=${YARD_EVENTOS_ROUTING_MOVIMENTO:yard.m
 cloudport.yard.integracoes.ferrovia.exchange=${YARD_FERROVIA_EXCHANGE:ferrovia.eventos}
 cloudport.yard.integracoes.ferrovia.queue=${YARD_FERROVIA_QUEUE:yard.movimentacao.trem}
 cloudport.yard.integracoes.ferrovia.routing=${YARD_FERROVIA_ROUTING:rail.movimentacao.concluida}
+cloudport.yard.integracoes.navio.exchange=${YARD_NAVIO_EXCHANGE:navio.eventos}
+cloudport.yard.integracoes.navio.queue=${YARD_NAVIO_QUEUE:yard.movimentacao.navio}
+cloudport.yard.integracoes.navio.routing=${YARD_NAVIO_ROUTING:navio.movimentacao.concluida}

--- a/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.css
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.css
@@ -251,6 +251,85 @@
   white-space: nowrap;
 }
 
+.ajuda {
+  margin: 0 0 14px;
+  color: #6a7480;
+  font-size: 0.9rem;
+}
+
+.listas-conteiner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.lista-bloco h3 {
+  margin: 0 0 10px;
+  font-size: 1rem;
+}
+
+.adicionar-conteiner {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.adicionar-conteiner input {
+  flex: 1;
+  padding: 7px 10px;
+  border: 1px solid #c5c5c5;
+  border-radius: 4px;
+}
+
+.conteineres {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.conteineres li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background-color: #f7f9fb;
+  border: 1px solid #e6e6e6;
+  border-radius: 4px;
+}
+
+.conteineres .codigo {
+  font-family: monospace;
+  font-weight: 600;
+  flex: 1;
+}
+
+.conteineres .status-conteiner {
+  font-size: 0.78rem;
+  color: #6a7480;
+  text-transform: uppercase;
+}
+
+.conteineres .remover {
+  border: none;
+  background: none;
+  color: #c62828;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.conteineres .remover:hover:not(:disabled) {
+  color: #7f1d1d;
+}
+
+.vazio {
+  color: #97a0ab;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
 .fase-prevista { background-color: #e3eefc; color: #1d4e89; }
 .fase-inbound { background-color: #e7f0ff; color: #0b5cad; }
 .fase-atracado { background-color: #fff4d6; color: #8a6100; }

--- a/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.html
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.html
@@ -107,6 +107,56 @@
       </div>
     </form>
 
+    <!-- Planejamento de pátio: listas de descarga e carga -->
+    <div class="painel" *ngIf="!modoEdicao">
+      <div class="cabecalho-painel">
+        <h2>Planejamento de pátio</h2>
+        <button type="button" class="botao-secundario" (click)="irParaListaTrabalho()">Lista de trabalho</button>
+      </div>
+      <p class="ajuda">
+        Os contêineres planejados geram ordens de movimentação quando a escala está atracada/em operação.
+        Ao concluir as ordens, o pátio é atualizado automaticamente.
+      </p>
+
+      <div class="listas-conteiner">
+        <div class="lista-bloco">
+          <h3>Descarga ({{ escala.listaDescarga.length }})</h3>
+          <div class="adicionar-conteiner" *ngIf="listasEditaveis">
+            <input type="text" maxlength="20" placeholder="Código do contêiner"
+                   [(ngModel)]="novoConteinerDescarga" (keyup.enter)="adicionarDescarga()" />
+            <button type="button" class="botao-primario" (click)="adicionarDescarga()" [disabled]="processando">Adicionar</button>
+          </div>
+          <ul class="conteineres" *ngIf="escala.listaDescarga.length > 0">
+            <li *ngFor="let op of escala.listaDescarga">
+              <span class="codigo">{{ textoSeguro(op.codigoConteiner) }}</span>
+              <span class="status-conteiner">{{ op.statusOperacao }}</span>
+              <button type="button" class="remover" *ngIf="listasEditaveis"
+                      (click)="removerDescarga(op.codigoConteiner)" [disabled]="processando" aria-label="Remover">✕</button>
+            </li>
+          </ul>
+          <p class="vazio" *ngIf="escala.listaDescarga.length === 0">Nenhum contêiner para descarga.</p>
+        </div>
+
+        <div class="lista-bloco">
+          <h3>Carga ({{ escala.listaCarga.length }})</h3>
+          <div class="adicionar-conteiner" *ngIf="listasEditaveis">
+            <input type="text" maxlength="20" placeholder="Código do contêiner"
+                   [(ngModel)]="novoConteinerCarga" (keyup.enter)="adicionarCarga()" />
+            <button type="button" class="botao-primario" (click)="adicionarCarga()" [disabled]="processando">Adicionar</button>
+          </div>
+          <ul class="conteineres" *ngIf="escala.listaCarga.length > 0">
+            <li *ngFor="let op of escala.listaCarga">
+              <span class="codigo">{{ textoSeguro(op.codigoConteiner) }}</span>
+              <span class="status-conteiner">{{ op.statusOperacao }}</span>
+              <button type="button" class="remover" *ngIf="listasEditaveis"
+                      (click)="removerCarga(op.codigoConteiner)" [disabled]="processando" aria-label="Remover">✕</button>
+            </li>
+          </ul>
+          <p class="vazio" *ngIf="escala.listaCarga.length === 0">Nenhum contêiner para carga.</p>
+        </div>
+      </div>
+    </div>
+
     <div class="painel zona-perigo" *ngIf="!modoEdicao">
       <button type="button" class="botao-perigo" (click)="remover()" [disabled]="processando">Remover escala</button>
     </div>

--- a/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.ts
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/detalhe-escala/detalhe-escala.component.ts
@@ -11,6 +11,7 @@ import {
   ServicoNavioService,
   TRANSICOES_FASE
 } from '../../../service/servico-navio/servico-navio.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-detalhe-escala',
@@ -25,6 +26,8 @@ export class DetalheEscalaComponent implements OnInit {
   erro?: string;
   mensagem?: string;
   modoEdicao = false;
+  novoConteinerDescarga = '';
+  novoConteinerCarga = '';
 
   edicao: {
     viagemEntrada: string;
@@ -179,6 +182,84 @@ export class DetalheEscalaComponent implements OnInit {
 
   voltar(): void {
     this.router.navigate(['/home', 'navio', 'escalas']);
+  }
+
+  irParaListaTrabalho(): void {
+    if (this.escala) {
+      this.router.navigate(['/home', 'navio', 'escalas', this.escala.id, 'lista-trabalho']);
+    }
+  }
+
+  get listasEditaveis(): boolean {
+    return !!this.escala && this.escala.fase !== 'ENCERRADA' && this.escala.fase !== 'CANCELADA';
+  }
+
+  adicionarDescarga(): void {
+    this.adicionarConteiner(this.novoConteinerDescarga,
+      (id, codigo) => this.servicoNavio.adicionarConteinerDescarga(id, codigo),
+      () => this.novoConteinerDescarga = '');
+  }
+
+  adicionarCarga(): void {
+    this.adicionarConteiner(this.novoConteinerCarga,
+      (id, codigo) => this.servicoNavio.adicionarConteinerCarga(id, codigo),
+      () => this.novoConteinerCarga = '');
+  }
+
+  removerDescarga(codigoConteiner: string): void {
+    this.executarOperacaoLista(
+      (id) => this.servicoNavio.removerConteinerDescarga(id, codigoConteiner));
+  }
+
+  removerCarga(codigoConteiner: string): void {
+    this.executarOperacaoLista(
+      (id) => this.servicoNavio.removerConteinerCarga(id, codigoConteiner));
+  }
+
+  private adicionarConteiner(codigo: string,
+                             acao: (id: number, codigo: string) => Observable<EscalaDetalhe>,
+                             aoConcluir: () => void): void {
+    if (!this.escala || this.processando) {
+      return;
+    }
+    const codigoLimpo = (codigo ?? '').trim();
+    if (!codigoLimpo) {
+      this.erro = 'Informe o código do contêiner.';
+      return;
+    }
+    this.processando = true;
+    this.erro = undefined;
+    this.mensagem = undefined;
+    acao(this.escala.id, codigoLimpo)
+      .pipe(finalize(() => this.processando = false))
+      .subscribe({
+        next: (escala) => {
+          this.escala = escala;
+          aoConcluir();
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro, 'Não foi possível adicionar o contêiner.');
+        }
+      });
+  }
+
+  private executarOperacaoLista(acao: (id: number) => Observable<EscalaDetalhe>): void {
+    if (!this.escala || this.processando) {
+      return;
+    }
+    this.processando = true;
+    this.erro = undefined;
+    this.mensagem = undefined;
+    acao(this.escala.id)
+      .pipe(finalize(() => this.processando = false))
+      .subscribe({
+        next: (escala) => {
+          this.escala = escala;
+        },
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro, 'Não foi possível atualizar a lista.');
+        }
+      });
   }
 
   rotuloFase(fase: FaseEscala): string {

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-trabalho-escala/lista-trabalho-escala.component.css
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-trabalho-escala/lista-trabalho-escala.component.css
@@ -1,0 +1,108 @@
+.lista-trabalho {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  max-width: 880px;
+}
+
+.link-voltar {
+  align-self: flex-start;
+  border: none;
+  background: none;
+  color: #005f9e;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0;
+}
+
+.link-voltar:hover {
+  text-decoration: underline;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.descricao {
+  margin: 4px 0 0;
+  color: #555;
+}
+
+.tabela-ordens {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+}
+
+.tabela-ordens th,
+.tabela-ordens td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #e6e6e6;
+  text-align: left;
+}
+
+.tabela-ordens thead {
+  background-color: #f5f7fa;
+}
+
+.tabela-ordens .codigo {
+  font-family: monospace;
+  font-weight: 600;
+}
+
+.coluna-acoes {
+  width: 160px;
+  text-align: right;
+}
+
+.botao-primario {
+  padding: 7px 14px;
+  border: none;
+  border-radius: 4px;
+  background-color: #1b6b3a;
+  color: #fff;
+  cursor: pointer;
+}
+
+.botao-primario:hover:not(:disabled),
+.botao-primario:focus:not(:disabled) {
+  background-color: #14512c;
+}
+
+.botao-primario:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.finalizada {
+  color: #97a0ab;
+}
+
+.status-tag {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.status-pendente { background-color: #e3eefc; color: #1d4e89; }
+.status-em_execucao { background-color: #fff4d6; color: #8a6100; }
+.status-concluida { background-color: #d8f3e0; color: #1b6b3a; }
+
+.estado-informativo {
+  padding: 12px;
+  background-color: #eef5ff;
+  border-left: 4px solid #005f9e;
+  color: #003b63;
+}
+
+.estado-erro {
+  padding: 12px;
+  background-color: #ffecec;
+  border-left: 4px solid #c62828;
+  color: #7f1d1d;
+}

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-trabalho-escala/lista-trabalho-escala.component.html
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-trabalho-escala/lista-trabalho-escala.component.html
@@ -1,0 +1,42 @@
+<section class="lista-trabalho">
+  <button type="button" class="link-voltar" (click)="voltar()">← Voltar à escala</button>
+
+  <header>
+    <h1>Lista de Trabalho</h1>
+    <p class="descricao">Ordens de movimentação geradas para a operação do navio. Concluí-las atualiza o pátio.</p>
+  </header>
+
+  <div *ngIf="estaCarregando" class="estado-informativo">Carregando ordens...</div>
+  <div *ngIf="erro" class="estado-erro">{{ textoSeguro(erro) }}</div>
+
+  <table *ngIf="!estaCarregando && ordens.length > 0" class="tabela-ordens" aria-label="Ordens de movimentação">
+    <thead>
+      <tr>
+        <th scope="col">Contêiner</th>
+        <th scope="col">Tipo</th>
+        <th scope="col">Status</th>
+        <th scope="col" class="coluna-acoes">Ação</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let ordem of ordens">
+        <td class="codigo">{{ textoSeguro(ordem.codigoConteiner) }}</td>
+        <td>{{ rotuloTipo(ordem.tipoMovimentacao) }}</td>
+        <td><span [class]="classeStatus(ordem.statusMovimentacao)">{{ rotuloStatus(ordem.statusMovimentacao) }}</span></td>
+        <td class="coluna-acoes">
+          <button type="button" class="botao-primario"
+                  *ngIf="proximoStatus(ordem)"
+                  [disabled]="processando"
+                  (click)="avancar(ordem)">
+            {{ rotuloProximo(ordem) }}
+          </button>
+          <span *ngIf="!proximoStatus(ordem)" class="finalizada">—</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div *ngIf="!estaCarregando && !erro && ordens.length === 0" class="estado-informativo">
+    Nenhuma ordem pendente. As ordens são geradas quando a escala está atracada/em operação e há contêineres planejados.
+  </div>
+</section>

--- a/frontend/cloudport/src/app/componentes/navio/componentes/lista-trabalho-escala/lista-trabalho-escala.component.ts
+++ b/frontend/cloudport/src/app/componentes/navio/componentes/lista-trabalho-escala/lista-trabalho-escala.component.ts
@@ -1,0 +1,122 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ActivatedRoute, Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { SanitizadorConteudoService } from '../../../service/sanitizacao/sanitizador-conteudo.service';
+import {
+  OrdemMovimentacaoNavio,
+  ROTULOS_STATUS_ORDEM,
+  ROTULOS_TIPO_MOVIMENTACAO,
+  ServicoNavioService,
+  StatusOrdemMovimentacaoNavio,
+  TipoMovimentacaoOrdemNavio
+} from '../../../service/servico-navio/servico-navio.service';
+
+@Component({
+  selector: 'app-lista-trabalho-escala',
+  templateUrl: './lista-trabalho-escala.component.html',
+  styleUrls: ['./lista-trabalho-escala.component.css'],
+  standalone: false
+})
+export class ListaTrabalhoEscalaComponent implements OnInit {
+  ordens: OrdemMovimentacaoNavio[] = [];
+  estaCarregando = false;
+  processando = false;
+  erro?: string;
+
+  private escalaId!: number;
+
+  constructor(
+    private readonly servicoNavio: ServicoNavioService,
+    private readonly sanitizadorConteudo: SanitizadorConteudoService,
+    private readonly rota: ActivatedRoute,
+    private readonly router: Router
+  ) {}
+
+  ngOnInit(): void {
+    const idParam = this.rota.snapshot.paramMap.get('id');
+    const id = Number(idParam);
+    if (!idParam || !Number.isInteger(id) || id <= 0) {
+      this.erro = 'Escala inválida.';
+      return;
+    }
+    this.escalaId = id;
+    this.carregarOrdens();
+  }
+
+  carregarOrdens(): void {
+    this.estaCarregando = true;
+    this.erro = undefined;
+    this.servicoNavio.listarOrdens(this.escalaId)
+      .pipe(finalize(() => this.estaCarregando = false))
+      .subscribe({
+        next: (ordens) => {
+          this.ordens = ordens ?? [];
+        },
+        error: () => {
+          this.erro = 'Não foi possível carregar a lista de trabalho.';
+          this.ordens = [];
+        }
+      });
+  }
+
+  proximoStatus(ordem: OrdemMovimentacaoNavio): StatusOrdemMovimentacaoNavio | null {
+    if (ordem.statusMovimentacao === 'PENDENTE') {
+      return 'EM_EXECUCAO';
+    }
+    if (ordem.statusMovimentacao === 'EM_EXECUCAO') {
+      return 'CONCLUIDA';
+    }
+    return null;
+  }
+
+  avancar(ordem: OrdemMovimentacaoNavio): void {
+    const proximo = this.proximoStatus(ordem);
+    if (!proximo || this.processando) {
+      return;
+    }
+    this.processando = true;
+    this.erro = undefined;
+    this.servicoNavio.atualizarStatusOrdem(this.escalaId, ordem.id, proximo)
+      .pipe(finalize(() => this.processando = false))
+      .subscribe({
+        next: () => this.carregarOrdens(),
+        error: (erro: HttpErrorResponse) => {
+          this.erro = this.extrairMensagemErro(erro, 'Não foi possível atualizar a ordem.');
+        }
+      });
+  }
+
+  voltar(): void {
+    this.router.navigate(['/home', 'navio', 'escalas', this.escalaId]);
+  }
+
+  rotuloTipo(tipo: TipoMovimentacaoOrdemNavio): string {
+    return ROTULOS_TIPO_MOVIMENTACAO[tipo] ?? tipo;
+  }
+
+  rotuloStatus(status: StatusOrdemMovimentacaoNavio): string {
+    return ROTULOS_STATUS_ORDEM[status] ?? status;
+  }
+
+  rotuloProximo(ordem: OrdemMovimentacaoNavio): string {
+    const proximo = this.proximoStatus(ordem);
+    return proximo ? this.rotuloStatus(proximo) : '';
+  }
+
+  classeStatus(status: StatusOrdemMovimentacaoNavio): string {
+    return `status-tag status-${status.toLowerCase()}`;
+  }
+
+  textoSeguro(valor: string | null | undefined): string {
+    return this.sanitizadorConteudo.sanitizar(valor);
+  }
+
+  private extrairMensagemErro(erro: HttpErrorResponse, padrao: string): string {
+    const corpo = erro?.error;
+    if (corpo && typeof corpo === 'object' && typeof corpo.mensagem === 'string' && corpo.mensagem.trim()) {
+      return this.sanitizadorConteudo.sanitizar(corpo.mensagem);
+    }
+    return padrao;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/navio/navio-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/navio/navio-routing.module.ts
@@ -4,6 +4,7 @@ import { ListaEscalasComponent } from './componentes/lista-escalas/lista-escalas
 import { FormularioEscalaComponent } from './componentes/formulario-escala/formulario-escala.component';
 import { DetalheEscalaComponent } from './componentes/detalhe-escala/detalhe-escala.component';
 import { ListaNaviosComponent } from './componentes/lista-navios/lista-navios.component';
+import { ListaTrabalhoEscalaComponent } from './componentes/lista-trabalho-escala/lista-trabalho-escala.component';
 
 const routes: Routes = [
   {
@@ -18,6 +19,10 @@ const routes: Routes = [
   {
     path: 'escalas/nova',
     component: FormularioEscalaComponent
+  },
+  {
+    path: 'escalas/:id/lista-trabalho',
+    component: ListaTrabalhoEscalaComponent
   },
   {
     path: 'escalas/:id',

--- a/frontend/cloudport/src/app/componentes/navio/navio.module.ts
+++ b/frontend/cloudport/src/app/componentes/navio/navio.module.ts
@@ -6,13 +6,15 @@ import { ListaEscalasComponent } from './componentes/lista-escalas/lista-escalas
 import { FormularioEscalaComponent } from './componentes/formulario-escala/formulario-escala.component';
 import { DetalheEscalaComponent } from './componentes/detalhe-escala/detalhe-escala.component';
 import { ListaNaviosComponent } from './componentes/lista-navios/lista-navios.component';
+import { ListaTrabalhoEscalaComponent } from './componentes/lista-trabalho-escala/lista-trabalho-escala.component';
 
 @NgModule({
   declarations: [
     ListaEscalasComponent,
     FormularioEscalaComponent,
     DetalheEscalaComponent,
-    ListaNaviosComponent
+    ListaNaviosComponent,
+    ListaTrabalhoEscalaComponent
   ],
   imports: [
     CommonModule,

--- a/frontend/cloudport/src/app/componentes/service/servico-navio/servico-navio.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-navio/servico-navio.service.ts
@@ -49,6 +49,26 @@ export interface EscalaResumo {
   bercoPrevisto?: string | null;
 }
 
+export type StatusOperacaoConteinerEscala = 'PENDENTE' | 'CONCLUIDO';
+
+export interface OperacaoConteinerEscala {
+  codigoConteiner: string;
+  statusOperacao: StatusOperacaoConteinerEscala;
+}
+
+export type TipoMovimentacaoOrdemNavio = 'DESCARGA_NAVIO' | 'CARGA_NAVIO';
+export type StatusOrdemMovimentacaoNavio = 'PENDENTE' | 'EM_EXECUCAO' | 'CONCLUIDA';
+
+export interface OrdemMovimentacaoNavio {
+  id: number;
+  idEscala: number;
+  codigoConteiner: string;
+  tipoMovimentacao: TipoMovimentacaoOrdemNavio;
+  statusMovimentacao: StatusOrdemMovimentacaoNavio;
+  criadoEm: string;
+  atualizadoEm: string;
+}
+
 export interface EscalaDetalhe {
   id: number;
   navioId: number;
@@ -66,6 +86,8 @@ export interface EscalaDetalhe {
   bercoPrevisto?: string | null;
   bercoAtual?: string | null;
   observacoes?: string | null;
+  listaDescarga: OperacaoConteinerEscala[];
+  listaCarga: OperacaoConteinerEscala[];
 }
 
 export interface CadastroEscala {
@@ -111,6 +133,17 @@ export const ROTULOS_FASE: Record<FaseEscala, string> = {
   PARTIU: 'Partiu',
   ENCERRADA: 'Encerrada',
   CANCELADA: 'Cancelada'
+};
+
+export const ROTULOS_TIPO_MOVIMENTACAO: Record<TipoMovimentacaoOrdemNavio, string> = {
+  DESCARGA_NAVIO: 'Descarga',
+  CARGA_NAVIO: 'Carga'
+};
+
+export const ROTULOS_STATUS_ORDEM: Record<StatusOrdemMovimentacaoNavio, string> = {
+  PENDENTE: 'Pendente',
+  EM_EXECUCAO: 'Em execução',
+  CONCLUIDA: 'Concluída'
 };
 
 @Injectable({
@@ -168,6 +201,39 @@ export class ServicoNavioService {
 
   removerEscala(id: number): Observable<void> {
     return this.http.delete<void>(this.urlEscalas(`/${id}`));
+  }
+
+  adicionarConteinerDescarga(idEscala: number, codigoConteiner: string): Observable<EscalaDetalhe> {
+    return this.http.post<EscalaDetalhe>(this.urlEscalas(`/${idEscala}/descarga`), { codigoConteiner });
+  }
+
+  adicionarConteinerCarga(idEscala: number, codigoConteiner: string): Observable<EscalaDetalhe> {
+    return this.http.post<EscalaDetalhe>(this.urlEscalas(`/${idEscala}/carga`), { codigoConteiner });
+  }
+
+  removerConteinerDescarga(idEscala: number, codigoConteiner: string): Observable<EscalaDetalhe> {
+    return this.http.delete<EscalaDetalhe>(
+      this.urlEscalas(`/${idEscala}/descarga/${encodeURIComponent(codigoConteiner)}`));
+  }
+
+  removerConteinerCarga(idEscala: number, codigoConteiner: string): Observable<EscalaDetalhe> {
+    return this.http.delete<EscalaDetalhe>(
+      this.urlEscalas(`/${idEscala}/carga/${encodeURIComponent(codigoConteiner)}`));
+  }
+
+  listarOrdens(idEscala: number, status?: StatusOrdemMovimentacaoNavio): Observable<OrdemMovimentacaoNavio[]> {
+    let params = new HttpParams();
+    if (status) {
+      params = params.set('status', status);
+    }
+    return this.http.get<OrdemMovimentacaoNavio[]>(this.urlEscalas(`/${idEscala}/ordens`), { params });
+  }
+
+  atualizarStatusOrdem(idEscala: number,
+                       idOrdem: number,
+                       statusMovimentacao: StatusOrdemMovimentacaoNavio): Observable<OrdemMovimentacaoNavio> {
+    return this.http.patch<OrdemMovimentacaoNavio>(
+      this.urlEscalas(`/${idEscala}/ordens/${idOrdem}/status`), { statusMovimentacao });
   }
 
   private urlNavios(caminho: string): string {


### PR DESCRIPTION
## Resumo

Faz o **planejamento de pátio para o navio**, espelhando a integração ferrovia→pátio que já existia.

### `servico-navio` (backend)
- Listas de **descarga/carga** por escala (`@ElementCollection`).
- **Ordens de movimentação** (`OrdemMovimentacaoNavio`) geradas automaticamente quando a escala entra em fase operacional (`ATRACADO`/`OPERANDO`) e quando contêineres são adicionados.
- Avanço de status da ordem (`PENDENTE → EM_EXECUCAO → CONCLUIDA`); ao concluir, publica evento RabbitMQ `navio.movimentacao.concluida`.
- Endpoints: `POST/DELETE /escalas/{id}/descarga|carga`, `GET /escalas/{id}/ordens`, `PATCH /escalas/{id}/ordens/{idOrdem}/status`.
- Migração `V3` (tabelas `escala_descarga`, `escala_carga`, `ordem_movimentacao_navio`).

### `servico-yard` (backend)
- Fila/binding/listener para o evento do navio (`IntegracaoNavioRabbitConfiguracao`, `MovimentacaoNavioListener`).
- `ProcessadorMovimentacaoNavioService`: descarga → contêiner `ALOCADO` no pátio; carga → `EM_TRANSFERENCIA`; registra histórico da operação.

### Frontend
- No detalhe da escala: gestão das listas de **descarga/carga** (adicionar/remover contêineres).
- Nova tela **Lista de Trabalho** com avanço de status das ordens (que dispara a atualização do pátio).

## Base do PR
Empilhado sobre `claude/navio-operacao-visual` (que traz o backend de Escala + o frontend de navio), para manter o diff restrito a esta etapa.

## Test plan
- [x] `servico-navio`: `mvn test` → 15 testes verdes (inclui regras de geração de ordens e transições de fase).
- [x] `servico-navio` e `servico-yard`: `mvn compile` verde.
- [x] Frontend: `npm run build` (AOT) verde.
- [ ] `servico-yard`: testes de integração (`ConteinerServicoTest`, `ConteinerControladorTest`) exigem Docker (Testcontainers) e não rodam neste ambiente; rodam no CI.
- [ ] Validar ponta a ponta com RabbitMQ + serviços no ar: concluir ordem no navio e ver o contêiner mudar de status no pátio.


---
_Generated by [Claude Code](https://claude.ai/code/session_0124hSrsgg5JLbWYYC4PeSvP)_