### PR TITLE
Planejamento de embarque (plano de estiva) + controle de tamanho do texto

### DIFF
--- a/backend/servico-autenticacao/src/main/resources/db/migration/V8__inserir_navegacao_embarque.sql
+++ b/backend/servico-autenticacao/src/main/resources/db/migration/V8__inserir_navegacao_embarque.sql
@@ -1,0 +1,14 @@
+-- Disponibiliza a aba "Planejamento de Embarque" (plano de estiva) no grupo NAVIO.
+INSERT INTO configuracoes_navegacao (
+    identificador,
+    rotulo,
+    rota,
+    grupo,
+    roles_permitidos,
+    desabilitado,
+    mensagem_em_breve,
+    ordem,
+    padrao
+) VALUES
+    ('embarque/planejamento', 'Planejamento de Embarque', 'embarque/planejamento', 'NAVIO', 'ROLE_ADMIN_PORTO,ROLE_PLANEJADOR', FALSE, NULL, 20, FALSE)
+ON CONFLICT (identificador) DO NOTHING;

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/controlador/PlanoEstivaControlador.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/controlador/PlanoEstivaControlador.java
@@ -1,0 +1,57 @@
+package br.com.cloudport.serviconavio.estiva.controlador;
+
+import br.com.cloudport.serviconavio.estiva.dto.CriarAtribuicaoEstivaDTO;
+import br.com.cloudport.serviconavio.estiva.dto.CriarPlanoEstivaDTO;
+import br.com.cloudport.serviconavio.estiva.dto.PlanoEstivaDetalheDTO;
+import br.com.cloudport.serviconavio.estiva.servico.PlanoEstivaServico;
+import javax.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+public class PlanoEstivaControlador {
+
+    private final PlanoEstivaServico planoEstivaServico;
+
+    public PlanoEstivaControlador(PlanoEstivaServico planoEstivaServico) {
+        this.planoEstivaServico = planoEstivaServico;
+    }
+
+    @GetMapping("/escalas/{escalaId}/plano-estiva")
+    public PlanoEstivaDetalheDTO buscar(@PathVariable Long escalaId) {
+        return planoEstivaServico.buscarPorEscala(escalaId);
+    }
+
+    @PostMapping("/escalas/{escalaId}/plano-estiva")
+    @ResponseStatus(HttpStatus.CREATED)
+    public PlanoEstivaDetalheDTO criar(@PathVariable Long escalaId,
+                                       @Valid @RequestBody CriarPlanoEstivaDTO dto) {
+        return planoEstivaServico.criar(escalaId, dto);
+    }
+
+    @PostMapping("/escalas/{escalaId}/plano-estiva/atribuicoes")
+    @ResponseStatus(HttpStatus.CREATED)
+    public PlanoEstivaDetalheDTO adicionarAtribuicao(@PathVariable Long escalaId,
+                                                     @Valid @RequestBody CriarAtribuicaoEstivaDTO dto) {
+        return planoEstivaServico.adicionarAtribuicao(escalaId, dto);
+    }
+
+    @PatchMapping("/plano-estiva/atribuicoes/{atribuicaoId}/embarcar")
+    public PlanoEstivaDetalheDTO embarcar(@PathVariable Long atribuicaoId) {
+        return planoEstivaServico.embarcar(atribuicaoId);
+    }
+
+    @DeleteMapping("/plano-estiva/atribuicoes/{atribuicaoId}")
+    public PlanoEstivaDetalheDTO removerAtribuicao(@PathVariable Long atribuicaoId) {
+        return planoEstivaServico.removerAtribuicao(atribuicaoId);
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/AtribuicaoEstivaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/AtribuicaoEstivaDTO.java
@@ -1,0 +1,107 @@
+package br.com.cloudport.serviconavio.estiva.dto;
+
+import br.com.cloudport.serviconavio.estiva.entidade.AtribuicaoEstiva;
+import br.com.cloudport.serviconavio.estiva.entidade.TipoCargaConteiner;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class AtribuicaoEstivaDTO {
+
+    private final Long id;
+    private final String codigoConteiner;
+    private final TipoCargaConteiner tipoCarga;
+    private final BigDecimal pesoToneladas;
+    private final int baia;
+    private final int fileira;
+    private final int camada;
+    private final String posicaoPatioOrigem;
+    private final Integer sequenciaEmbarque;
+    private final boolean embarcado;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime embarcadoEm;
+
+    public AtribuicaoEstivaDTO(Long id,
+                               String codigoConteiner,
+                               TipoCargaConteiner tipoCarga,
+                               BigDecimal pesoToneladas,
+                               int baia,
+                               int fileira,
+                               int camada,
+                               String posicaoPatioOrigem,
+                               Integer sequenciaEmbarque,
+                               boolean embarcado,
+                               LocalDateTime embarcadoEm) {
+        this.id = id;
+        this.codigoConteiner = codigoConteiner;
+        this.tipoCarga = tipoCarga;
+        this.pesoToneladas = pesoToneladas;
+        this.baia = baia;
+        this.fileira = fileira;
+        this.camada = camada;
+        this.posicaoPatioOrigem = posicaoPatioOrigem;
+        this.sequenciaEmbarque = sequenciaEmbarque;
+        this.embarcado = embarcado;
+        this.embarcadoEm = embarcadoEm;
+    }
+
+    public static AtribuicaoEstivaDTO deEntidade(AtribuicaoEstiva atribuicao) {
+        return new AtribuicaoEstivaDTO(
+                atribuicao.getId(),
+                atribuicao.getCodigoConteiner(),
+                atribuicao.getTipoCarga(),
+                atribuicao.getPesoToneladas(),
+                atribuicao.getBaia(),
+                atribuicao.getFileira(),
+                atribuicao.getCamada(),
+                atribuicao.getPosicaoPatioOrigem(),
+                atribuicao.getSequenciaEmbarque(),
+                atribuicao.isEmbarcado(),
+                atribuicao.getEmbarcadoEm()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public TipoCargaConteiner getTipoCarga() {
+        return tipoCarga;
+    }
+
+    public BigDecimal getPesoToneladas() {
+        return pesoToneladas;
+    }
+
+    public int getBaia() {
+        return baia;
+    }
+
+    public int getFileira() {
+        return fileira;
+    }
+
+    public int getCamada() {
+        return camada;
+    }
+
+    public String getPosicaoPatioOrigem() {
+        return posicaoPatioOrigem;
+    }
+
+    public Integer getSequenciaEmbarque() {
+        return sequenciaEmbarque;
+    }
+
+    public boolean isEmbarcado() {
+        return embarcado;
+    }
+
+    public LocalDateTime getEmbarcadoEm() {
+        return embarcadoEm;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarAtribuicaoEstivaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarAtribuicaoEstivaDTO.java
@@ -1,0 +1,109 @@
+package br.com.cloudport.serviconavio.estiva.dto;
+
+import br.com.cloudport.serviconavio.estiva.entidade.TipoCargaConteiner;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
+import java.math.BigDecimal;
+
+public class CriarAtribuicaoEstivaDTO {
+
+    @NotBlank(message = "Informe o código do contêiner.")
+    @Size(max = 20, message = "O código do contêiner deve ter no máximo 20 caracteres.")
+    private String codigoConteiner;
+
+    @NotNull(message = "Informe o tipo de carga do contêiner.")
+    private TipoCargaConteiner tipoCarga;
+
+    @PositiveOrZero(message = "O peso não pode ser negativo.")
+    @DecimalMax(value = "99999.99", message = "O peso informado é inválido.")
+    private BigDecimal pesoToneladas;
+
+    @NotNull(message = "Informe a baia (bay) de destino.")
+    @Min(value = 1, message = "A baia deve ser maior ou igual a 1.")
+    private Integer baia;
+
+    @NotNull(message = "Informe a fileira (row) de destino.")
+    @Min(value = 1, message = "A fileira deve ser maior ou igual a 1.")
+    private Integer fileira;
+
+    @NotNull(message = "Informe a camada (tier) de destino.")
+    @Min(value = 1, message = "A camada deve ser maior ou igual a 1.")
+    private Integer camada;
+
+    @Size(max = 40, message = "A posição de origem no pátio deve ter no máximo 40 caracteres.")
+    private String posicaoPatioOrigem;
+
+    @Min(value = 1, message = "A sequência de embarque deve ser maior ou igual a 1.")
+    private Integer sequenciaEmbarque;
+
+    public CriarAtribuicaoEstivaDTO() {
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public TipoCargaConteiner getTipoCarga() {
+        return tipoCarga;
+    }
+
+    public void setTipoCarga(TipoCargaConteiner tipoCarga) {
+        this.tipoCarga = tipoCarga;
+    }
+
+    public BigDecimal getPesoToneladas() {
+        return pesoToneladas;
+    }
+
+    public void setPesoToneladas(BigDecimal pesoToneladas) {
+        this.pesoToneladas = pesoToneladas;
+    }
+
+    public Integer getBaia() {
+        return baia;
+    }
+
+    public void setBaia(Integer baia) {
+        this.baia = baia;
+    }
+
+    public Integer getFileira() {
+        return fileira;
+    }
+
+    public void setFileira(Integer fileira) {
+        this.fileira = fileira;
+    }
+
+    public Integer getCamada() {
+        return camada;
+    }
+
+    public void setCamada(Integer camada) {
+        this.camada = camada;
+    }
+
+    public String getPosicaoPatioOrigem() {
+        return posicaoPatioOrigem;
+    }
+
+    public void setPosicaoPatioOrigem(String posicaoPatioOrigem) {
+        this.posicaoPatioOrigem = posicaoPatioOrigem;
+    }
+
+    public Integer getSequenciaEmbarque() {
+        return sequenciaEmbarque;
+    }
+
+    public void setSequenciaEmbarque(Integer sequenciaEmbarque) {
+        this.sequenciaEmbarque = sequenciaEmbarque;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarPlanoEstivaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarPlanoEstivaDTO.java
@@ -1,0 +1,50 @@
+package br.com.cloudport.serviconavio.estiva.dto;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+public class CriarPlanoEstivaDTO {
+
+    @NotNull(message = "Informe a quantidade de baias (bays).")
+    @Min(value = 1, message = "O navio deve ter ao menos 1 baia.")
+    @Max(value = 99, message = "O número de baias não pode exceder 99.")
+    private Integer baias;
+
+    @NotNull(message = "Informe a quantidade de fileiras (rows).")
+    @Min(value = 1, message = "O navio deve ter ao menos 1 fileira.")
+    @Max(value = 40, message = "O número de fileiras não pode exceder 40.")
+    private Integer fileiras;
+
+    @NotNull(message = "Informe a quantidade de camadas (tiers).")
+    @Min(value = 1, message = "O navio deve ter ao menos 1 camada.")
+    @Max(value = 20, message = "O número de camadas não pode exceder 20.")
+    private Integer camadas;
+
+    public CriarPlanoEstivaDTO() {
+    }
+
+    public Integer getBaias() {
+        return baias;
+    }
+
+    public void setBaias(Integer baias) {
+        this.baias = baias;
+    }
+
+    public Integer getFileiras() {
+        return fileiras;
+    }
+
+    public void setFileiras(Integer fileiras) {
+        this.fileiras = fileiras;
+    }
+
+    public Integer getCamadas() {
+        return camadas;
+    }
+
+    public void setCamadas(Integer camadas) {
+        this.camadas = camadas;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/PlanoEstivaDetalheDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/PlanoEstivaDetalheDTO.java
@@ -1,0 +1,139 @@
+package br.com.cloudport.serviconavio.estiva.dto;
+
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import br.com.cloudport.serviconavio.estiva.entidade.PlanoEstiva;
+import br.com.cloudport.serviconavio.estiva.entidade.StatusPlanoEstiva;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PlanoEstivaDetalheDTO {
+
+    private final Long id;
+    private final Long escalaId;
+    private final String nomeNavio;
+    private final String viagemEntrada;
+    private final StatusPlanoEstiva status;
+    private final int baias;
+    private final int fileiras;
+    private final int camadas;
+    private final int capacidadeCelulas;
+    private final int totalPlanejado;
+    private final int totalEmbarcado;
+    private final int totalPendente;
+    private final double ocupacaoPercentual;
+    private final List<AtribuicaoEstivaDTO> atribuicoes;
+
+    public PlanoEstivaDetalheDTO(Long id,
+                                 Long escalaId,
+                                 String nomeNavio,
+                                 String viagemEntrada,
+                                 StatusPlanoEstiva status,
+                                 int baias,
+                                 int fileiras,
+                                 int camadas,
+                                 int capacidadeCelulas,
+                                 int totalPlanejado,
+                                 int totalEmbarcado,
+                                 int totalPendente,
+                                 double ocupacaoPercentual,
+                                 List<AtribuicaoEstivaDTO> atribuicoes) {
+        this.id = id;
+        this.escalaId = escalaId;
+        this.nomeNavio = nomeNavio;
+        this.viagemEntrada = viagemEntrada;
+        this.status = status;
+        this.baias = baias;
+        this.fileiras = fileiras;
+        this.camadas = camadas;
+        this.capacidadeCelulas = capacidadeCelulas;
+        this.totalPlanejado = totalPlanejado;
+        this.totalEmbarcado = totalEmbarcado;
+        this.totalPendente = totalPendente;
+        this.ocupacaoPercentual = ocupacaoPercentual;
+        this.atribuicoes = atribuicoes;
+    }
+
+    public static PlanoEstivaDetalheDTO deEntidade(PlanoEstiva plano) {
+        List<AtribuicaoEstivaDTO> atribuicoes = plano.getAtribuicoes().stream()
+                .map(AtribuicaoEstivaDTO::deEntidade)
+                .collect(Collectors.toList());
+        int totalPlanejado = atribuicoes.size();
+        int totalEmbarcado = (int) atribuicoes.stream().filter(AtribuicaoEstivaDTO::isEmbarcado).count();
+        int capacidade = plano.capacidadeCelulas();
+        double ocupacao = capacidade == 0 ? 0d
+                : Math.round((totalPlanejado * 10000d) / capacidade) / 100d;
+        Escala escala = plano.getEscala();
+        return new PlanoEstivaDetalheDTO(
+                plano.getId(),
+                escala.getId(),
+                escala.getNavio().getNome(),
+                escala.getViagemEntrada(),
+                plano.getStatus(),
+                plano.getBaias(),
+                plano.getFileiras(),
+                plano.getCamadas(),
+                capacidade,
+                totalPlanejado,
+                totalEmbarcado,
+                totalPlanejado - totalEmbarcado,
+                ocupacao,
+                atribuicoes
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getEscalaId() {
+        return escalaId;
+    }
+
+    public String getNomeNavio() {
+        return nomeNavio;
+    }
+
+    public String getViagemEntrada() {
+        return viagemEntrada;
+    }
+
+    public StatusPlanoEstiva getStatus() {
+        return status;
+    }
+
+    public int getBaias() {
+        return baias;
+    }
+
+    public int getFileiras() {
+        return fileiras;
+    }
+
+    public int getCamadas() {
+        return camadas;
+    }
+
+    public int getCapacidadeCelulas() {
+        return capacidadeCelulas;
+    }
+
+    public int getTotalPlanejado() {
+        return totalPlanejado;
+    }
+
+    public int getTotalEmbarcado() {
+        return totalEmbarcado;
+    }
+
+    public int getTotalPendente() {
+        return totalPendente;
+    }
+
+    public double getOcupacaoPercentual() {
+        return ocupacaoPercentual;
+    }
+
+    public List<AtribuicaoEstivaDTO> getAtribuicoes() {
+        return atribuicoes;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/AtribuicaoEstiva.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/AtribuicaoEstiva.java
@@ -1,0 +1,200 @@
+package br.com.cloudport.serviconavio.estiva.entidade;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Atribuição de um contêiner a uma célula do navio (bay/row/tier) dentro de um
+ * plano de estiva. Registra a posição de origem no pátio e o instante de
+ * embarque efetivo, que representa a baixa do estoque do pátio.
+ */
+@Entity
+@Table(name = "atribuicao_estiva", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_atribuicao_celula", columnNames = {"plano_id", "baia", "fileira", "camada"}),
+        @UniqueConstraint(name = "uk_atribuicao_conteiner", columnNames = {"plano_id", "codigo_conteiner"})
+})
+public class AtribuicaoEstiva {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plano_id", nullable = false)
+    private PlanoEstiva plano;
+
+    @Column(name = "codigo_conteiner", nullable = false, length = 20)
+    private String codigoConteiner;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_carga", nullable = false, length = 20)
+    private TipoCargaConteiner tipoCarga;
+
+    @Column(name = "peso_toneladas", precision = 7, scale = 2)
+    private BigDecimal pesoToneladas;
+
+    @Column(name = "baia", nullable = false)
+    private int baia;
+
+    @Column(name = "fileira", nullable = false)
+    private int fileira;
+
+    @Column(name = "camada", nullable = false)
+    private int camada;
+
+    @Column(name = "posicao_patio_origem", length = 40)
+    private String posicaoPatioOrigem;
+
+    @Column(name = "sequencia_embarque")
+    private Integer sequenciaEmbarque;
+
+    @Column(name = "embarcado", nullable = false)
+    private boolean embarcado;
+
+    @Column(name = "embarcado_em")
+    private LocalDateTime embarcadoEm;
+
+    @Column(name = "criado_em", nullable = false)
+    private LocalDateTime criadoEm;
+
+    @Column(name = "atualizado_em", nullable = false)
+    private LocalDateTime atualizadoEm;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public PlanoEstiva getPlano() {
+        return plano;
+    }
+
+    public void setPlano(PlanoEstiva plano) {
+        this.plano = plano;
+    }
+
+    public String getCodigoConteiner() {
+        return codigoConteiner;
+    }
+
+    public void setCodigoConteiner(String codigoConteiner) {
+        this.codigoConteiner = codigoConteiner;
+    }
+
+    public TipoCargaConteiner getTipoCarga() {
+        return tipoCarga;
+    }
+
+    public void setTipoCarga(TipoCargaConteiner tipoCarga) {
+        this.tipoCarga = tipoCarga;
+    }
+
+    public BigDecimal getPesoToneladas() {
+        return pesoToneladas;
+    }
+
+    public void setPesoToneladas(BigDecimal pesoToneladas) {
+        this.pesoToneladas = pesoToneladas;
+    }
+
+    public int getBaia() {
+        return baia;
+    }
+
+    public void setBaia(int baia) {
+        this.baia = baia;
+    }
+
+    public int getFileira() {
+        return fileira;
+    }
+
+    public void setFileira(int fileira) {
+        this.fileira = fileira;
+    }
+
+    public int getCamada() {
+        return camada;
+    }
+
+    public void setCamada(int camada) {
+        this.camada = camada;
+    }
+
+    public String getPosicaoPatioOrigem() {
+        return posicaoPatioOrigem;
+    }
+
+    public void setPosicaoPatioOrigem(String posicaoPatioOrigem) {
+        this.posicaoPatioOrigem = posicaoPatioOrigem;
+    }
+
+    public Integer getSequenciaEmbarque() {
+        return sequenciaEmbarque;
+    }
+
+    public void setSequenciaEmbarque(Integer sequenciaEmbarque) {
+        this.sequenciaEmbarque = sequenciaEmbarque;
+    }
+
+    public boolean isEmbarcado() {
+        return embarcado;
+    }
+
+    public void setEmbarcado(boolean embarcado) {
+        this.embarcado = embarcado;
+    }
+
+    public LocalDateTime getEmbarcadoEm() {
+        return embarcadoEm;
+    }
+
+    public void setEmbarcadoEm(LocalDateTime embarcadoEm) {
+        this.embarcadoEm = embarcadoEm;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public void setCriadoEm(LocalDateTime criadoEm) {
+        this.criadoEm = criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+
+    public void setAtualizadoEm(LocalDateTime atualizadoEm) {
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    @PrePersist
+    public void aoCriar() {
+        LocalDateTime agora = LocalDateTime.now();
+        this.criadoEm = agora;
+        this.atualizadoEm = agora;
+    }
+
+    @PreUpdate
+    public void aoAtualizar() {
+        this.atualizadoEm = LocalDateTime.now();
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/PlanoEstiva.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/PlanoEstiva.java
@@ -1,0 +1,161 @@
+package br.com.cloudport.serviconavio.estiva.entidade;
+
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Plano de estiva (stowage plan) de uma escala. Define as dimensões do
+ * arranjo tridimensional bay/row/tier do navio para esta visita e agrupa as
+ * atribuições de contêineres às células.
+ */
+@Entity
+@Table(name = "plano_estiva")
+public class PlanoEstiva {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "escala_id", nullable = false, unique = true)
+    private Escala escala;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private StatusPlanoEstiva status;
+
+    @Column(name = "baias", nullable = false)
+    private int baias;
+
+    @Column(name = "fileiras", nullable = false)
+    private int fileiras;
+
+    @Column(name = "camadas", nullable = false)
+    private int camadas;
+
+    @OneToMany(mappedBy = "plano", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("baia ASC, fileira ASC, camada ASC")
+    private List<AtribuicaoEstiva> atribuicoes = new ArrayList<>();
+
+    @Column(name = "criado_em", nullable = false)
+    private LocalDateTime criadoEm;
+
+    @Column(name = "atualizado_em", nullable = false)
+    private LocalDateTime atualizadoEm;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Escala getEscala() {
+        return escala;
+    }
+
+    public void setEscala(Escala escala) {
+        this.escala = escala;
+    }
+
+    public StatusPlanoEstiva getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusPlanoEstiva status) {
+        this.status = status;
+    }
+
+    public int getBaias() {
+        return baias;
+    }
+
+    public void setBaias(int baias) {
+        this.baias = baias;
+    }
+
+    public int getFileiras() {
+        return fileiras;
+    }
+
+    public void setFileiras(int fileiras) {
+        this.fileiras = fileiras;
+    }
+
+    public int getCamadas() {
+        return camadas;
+    }
+
+    public void setCamadas(int camadas) {
+        this.camadas = camadas;
+    }
+
+    public List<AtribuicaoEstiva> getAtribuicoes() {
+        return atribuicoes;
+    }
+
+    public void setAtribuicoes(List<AtribuicaoEstiva> atribuicoes) {
+        this.atribuicoes = atribuicoes;
+    }
+
+    public void adicionarAtribuicao(AtribuicaoEstiva atribuicao) {
+        atribuicao.setPlano(this);
+        this.atribuicoes.add(atribuicao);
+    }
+
+    public void removerAtribuicao(AtribuicaoEstiva atribuicao) {
+        this.atribuicoes.remove(atribuicao);
+        atribuicao.setPlano(null);
+    }
+
+    public int capacidadeCelulas() {
+        return baias * fileiras * camadas;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public void setCriadoEm(LocalDateTime criadoEm) {
+        this.criadoEm = criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+
+    public void setAtualizadoEm(LocalDateTime atualizadoEm) {
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    @PrePersist
+    public void aoCriar() {
+        LocalDateTime agora = LocalDateTime.now();
+        this.criadoEm = agora;
+        this.atualizadoEm = agora;
+    }
+
+    @PreUpdate
+    public void aoAtualizar() {
+        this.atualizadoEm = LocalDateTime.now();
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/StatusPlanoEstiva.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/StatusPlanoEstiva.java
@@ -1,0 +1,12 @@
+package br.com.cloudport.serviconavio.estiva.entidade;
+
+/**
+ * Estados do plano de estiva (stowage/loading plan) de uma escala.
+ * RASCUNHO -> CONFIRMADO -> EM_EXECUCAO -> CONCLUIDO.
+ */
+public enum StatusPlanoEstiva {
+    RASCUNHO,
+    CONFIRMADO,
+    EM_EXECUCAO,
+    CONCLUIDO
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/TipoCargaConteiner.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/TipoCargaConteiner.java
@@ -1,0 +1,13 @@
+package br.com.cloudport.serviconavio.estiva.entidade;
+
+/**
+ * Tipos de carga de contêiner relevantes para a estiva. Espelha os tipos
+ * adotados no serviço de pátio (servico-yard) para manter a integração coerente.
+ */
+public enum TipoCargaConteiner {
+    SECO,
+    REFRIGERADO,
+    PERIGOSO,
+    GRANELEIRO,
+    OUTRO
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/repositorio/AtribuicaoEstivaRepositorio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/repositorio/AtribuicaoEstivaRepositorio.java
@@ -1,0 +1,7 @@
+package br.com.cloudport.serviconavio.estiva.repositorio;
+
+import br.com.cloudport.serviconavio.estiva.entidade.AtribuicaoEstiva;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AtribuicaoEstivaRepositorio extends JpaRepository<AtribuicaoEstiva, Long> {
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/repositorio/PlanoEstivaRepositorio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/repositorio/PlanoEstivaRepositorio.java
@@ -1,0 +1,12 @@
+package br.com.cloudport.serviconavio.estiva.repositorio;
+
+import br.com.cloudport.serviconavio.estiva.entidade.PlanoEstiva;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanoEstivaRepositorio extends JpaRepository<PlanoEstiva, Long> {
+
+    Optional<PlanoEstiva> findByEscalaId(Long escalaId);
+
+    boolean existsByEscalaId(Long escalaId);
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/servico/PlanoEstivaServico.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/servico/PlanoEstivaServico.java
@@ -1,0 +1,170 @@
+package br.com.cloudport.serviconavio.estiva.servico;
+
+import br.com.cloudport.serviconavio.comum.validacao.SanitizadorEntrada;
+import br.com.cloudport.serviconavio.escala.entidade.Escala;
+import br.com.cloudport.serviconavio.escala.repositorio.EscalaRepositorio;
+import br.com.cloudport.serviconavio.estiva.dto.CriarAtribuicaoEstivaDTO;
+import br.com.cloudport.serviconavio.estiva.dto.CriarPlanoEstivaDTO;
+import br.com.cloudport.serviconavio.estiva.dto.PlanoEstivaDetalheDTO;
+import br.com.cloudport.serviconavio.estiva.entidade.AtribuicaoEstiva;
+import br.com.cloudport.serviconavio.estiva.entidade.PlanoEstiva;
+import br.com.cloudport.serviconavio.estiva.entidade.StatusPlanoEstiva;
+import br.com.cloudport.serviconavio.estiva.repositorio.AtribuicaoEstivaRepositorio;
+import br.com.cloudport.serviconavio.estiva.repositorio.PlanoEstivaRepositorio;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class PlanoEstivaServico {
+
+    private final PlanoEstivaRepositorio planoEstivaRepositorio;
+    private final AtribuicaoEstivaRepositorio atribuicaoEstivaRepositorio;
+    private final EscalaRepositorio escalaRepositorio;
+    private final SanitizadorEntrada sanitizadorEntrada;
+
+    public PlanoEstivaServico(PlanoEstivaRepositorio planoEstivaRepositorio,
+                              AtribuicaoEstivaRepositorio atribuicaoEstivaRepositorio,
+                              EscalaRepositorio escalaRepositorio,
+                              SanitizadorEntrada sanitizadorEntrada) {
+        this.planoEstivaRepositorio = planoEstivaRepositorio;
+        this.atribuicaoEstivaRepositorio = atribuicaoEstivaRepositorio;
+        this.escalaRepositorio = escalaRepositorio;
+        this.sanitizadorEntrada = sanitizadorEntrada;
+    }
+
+    @Transactional(readOnly = true)
+    public PlanoEstivaDetalheDTO buscarPorEscala(Long escalaId) {
+        return PlanoEstivaDetalheDTO.deEntidade(obterPlanoPorEscala(escalaId));
+    }
+
+    @Transactional
+    public PlanoEstivaDetalheDTO criar(Long escalaId, CriarPlanoEstivaDTO dto) {
+        Escala escala = escalaRepositorio.findById(escalaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Escala não encontrada."));
+        if (planoEstivaRepositorio.existsByEscalaId(escalaId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Esta escala já possui um plano de estiva.");
+        }
+
+        PlanoEstiva plano = new PlanoEstiva();
+        plano.setEscala(escala);
+        plano.setStatus(StatusPlanoEstiva.RASCUNHO);
+        plano.setBaias(dto.getBaias());
+        plano.setFileiras(dto.getFileiras());
+        plano.setCamadas(dto.getCamadas());
+
+        return PlanoEstivaDetalheDTO.deEntidade(planoEstivaRepositorio.save(plano));
+    }
+
+    @Transactional
+    public PlanoEstivaDetalheDTO adicionarAtribuicao(Long escalaId, CriarAtribuicaoEstivaDTO dto) {
+        PlanoEstiva plano = obterPlanoPorEscala(escalaId);
+        if (plano.getStatus() == StatusPlanoEstiva.CONCLUIDO) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "O plano de estiva já foi concluído e não aceita novas atribuições.");
+        }
+
+        validarCelulaDentroDosLimites(plano, dto.getBaia(), dto.getFileira(), dto.getCamada());
+
+        String codigo = sanitizadorEntrada
+                .limparTextoObrigatorio(dto.getCodigoConteiner(), "código do contêiner")
+                .toUpperCase(Locale.ROOT);
+
+        for (AtribuicaoEstiva existente : plano.getAtribuicoes()) {
+            if (existente.getCodigoConteiner().equalsIgnoreCase(codigo)) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        String.format(Locale.ROOT, "O contêiner %s já está atribuído neste plano.", codigo));
+            }
+            if (existente.getBaia() == dto.getBaia()
+                    && existente.getFileira() == dto.getFileira()
+                    && existente.getCamada() == dto.getCamada()) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        String.format(Locale.ROOT, "A célula %d-%d-%d já está ocupada.",
+                                dto.getBaia(), dto.getFileira(), dto.getCamada()));
+            }
+        }
+
+        AtribuicaoEstiva atribuicao = new AtribuicaoEstiva();
+        atribuicao.setCodigoConteiner(codigo);
+        atribuicao.setTipoCarga(dto.getTipoCarga());
+        atribuicao.setPesoToneladas(dto.getPesoToneladas());
+        atribuicao.setBaia(dto.getBaia());
+        atribuicao.setFileira(dto.getFileira());
+        atribuicao.setCamada(dto.getCamada());
+        atribuicao.setPosicaoPatioOrigem(tratarTextoOpcional(dto.getPosicaoPatioOrigem()));
+        atribuicao.setSequenciaEmbarque(dto.getSequenciaEmbarque());
+        atribuicao.setEmbarcado(false);
+
+        plano.adicionarAtribuicao(atribuicao);
+        return PlanoEstivaDetalheDTO.deEntidade(planoEstivaRepositorio.save(plano));
+    }
+
+    @Transactional
+    public PlanoEstivaDetalheDTO embarcar(Long atribuicaoId) {
+        AtribuicaoEstiva atribuicao = obterAtribuicao(atribuicaoId);
+        PlanoEstiva plano = atribuicao.getPlano();
+
+        if (!atribuicao.isEmbarcado()) {
+            atribuicao.setEmbarcado(true);
+            atribuicao.setEmbarcadoEm(LocalDateTime.now());
+            atualizarStatusAposEmbarque(plano);
+        }
+
+        return PlanoEstivaDetalheDTO.deEntidade(plano);
+    }
+
+    @Transactional
+    public PlanoEstivaDetalheDTO removerAtribuicao(Long atribuicaoId) {
+        AtribuicaoEstiva atribuicao = obterAtribuicao(atribuicaoId);
+        if (atribuicao.isEmbarcado()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Não é possível remover um contêiner que já foi embarcado.");
+        }
+        PlanoEstiva plano = atribuicao.getPlano();
+        plano.removerAtribuicao(atribuicao);
+        atribuicaoEstivaRepositorio.delete(atribuicao);
+        return PlanoEstivaDetalheDTO.deEntidade(planoEstivaRepositorio.save(plano));
+    }
+
+    private void atualizarStatusAposEmbarque(PlanoEstiva plano) {
+        boolean todosEmbarcados = !plano.getAtribuicoes().isEmpty()
+                && plano.getAtribuicoes().stream().allMatch(AtribuicaoEstiva::isEmbarcado);
+        if (todosEmbarcados) {
+            plano.setStatus(StatusPlanoEstiva.CONCLUIDO);
+        } else if (plano.getStatus() == StatusPlanoEstiva.RASCUNHO
+                || plano.getStatus() == StatusPlanoEstiva.CONFIRMADO) {
+            plano.setStatus(StatusPlanoEstiva.EM_EXECUCAO);
+        }
+    }
+
+    private void validarCelulaDentroDosLimites(PlanoEstiva plano, int baia, int fileira, int camada) {
+        if (baia > plano.getBaias() || fileira > plano.getFileiras() || camada > plano.getCamadas()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format(Locale.ROOT,
+                            "A célula %d-%d-%d está fora dos limites do navio (%d baias, %d fileiras, %d camadas).",
+                            baia, fileira, camada, plano.getBaias(), plano.getFileiras(), plano.getCamadas()));
+        }
+    }
+
+    private PlanoEstiva obterPlanoPorEscala(Long escalaId) {
+        return planoEstivaRepositorio.findByEscalaId(escalaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Plano de estiva não encontrado para esta escala."));
+    }
+
+    private AtribuicaoEstiva obterAtribuicao(Long atribuicaoId) {
+        return atribuicaoEstivaRepositorio.findById(atribuicaoId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Atribuição de estiva não encontrada."));
+    }
+
+    private String tratarTextoOpcional(String valor) {
+        String limpo = sanitizadorEntrada.limparTexto(valor);
+        return StringUtils.hasText(limpo) ? limpo.toUpperCase(Locale.ROOT) : null;
+    }
+}

--- a/backend/servico-navio/src/main/resources/db/migration/V3__criar_tabelas_estiva.sql
+++ b/backend/servico-navio/src/main/resources/db/migration/V3__criar_tabelas_estiva.sql
@@ -1,0 +1,36 @@
+-- Plano de estiva (stowage plan) por escala e atribuições de contêineres às
+-- células bay/row/tier do navio. O instante de embarque efetivo de cada
+-- atribuição representa a baixa do estoque do pátio.
+
+CREATE TABLE IF NOT EXISTS plano_estiva (
+    id BIGSERIAL PRIMARY KEY,
+    escala_id BIGINT NOT NULL UNIQUE REFERENCES escala (id),
+    status VARCHAR(20) NOT NULL,
+    baias INTEGER NOT NULL,
+    fileiras INTEGER NOT NULL,
+    camadas INTEGER NOT NULL,
+    criado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    atualizado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS atribuicao_estiva (
+    id BIGSERIAL PRIMARY KEY,
+    plano_id BIGINT NOT NULL REFERENCES plano_estiva (id),
+    codigo_conteiner VARCHAR(20) NOT NULL,
+    tipo_carga VARCHAR(20) NOT NULL,
+    peso_toneladas NUMERIC(7, 2),
+    baia INTEGER NOT NULL,
+    fileira INTEGER NOT NULL,
+    camada INTEGER NOT NULL,
+    posicao_patio_origem VARCHAR(40),
+    sequencia_embarque INTEGER,
+    embarcado BOOLEAN NOT NULL DEFAULT FALSE,
+    embarcado_em TIMESTAMP WITHOUT TIME ZONE,
+    criado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    atualizado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    CONSTRAINT uk_atribuicao_celula UNIQUE (plano_id, baia, fileira, camada),
+    CONSTRAINT uk_atribuicao_conteiner UNIQUE (plano_id, codigo_conteiner)
+);
+
+CREATE INDEX IF NOT EXISTS idx_atribuicao_estiva_plano ON atribuicao_estiva (plano_id);
+CREATE INDEX IF NOT EXISTS idx_atribuicao_estiva_embarcado ON atribuicao_estiva (embarcado);

--- a/frontend/cloudport/src/app/app-routing.module.ts
+++ b/frontend/cloudport/src/app/app-routing.module.ts
@@ -52,6 +52,12 @@ const homeChildRoutes: Routes = [
     canActivate: [AuthGuard],
     canLoad: [AuthGuard],
     loadChildren: () => import('./componentes/patio/patio.module').then(m => m.PatioModule)
+  },
+  {
+    path: 'embarque',
+    canActivate: [AuthGuard],
+    canLoad: [AuthGuard],
+    loadChildren: () => import('./componentes/embarque/embarque.module').then(m => m.EmbarqueModule)
   }
 ];
 

--- a/frontend/cloudport/src/app/app.module.ts
+++ b/frontend/cloudport/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { HomeComponent } from './componentes/home/home.component';
 import { HeaderComponent } from './componentes/header/header.component';
 import { FooterComponent } from './componentes/footer/footer.component';
 import { NavbarComponent } from './componentes/navbar/navbar.component';
+import { ControleTamanhoTextoComponent } from './componentes/controle-tamanho-texto/controle-tamanho-texto.component';
 import { RoleTabelaComponent } from './componentes/role/role-tabela/role-tabela.component';
 import { ContextMenuComponent } from './componentes/context-menu/context-menu.component';
 import { AgGridModule } from 'ag-grid-angular';
@@ -33,6 +34,7 @@ import { TextoSeguroPipe } from './componentes/pipes/texto-seguro.pipe';
         HeaderComponent,
         FooterComponent,
         NavbarComponent,
+        ControleTamanhoTextoComponent,
         RoleTabelaComponent,
         ContextMenuComponent,
         SegurancaComponent,

--- a/frontend/cloudport/src/app/componentes/controle-tamanho-texto/controle-tamanho-texto.component.css
+++ b/frontend/cloudport/src/app/componentes/controle-tamanho-texto/controle-tamanho-texto.component.css
@@ -1,0 +1,69 @@
+.size-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: inherit;
+}
+
+.size-label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  white-space: nowrap;
+  text-shadow: none;
+}
+
+.size-buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.15rem;
+}
+
+.size-btn,
+.size-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-shadow: none;
+}
+
+.size-btn {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  padding: 0;
+  transition: background-color 0.15s ease;
+}
+
+.size-btn:hover:not(:disabled),
+.size-value:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.size-btn:focus-visible,
+.size-value:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 1px;
+}
+
+.size-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.size-value {
+  min-width: 3rem;
+  height: 1.75rem;
+  padding: 0 0.5rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/cloudport/src/app/componentes/controle-tamanho-texto/controle-tamanho-texto.component.html
+++ b/frontend/cloudport/src/app/componentes/controle-tamanho-texto/controle-tamanho-texto.component.html
@@ -1,0 +1,40 @@
+<div class="size-control">
+  <span class="size-label">Tamanho do texto</span>
+  <div class="size-buttons">
+    <button
+      class="size-btn"
+      type="button"
+      data-action="size-down"
+      aria-label="Diminuir texto"
+      [disabled]="!podeDiminuir"
+      (click)="diminuir()"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <path d="M5 12h14"></path>
+      </svg>
+    </button>
+    <button
+      class="size-value"
+      type="button"
+      aria-live="polite"
+      aria-label="Redefinir tamanho do texto"
+      title="Redefinir tamanho do texto"
+      (click)="redefinir()"
+    >
+      {{ tamanho }}%
+    </button>
+    <button
+      class="size-btn"
+      type="button"
+      data-action="size-up"
+      aria-label="Aumentar texto"
+      [disabled]="!podeAumentar"
+      (click)="aumentar()"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <path d="M5 12h14"></path>
+        <path d="M12 5v14"></path>
+      </svg>
+    </button>
+  </div>
+</div>

--- a/frontend/cloudport/src/app/componentes/controle-tamanho-texto/controle-tamanho-texto.component.ts
+++ b/frontend/cloudport/src/app/componentes/controle-tamanho-texto/controle-tamanho-texto.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { TamanhoTextoService } from '../service/tamanho-texto/tamanho-texto.service';
+
+@Component({
+    selector: 'app-controle-tamanho-texto',
+    templateUrl: './controle-tamanho-texto.component.html',
+    styleUrls: ['./controle-tamanho-texto.component.css'],
+    standalone: false
+})
+export class ControleTamanhoTextoComponent implements OnInit, OnDestroy {
+  tamanho = TamanhoTextoService.TAMANHO_PADRAO;
+  private tamanhoSubscription?: Subscription;
+
+  constructor(private readonly tamanhoTextoService: TamanhoTextoService) {}
+
+  ngOnInit(): void {
+    this.tamanhoSubscription = this.tamanhoTextoService.tamanho$.subscribe(
+      (valor) => (this.tamanho = valor)
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.tamanhoSubscription?.unsubscribe();
+  }
+
+  get podeAumentar(): boolean {
+    return this.tamanho < this.tamanhoTextoService.tamanhoMaximo;
+  }
+
+  get podeDiminuir(): boolean {
+    return this.tamanho > this.tamanhoTextoService.tamanhoMinimo;
+  }
+
+  aumentar(): void {
+    this.tamanhoTextoService.aumentar();
+  }
+
+  diminuir(): void {
+    this.tamanhoTextoService.diminuir();
+  }
+
+  redefinir(): void {
+    this.tamanhoTextoService.redefinir();
+  }
+}

--- a/frontend/cloudport/src/app/componentes/embarque/embarque-routing.module.ts
+++ b/frontend/cloudport/src/app/componentes/embarque/embarque-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PlanejamentoEmbarqueComponent } from './planejamento-embarque/planejamento-embarque.component';
+
+const routes: Routes = [
+  {
+    path: 'planejamento',
+    component: PlanejamentoEmbarqueComponent
+  },
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: 'planejamento'
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class EmbarqueRoutingModule { }

--- a/frontend/cloudport/src/app/componentes/embarque/embarque.module.ts
+++ b/frontend/cloudport/src/app/componentes/embarque/embarque.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { EmbarqueRoutingModule } from './embarque-routing.module';
+import { PlanejamentoEmbarqueComponent } from './planejamento-embarque/planejamento-embarque.component';
+
+@NgModule({
+  declarations: [PlanejamentoEmbarqueComponent],
+  imports: [CommonModule, FormsModule, EmbarqueRoutingModule]
+})
+export class EmbarqueModule { }

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.css
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.css
@@ -1,0 +1,366 @@
+.embarque {
+  padding: 1.5rem;
+  max-width: 1280px;
+  margin: 0 auto;
+  color: #1f2933;
+}
+
+.embarque-cabecalho h2 {
+  margin: 0;
+  color: #234986;
+}
+
+.subtitulo {
+  margin: 0.25rem 0 1rem;
+  color: #52606d;
+}
+
+.alerta {
+  border-radius: 6px;
+  padding: 0.6rem 0.9rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.alerta-erro {
+  background: #fde8e8;
+  color: #9b1c1c;
+  border: 1px solid #f8b4b4;
+}
+
+.alerta-aviso {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fde68a;
+}
+
+.seletor-escala {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.seletor-escala select {
+  min-width: 22rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid #cbd2d9;
+}
+
+.carregando {
+  color: #52606d;
+  font-style: italic;
+}
+
+.cartao {
+  background: #ffffff;
+  border: 1px solid #e4e7eb;
+  border-radius: 10px;
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.cartao h3 {
+  margin-top: 0;
+  color: #234986;
+}
+
+.criar-plano .campos-grade {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #3e4c59;
+  gap: 0.25rem;
+}
+
+input,
+select {
+  font: inherit;
+  padding: 0.4rem 0.55rem;
+  border-radius: 6px;
+  border: 1px solid #cbd2d9;
+}
+
+.indicadores {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.indicador {
+  background: #ffffff;
+  border: 1px solid #e4e7eb;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.indicador.embarcado {
+  border-color: #84cc16;
+  background: #f7fee7;
+}
+
+.indicador-valor {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #234986;
+}
+
+.indicador-rotulo {
+  font-size: 0.78rem;
+  color: #52606d;
+}
+
+.layout-plano {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+@media (max-width: 980px) {
+  .layout-plano {
+    grid-template-columns: 1fr;
+  }
+}
+
+.baias-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.chip-baia {
+  border: 1px solid #cbd2d9;
+  background: #f5f7fa;
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+  font-size: 0.82rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.chip-baia.ativa {
+  background: #234986;
+  color: #ffffff;
+  border-color: #234986;
+}
+
+.chip-contador {
+  background: rgba(0, 0, 0, 0.12);
+  border-radius: 999px;
+  padding: 0 0.4rem;
+  font-size: 0.72rem;
+}
+
+.chip-baia.ativa .chip-contador {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.grade-legenda-eixo {
+  font-size: 0.8rem;
+  color: #52606d;
+  margin: 0 0 0.5rem;
+}
+
+.grade-celulas {
+  border-collapse: separate;
+  border-spacing: 4px;
+}
+
+.rotulo-eixo {
+  font-size: 0.7rem;
+  color: #7b8794;
+  text-align: center;
+  font-weight: 600;
+}
+
+.celula {
+  width: 3.4rem;
+  height: 2.4rem;
+  border-radius: 5px;
+  border: 1px solid #cbd2d9;
+  cursor: pointer;
+  font-size: 0.62rem;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.celula-codigo {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  padding: 0 2px;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.celula-vazia {
+  background: #eef2f6;
+  border-style: dashed;
+}
+
+.celula-vazia .celula-codigo {
+  color: transparent;
+}
+
+.celula.selecionada {
+  outline: 3px solid #f59e0b;
+  outline-offset: 1px;
+}
+
+.tipo-seco { background: #3b82f6; }
+.tipo-refrigerado { background: #06b6d4; }
+.tipo-perigoso { background: #dc2626; }
+.tipo-graneleiro { background: #a16207; }
+.tipo-outro { background: #6b7280; }
+
+.celula-ocupada.embarcado {
+  box-shadow: inset 0 0 0 3px #65a30d;
+}
+
+.legenda {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 1rem 0 0;
+  font-size: 0.78rem;
+  color: #52606d;
+}
+
+.legenda li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.amostra {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 3px;
+  display: inline-block;
+}
+
+.amostra.embarcado {
+  background: #eef2f6;
+  box-shadow: inset 0 0 0 3px #65a30d;
+}
+
+.ajuda,
+.vazio {
+  font-size: 0.82rem;
+  color: #52606d;
+}
+
+.form-atribuicao {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.posicao-celula {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.btn-primario,
+.btn-secundario,
+.btn-remover {
+  border: none;
+  border-radius: 6px;
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+}
+
+.btn-primario {
+  background: #234986;
+  color: #ffffff;
+  align-self: flex-start;
+}
+
+.btn-primario:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secundario {
+  background: #65a30d;
+  color: #ffffff;
+}
+
+.btn-remover {
+  background: transparent;
+  color: #9b1c1c;
+  border: 1px solid #f8b4b4;
+}
+
+.lista-atribuicoes {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.lista-atribuicoes li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border: 1px solid #e4e7eb;
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+}
+
+.lista-atribuicoes li.embarcado {
+  background: #f7fee7;
+  border-color: #bef264;
+}
+
+.item-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.item-detalhe {
+  font-size: 0.74rem;
+  color: #52606d;
+}
+
+.item-acoes {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.tag-embarcado {
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: #4d7c0f;
+}

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.html
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.html
@@ -1,0 +1,191 @@
+<section class="embarque">
+  <header class="embarque-cabecalho">
+    <h2>Planejamento de Embarque</h2>
+    <p class="subtitulo">
+      Plano de estiva (bay/row/tier): organize a saída da carga do pátio para o navio e registre o embarque.
+    </p>
+  </header>
+
+  <div *ngIf="erro" class="alerta alerta-erro">{{ erro }}</div>
+  <div *ngIf="aviso" class="alerta alerta-aviso">{{ aviso }}</div>
+
+  <div class="seletor-escala">
+    <label for="escala">Escala (vessel visit)</label>
+    <select id="escala" [(ngModel)]="escalaSelecionadaId" (ngModelChange)="aoSelecionarEscala()">
+      <option [ngValue]="null">Selecione uma escala...</option>
+      <option *ngFor="let escala of escalas" [ngValue]="escala.id">
+        {{ escala.nomeNavio }} — viagem {{ escala.viagemEntrada }} ({{ escala.fase }})
+      </option>
+    </select>
+    <span *ngIf="carregando" class="carregando">Carregando...</span>
+  </div>
+
+  <!-- Criação do plano quando ainda não existe -->
+  <div *ngIf="escalaSelecionadaId != null && !plano && !carregando" class="cartao criar-plano">
+    <h3>Definir dimensões do navio</h3>
+    <p>Informe a grade de células do navio para iniciar o plano de estiva.</p>
+    <div class="campos-grade">
+      <label>Baias (bays)
+        <input type="number" min="1" max="99" [(ngModel)]="novoPlano.baias" />
+      </label>
+      <label>Fileiras (rows)
+        <input type="number" min="1" max="40" [(ngModel)]="novoPlano.fileiras" />
+      </label>
+      <label>Camadas (tiers)
+        <input type="number" min="1" max="20" [(ngModel)]="novoPlano.camadas" />
+      </label>
+    </div>
+    <button type="button" class="btn-primario" [disabled]="salvando" (click)="criarPlano()">
+      Criar plano de estiva
+    </button>
+  </div>
+
+  <ng-container *ngIf="plano">
+    <!-- Indicadores / controle de saída de estoque -->
+    <div class="indicadores">
+      <div class="indicador">
+        <span class="indicador-valor">{{ plano.status }}</span>
+        <span class="indicador-rotulo">Status do plano</span>
+      </div>
+      <div class="indicador">
+        <span class="indicador-valor">{{ plano.totalPlanejado }}</span>
+        <span class="indicador-rotulo">Planejados</span>
+      </div>
+      <div class="indicador embarcado">
+        <span class="indicador-valor">{{ plano.totalEmbarcado }}</span>
+        <span class="indicador-rotulo">Embarcados (baixa do pátio)</span>
+      </div>
+      <div class="indicador">
+        <span class="indicador-valor">{{ plano.totalPendente }}</span>
+        <span class="indicador-rotulo">Pendentes no pátio</span>
+      </div>
+      <div class="indicador">
+        <span class="indicador-valor">{{ plano.ocupacaoPercentual }}%</span>
+        <span class="indicador-rotulo">Ocupação ({{ plano.capacidadeCelulas }} células)</span>
+      </div>
+    </div>
+
+    <div class="layout-plano">
+      <!-- Visualização gráfica do navio -->
+      <div class="cartao navio">
+        <h3>Navio {{ plano.nomeNavio }} — arranjo de células</h3>
+
+        <div class="baias-chips">
+          <button
+            *ngFor="let baia of baiasArray"
+            type="button"
+            class="chip-baia"
+            [class.ativa]="baia === baiaSelecionada"
+            (click)="selecionarBaia(baia)"
+          >
+            Baia {{ baia }}
+            <span class="chip-contador">{{ contarNaBaia(baia) }}</span>
+          </button>
+        </div>
+
+        <div *ngIf="baiaSelecionada != null" class="grade-navio">
+          <p class="grade-legenda-eixo">Baia {{ baiaSelecionada }} — camadas (tiers) × fileiras (rows)</p>
+          <table class="grade-celulas">
+            <tbody>
+              <tr *ngFor="let camada of camadasArrayDescendente">
+                <th scope="row" class="rotulo-eixo">T{{ camada }}</th>
+                <td *ngFor="let fileira of fileirasArray">
+                  <button
+                    type="button"
+                    class="celula"
+                    [ngClass]="classeCelula(baiaSelecionada, fileira, camada)"
+                    [class.selecionada]="celulaSelecionadaNoForm(fileira, camada)"
+                    [title]="(atribuicaoEm(baiaSelecionada, fileira, camada)?.codigoConteiner) || ('Fileira ' + fileira + ' / Tier ' + camada)"
+                    (click)="selecionarCelula(fileira, camada)"
+                  >
+                    <span class="celula-codigo">
+                      {{ atribuicaoEm(baiaSelecionada, fileira, camada)?.codigoConteiner }}
+                    </span>
+                  </button>
+                </td>
+              </tr>
+              <tr class="linha-eixo">
+                <th scope="row" class="rotulo-eixo"></th>
+                <td *ngFor="let fileira of fileirasArray" class="rotulo-eixo">R{{ fileira }}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <ul class="legenda">
+            <li><span class="amostra tipo-seco"></span> Seco</li>
+            <li><span class="amostra tipo-refrigerado"></span> Reefer</li>
+            <li><span class="amostra tipo-perigoso"></span> Perigoso</li>
+            <li><span class="amostra tipo-graneleiro"></span> Granel</li>
+            <li><span class="amostra tipo-outro"></span> Outro</li>
+            <li><span class="amostra embarcado"></span> Embarcado</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Fluxo pátio -> navio -->
+      <div class="cartao fluxo">
+        <h3>Pátio → Navio</h3>
+        <p class="ajuda">Clique numa célula livre da grade para escolher a posição; preencha os dados do contêiner.</p>
+
+        <form class="form-atribuicao" (ngSubmit)="adicionarAtribuicao()">
+          <label>Código do contêiner
+            <input type="text" maxlength="20" required [(ngModel)]="novaAtribuicao.codigoConteiner" name="codigoConteiner" />
+          </label>
+          <label>Tipo de carga
+            <select [(ngModel)]="novaAtribuicao.tipoCarga" name="tipoCarga">
+              <option *ngFor="let tipo of tiposCarga" [ngValue]="tipo.valor">{{ tipo.rotulo }}</option>
+            </select>
+          </label>
+          <label>Peso (t)
+            <input type="number" min="0" step="0.01" [(ngModel)]="novaAtribuicao.pesoToneladas" name="peso" />
+          </label>
+          <label>Origem no pátio
+            <input type="text" maxlength="40" [(ngModel)]="novaAtribuicao.posicaoPatioOrigem" name="origem" placeholder="ex: A-12-3" />
+          </label>
+          <div class="posicao-celula">
+            <label>Baia
+              <input type="number" min="1" [(ngModel)]="novaAtribuicao.baia" name="baia" />
+            </label>
+            <label>Fileira
+              <input type="number" min="1" [(ngModel)]="novaAtribuicao.fileira" name="fileira" />
+            </label>
+            <label>Camada
+              <input type="number" min="1" [(ngModel)]="novaAtribuicao.camada" name="camada" />
+            </label>
+            <label>Sequência
+              <input type="number" min="1" [(ngModel)]="novaAtribuicao.sequenciaEmbarque" name="sequencia" />
+            </label>
+          </div>
+          <button type="submit" class="btn-primario" [disabled]="salvando || !novaAtribuicao.codigoConteiner">
+            Atribuir ao navio
+          </button>
+        </form>
+
+        <h4>Carga da baia {{ baiaSelecionada }}</h4>
+        <p *ngIf="baiaSelecionada != null && atribuicoesDaBaia(baiaSelecionada).length === 0" class="vazio">
+          Nenhum contêiner atribuído nesta baia.
+        </p>
+        <ul class="lista-atribuicoes" *ngIf="baiaSelecionada != null">
+          <li *ngFor="let item of atribuicoesDaBaia(baiaSelecionada)" [class.embarcado]="item.embarcado">
+            <div class="item-info">
+              <strong>{{ item.codigoConteiner }}</strong>
+              <span class="item-detalhe">
+                {{ rotuloTipo(item.tipoCarga) }} · R{{ item.fileira }}/T{{ item.camada }}
+                <ng-container *ngIf="item.posicaoPatioOrigem"> · pátio {{ item.posicaoPatioOrigem }}</ng-container>
+              </span>
+            </div>
+            <div class="item-acoes">
+              <span *ngIf="item.embarcado" class="tag-embarcado">Embarcado</span>
+              <button *ngIf="!item.embarcado" type="button" class="btn-secundario" [disabled]="salvando" (click)="embarcar(item)">
+                Embarcar
+              </button>
+              <button *ngIf="!item.embarcado" type="button" class="btn-remover" [disabled]="salvando" (click)="remover(item)">
+                Remover
+              </button>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </ng-container>
+</section>

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.ts
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.ts
@@ -1,0 +1,294 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  AtribuicaoEstiva,
+  EscalaResumo,
+  NovaAtribuicaoEstiva,
+  NovoPlanoEstiva,
+  PlanoEstivaDetalhe,
+  ServicoEstivaService,
+  TipoCargaConteiner
+} from '../../service/servico-estiva/servico-estiva.service';
+
+interface OpcaoTipoCarga {
+  valor: TipoCargaConteiner;
+  rotulo: string;
+}
+
+@Component({
+  selector: 'app-planejamento-embarque',
+  templateUrl: './planejamento-embarque.component.html',
+  styleUrls: ['./planejamento-embarque.component.css'],
+  standalone: false
+})
+export class PlanejamentoEmbarqueComponent implements OnInit {
+
+  readonly tiposCarga: OpcaoTipoCarga[] = [
+    { valor: 'SECO', rotulo: 'Seco' },
+    { valor: 'REFRIGERADO', rotulo: 'Refrigerado (reefer)' },
+    { valor: 'PERIGOSO', rotulo: 'Perigoso (IMO)' },
+    { valor: 'GRANELEIRO', rotulo: 'Granel' },
+    { valor: 'OUTRO', rotulo: 'Outro' }
+  ];
+
+  escalas: EscalaResumo[] = [];
+  escalaSelecionadaId: number | null = null;
+  plano: PlanoEstivaDetalhe | null = null;
+
+  carregando = false;
+  salvando = false;
+  erro: string | null = null;
+  aviso: string | null = null;
+
+  baiaSelecionada: number | null = null;
+
+  novoPlano: NovoPlanoEstiva = { baias: 10, fileiras: 6, camadas: 4 };
+
+  novaAtribuicao: NovaAtribuicaoEstiva = this.criarAtribuicaoVazia();
+
+  private celulasOcupadas = new Map<string, AtribuicaoEstiva>();
+
+  constructor(private readonly servicoEstiva: ServicoEstivaService) {}
+
+  ngOnInit(): void {
+    this.carregarEscalas();
+  }
+
+  carregarEscalas(): void {
+    this.carregando = true;
+    this.erro = null;
+    this.servicoEstiva.listarEscalas(30).subscribe({
+      next: (escalas) => {
+        this.escalas = escalas;
+        this.carregando = false;
+      },
+      error: (erro) => {
+        this.carregando = false;
+        this.erro = this.extrairMensagem(erro, 'Não foi possível carregar as escalas.');
+      }
+    });
+  }
+
+  aoSelecionarEscala(): void {
+    this.plano = null;
+    this.baiaSelecionada = null;
+    this.aviso = null;
+    this.erro = null;
+    if (this.escalaSelecionadaId == null) {
+      return;
+    }
+    this.carregarPlano(this.escalaSelecionadaId);
+  }
+
+  carregarPlano(escalaId: number): void {
+    this.carregando = true;
+    this.servicoEstiva.obterPlano(escalaId).subscribe({
+      next: (plano) => {
+        this.aplicarPlano(plano);
+        this.carregando = false;
+      },
+      error: (erro: HttpErrorResponse) => {
+        this.carregando = false;
+        if (erro.status === 404) {
+          this.plano = null;
+          this.aviso = 'Esta escala ainda não possui um plano de estiva. Defina as dimensões do navio para iniciar.';
+        } else {
+          this.erro = this.extrairMensagem(erro, 'Não foi possível carregar o plano de estiva.');
+        }
+      }
+    });
+  }
+
+  criarPlano(): void {
+    if (this.escalaSelecionadaId == null) {
+      return;
+    }
+    this.salvando = true;
+    this.erro = null;
+    this.servicoEstiva.criarPlano(this.escalaSelecionadaId, this.novoPlano).subscribe({
+      next: (plano) => {
+        this.aplicarPlano(plano);
+        this.aviso = null;
+        this.salvando = false;
+      },
+      error: (erro) => {
+        this.salvando = false;
+        this.erro = this.extrairMensagem(erro, 'Não foi possível criar o plano de estiva.');
+      }
+    });
+  }
+
+  selecionarBaia(baia: number): void {
+    this.baiaSelecionada = baia;
+    this.novaAtribuicao.baia = baia;
+  }
+
+  selecionarCelula(fileira: number, camada: number): void {
+    if (this.baiaSelecionada == null) {
+      return;
+    }
+    const ocupante = this.atribuicaoEm(this.baiaSelecionada, fileira, camada);
+    if (ocupante) {
+      return;
+    }
+    this.novaAtribuicao.baia = this.baiaSelecionada;
+    this.novaAtribuicao.fileira = fileira;
+    this.novaAtribuicao.camada = camada;
+  }
+
+  adicionarAtribuicao(): void {
+    if (this.escalaSelecionadaId == null) {
+      return;
+    }
+    this.salvando = true;
+    this.erro = null;
+    const payload: NovaAtribuicaoEstiva = {
+      ...this.novaAtribuicao,
+      pesoToneladas: this.novaAtribuicao.pesoToneladas || null,
+      posicaoPatioOrigem: this.novaAtribuicao.posicaoPatioOrigem || null,
+      sequenciaEmbarque: this.novaAtribuicao.sequenciaEmbarque || null
+    };
+    this.servicoEstiva.adicionarAtribuicao(this.escalaSelecionadaId, payload).subscribe({
+      next: (plano) => {
+        this.aplicarPlano(plano);
+        this.reiniciarFormularioAtribuicao();
+        this.salvando = false;
+      },
+      error: (erro) => {
+        this.salvando = false;
+        this.erro = this.extrairMensagem(erro, 'Não foi possível atribuir o contêiner.');
+      }
+    });
+  }
+
+  embarcar(atribuicao: AtribuicaoEstiva): void {
+    this.salvando = true;
+    this.erro = null;
+    this.servicoEstiva.embarcar(atribuicao.id).subscribe({
+      next: (plano) => {
+        this.aplicarPlano(plano);
+        this.salvando = false;
+      },
+      error: (erro) => {
+        this.salvando = false;
+        this.erro = this.extrairMensagem(erro, 'Não foi possível registrar o embarque.');
+      }
+    });
+  }
+
+  remover(atribuicao: AtribuicaoEstiva): void {
+    this.salvando = true;
+    this.erro = null;
+    this.servicoEstiva.removerAtribuicao(atribuicao.id).subscribe({
+      next: (plano) => {
+        this.aplicarPlano(plano);
+        this.salvando = false;
+      },
+      error: (erro) => {
+        this.salvando = false;
+        this.erro = this.extrairMensagem(erro, 'Não foi possível remover a atribuição.');
+      }
+    });
+  }
+
+  atribuicaoEm(baia: number, fileira: number, camada: number): AtribuicaoEstiva | undefined {
+    return this.celulasOcupadas.get(this.chaveCelula(baia, fileira, camada));
+  }
+
+  contarNaBaia(baia: number): number {
+    if (!this.plano) {
+      return 0;
+    }
+    return this.plano.atribuicoes.filter((a) => a.baia === baia).length;
+  }
+
+  atribuicoesDaBaia(baia: number): AtribuicaoEstiva[] {
+    if (!this.plano) {
+      return [];
+    }
+    return this.plano.atribuicoes
+      .filter((a) => a.baia === baia)
+      .sort((a, b) => (a.sequenciaEmbarque ?? 0) - (b.sequenciaEmbarque ?? 0));
+  }
+
+  get baiasArray(): number[] {
+    return this.intervalo(this.plano?.baias ?? 0);
+  }
+
+  get fileirasArray(): number[] {
+    return this.intervalo(this.plano?.fileiras ?? 0);
+  }
+
+  get camadasArrayDescendente(): number[] {
+    return this.intervalo(this.plano?.camadas ?? 0).reverse();
+  }
+
+  rotuloTipo(tipo: TipoCargaConteiner): string {
+    return this.tiposCarga.find((t) => t.valor === tipo)?.rotulo ?? tipo;
+  }
+
+  classeCelula(baia: number, fileira: number, camada: number): string {
+    const ocupante = this.atribuicaoEm(baia, fileira, camada);
+    if (!ocupante) {
+      return 'celula-vazia';
+    }
+    const base = `celula-ocupada tipo-${ocupante.tipoCarga.toLowerCase()}`;
+    return ocupante.embarcado ? `${base} embarcado` : base;
+  }
+
+  celulaSelecionadaNoForm(fileira: number, camada: number): boolean {
+    return this.baiaSelecionada != null
+      && this.novaAtribuicao.baia === this.baiaSelecionada
+      && this.novaAtribuicao.fileira === fileira
+      && this.novaAtribuicao.camada === camada;
+  }
+
+  private aplicarPlano(plano: PlanoEstivaDetalhe): void {
+    this.plano = plano;
+    this.celulasOcupadas = new Map<string, AtribuicaoEstiva>();
+    for (const atribuicao of plano.atribuicoes) {
+      this.celulasOcupadas.set(
+        this.chaveCelula(atribuicao.baia, atribuicao.fileira, atribuicao.camada),
+        atribuicao
+      );
+    }
+    if (this.baiaSelecionada == null || this.baiaSelecionada > plano.baias) {
+      this.baiaSelecionada = plano.baias > 0 ? 1 : null;
+    }
+    if (this.baiaSelecionada != null) {
+      this.novaAtribuicao.baia = this.baiaSelecionada;
+    }
+  }
+
+  private reiniciarFormularioAtribuicao(): void {
+    const baia = this.baiaSelecionada ?? 1;
+    this.novaAtribuicao = { ...this.criarAtribuicaoVazia(), baia };
+  }
+
+  private criarAtribuicaoVazia(): NovaAtribuicaoEstiva {
+    return {
+      codigoConteiner: '',
+      tipoCarga: 'SECO',
+      pesoToneladas: null,
+      baia: 1,
+      fileira: 1,
+      camada: 1,
+      posicaoPatioOrigem: null,
+      sequenciaEmbarque: null
+    };
+  }
+
+  private intervalo(tamanho: number): number[] {
+    return Array.from({ length: Math.max(0, tamanho) }, (_, indice) => indice + 1);
+  }
+
+  private chaveCelula(baia: number, fileira: number, camada: number): string {
+    return `${baia}-${fileira}-${camada}`;
+  }
+
+  private extrairMensagem(erro: unknown, padrao: string): string {
+    const httpErro = erro as HttpErrorResponse;
+    const mensagem = httpErro?.error?.mensagem;
+    return typeof mensagem === 'string' && mensagem.length > 0 ? mensagem : padrao;
+  }
+}

--- a/frontend/cloudport/src/app/componentes/header/header.component.css
+++ b/frontend/cloudport/src/app/componentes/header/header.component.css
@@ -40,3 +40,8 @@
 .d-flex {
     width: 100%;
 }
+
+.header-actions {
+    width: auto;
+    gap: 1rem;
+}

--- a/frontend/cloudport/src/app/componentes/header/header.component.html
+++ b/frontend/cloudport/src/app/componentes/header/header.component.html
@@ -6,7 +6,10 @@
               <h1 class="display-4 mt-3">CloudPort</h1>
               <app-navbar></app-navbar>
           </div>
-          <button *ngIf="mostrarMenu" class="btn btn-outline-danger btn-sm" (click)="logout()">Sair</button>
+          <div class="d-flex align-items-center header-actions">
+              <app-controle-tamanho-texto></app-controle-tamanho-texto>
+              <button *ngIf="mostrarMenu" class="btn btn-outline-danger btn-sm" (click)="logout()">Sair</button>
+          </div>
       </div>
   </div>
 </div>

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.html
@@ -68,6 +68,23 @@
         </li>
       </ul>
     </li>
+    <li *ngIf="navioTabs.length" (click)="toggleSubmenu($event)">
+      <button type="button" class="submenu-trigger">Navio</button>
+      <ul>
+        <li *ngFor="let tab of navioTabs">
+          <button
+            type="button"
+            class="submenu-item"
+            [class.coming-soon]="tab.disabled"
+            [disabled]="tab.disabled"
+            (click)="handleTabSelection($event, tab)"
+          >
+            <span>{{ tab.label }}</span>
+            <span *ngIf="tab.disabled" class="submenu-badge">{{ tab.comingSoonMessage || 'Em breve' }}</span>
+          </button>
+        </li>
+      </ul>
+    </li>
     <li *ngIf="userTabs.length" (click)="toggleSubmenu($event)">
       <button type="button" class="submenu-trigger">Usuários</button>
       <ul>

--- a/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
+++ b/frontend/cloudport/src/app/componentes/navbar/navbar.component.ts
@@ -19,6 +19,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
   private readonly grupoGate = 'GATE';
   private readonly grupoFerrovia = 'FERROVIA';
   private readonly grupoPatio = 'PATIO';
+  private readonly grupoNavio = 'NAVIO';
 
   constructor(
     private readonly servicoAutenticacao: ServicoAutenticacao,
@@ -57,6 +58,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   get yardTabs(): RegistroAba[] {
     return this.obterAbasPorGrupo(this.grupoPatio);
+  }
+
+  get navioTabs(): RegistroAba[] {
+    return this.obterAbasPorGrupo(this.grupoNavio);
   }
 
   openTab(tab: RegistroAba): void {

--- a/frontend/cloudport/src/app/componentes/service/servico-estiva/servico-estiva.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-estiva/servico-estiva.service.ts
@@ -1,0 +1,112 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfiguracaoAplicacaoService } from '../../../configuracao/configuracao-aplicacao.service';
+
+export type TipoCargaConteiner = 'SECO' | 'REFRIGERADO' | 'PERIGOSO' | 'GRANELEIRO' | 'OUTRO';
+export type StatusPlanoEstiva = 'RASCUNHO' | 'CONFIRMADO' | 'EM_EXECUCAO' | 'CONCLUIDO';
+
+export interface EscalaResumo {
+  id: number;
+  navioId: number;
+  nomeNavio: string;
+  codigoImo: string;
+  viagemEntrada: string;
+  fase: string;
+  chegadaPrevista: string;
+  bercoPrevisto?: string | null;
+}
+
+export interface AtribuicaoEstiva {
+  id: number;
+  codigoConteiner: string;
+  tipoCarga: TipoCargaConteiner;
+  pesoToneladas?: number | null;
+  baia: number;
+  fileira: number;
+  camada: number;
+  posicaoPatioOrigem?: string | null;
+  sequenciaEmbarque?: number | null;
+  embarcado: boolean;
+  embarcadoEm?: string | null;
+}
+
+export interface PlanoEstivaDetalhe {
+  id: number;
+  escalaId: number;
+  nomeNavio: string;
+  viagemEntrada: string;
+  status: StatusPlanoEstiva;
+  baias: number;
+  fileiras: number;
+  camadas: number;
+  capacidadeCelulas: number;
+  totalPlanejado: number;
+  totalEmbarcado: number;
+  totalPendente: number;
+  ocupacaoPercentual: number;
+  atribuicoes: AtribuicaoEstiva[];
+}
+
+export interface NovoPlanoEstiva {
+  baias: number;
+  fileiras: number;
+  camadas: number;
+}
+
+export interface NovaAtribuicaoEstiva {
+  codigoConteiner: string;
+  tipoCarga: TipoCargaConteiner;
+  pesoToneladas?: number | null;
+  baia: number;
+  fileira: number;
+  camada: number;
+  posicaoPatioOrigem?: string | null;
+  sequenciaEmbarque?: number | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ServicoEstivaService {
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly configuracaoAplicacao: ConfiguracaoAplicacaoService
+  ) {}
+
+  listarEscalas(dias = 30): Observable<EscalaResumo[]> {
+    const params = new HttpParams().set('dias', String(dias));
+    return this.http.get<EscalaResumo[]>(this.construirUrl('/escalas'), { params });
+  }
+
+  obterPlano(escalaId: number): Observable<PlanoEstivaDetalhe> {
+    return this.http.get<PlanoEstivaDetalhe>(this.construirUrl(`/escalas/${escalaId}/plano-estiva`));
+  }
+
+  criarPlano(escalaId: number, payload: NovoPlanoEstiva): Observable<PlanoEstivaDetalhe> {
+    return this.http.post<PlanoEstivaDetalhe>(this.construirUrl(`/escalas/${escalaId}/plano-estiva`), payload);
+  }
+
+  adicionarAtribuicao(escalaId: number, payload: NovaAtribuicaoEstiva): Observable<PlanoEstivaDetalhe> {
+    return this.http.post<PlanoEstivaDetalhe>(
+      this.construirUrl(`/escalas/${escalaId}/plano-estiva/atribuicoes`),
+      payload
+    );
+  }
+
+  embarcar(atribuicaoId: number): Observable<PlanoEstivaDetalhe> {
+    return this.http.patch<PlanoEstivaDetalhe>(
+      this.construirUrl(`/plano-estiva/atribuicoes/${atribuicaoId}/embarcar`),
+      {}
+    );
+  }
+
+  removerAtribuicao(atribuicaoId: number): Observable<PlanoEstivaDetalhe> {
+    return this.http.delete<PlanoEstivaDetalhe>(
+      this.construirUrl(`/plano-estiva/atribuicoes/${atribuicaoId}`)
+    );
+  }
+
+  private construirUrl(caminho: string): string {
+    return this.configuracaoAplicacao.construirUrlApi(caminho);
+  }
+}

--- a/frontend/cloudport/src/app/componentes/service/tamanho-texto/tamanho-texto.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/tamanho-texto/tamanho-texto.service.ts
@@ -1,0 +1,105 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * Controla o fator de escala do texto da aplicação (acessibilidade).
+ * O valor é expresso em porcentagem e aplicado ao tamanho de fonte da raiz,
+ * fazendo com que as unidades relativas (rem/em) acompanhem a preferência.
+ */
+@Injectable({ providedIn: 'root' })
+export class TamanhoTextoService {
+  static readonly TAMANHO_PADRAO = 100;
+  static readonly TAMANHO_MINIMO = 80;
+  static readonly TAMANHO_MAXIMO = 150;
+  static readonly PASSO = 10;
+
+  private static readonly CHAVE_ARMAZENAMENTO = 'cloudport.tamanho-texto';
+
+  private readonly tamanhoSubject = new BehaviorSubject<number>(this.carregarTamanhoInicial());
+  readonly tamanho$: Observable<number> = this.tamanhoSubject.asObservable();
+
+  constructor() {
+    this.aplicar(this.tamanhoSubject.value);
+  }
+
+  get tamanhoAtual(): number {
+    return this.tamanhoSubject.value;
+  }
+
+  get tamanhoMinimo(): number {
+    return TamanhoTextoService.TAMANHO_MINIMO;
+  }
+
+  get tamanhoMaximo(): number {
+    return TamanhoTextoService.TAMANHO_MAXIMO;
+  }
+
+  aumentar(): void {
+    this.definir(this.tamanhoSubject.value + TamanhoTextoService.PASSO);
+  }
+
+  diminuir(): void {
+    this.definir(this.tamanhoSubject.value - TamanhoTextoService.PASSO);
+  }
+
+  redefinir(): void {
+    this.definir(TamanhoTextoService.TAMANHO_PADRAO);
+  }
+
+  definir(valor: number): void {
+    const tamanho = this.normalizar(valor);
+    if (tamanho === this.tamanhoSubject.value) {
+      this.aplicar(tamanho);
+      return;
+    }
+    this.tamanhoSubject.next(tamanho);
+    this.persistir(tamanho);
+    this.aplicar(tamanho);
+  }
+
+  private normalizar(valor: number): number {
+    if (!Number.isFinite(valor)) {
+      return TamanhoTextoService.TAMANHO_PADRAO;
+    }
+    const arredondado = Math.round(valor);
+    return Math.min(
+      TamanhoTextoService.TAMANHO_MAXIMO,
+      Math.max(TamanhoTextoService.TAMANHO_MINIMO, arredondado)
+    );
+  }
+
+  private aplicar(valor: number): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const raiz = document.documentElement;
+    raiz.style.setProperty('--app-font-scale', String(valor / 100));
+    raiz.style.fontSize = `${valor}%`;
+  }
+
+  private carregarTamanhoInicial(): number {
+    if (typeof localStorage === 'undefined') {
+      return TamanhoTextoService.TAMANHO_PADRAO;
+    }
+    try {
+      const armazenado = localStorage.getItem(TamanhoTextoService.CHAVE_ARMAZENAMENTO);
+      if (armazenado === null) {
+        return TamanhoTextoService.TAMANHO_PADRAO;
+      }
+      return this.normalizar(Number(armazenado));
+    } catch {
+      return TamanhoTextoService.TAMANHO_PADRAO;
+    }
+  }
+
+  private persistir(valor: number): void {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    try {
+      localStorage.setItem(TamanhoTextoService.CHAVE_ARMAZENAMENTO, String(valor));
+    } catch {
+      // Ignora ambientes sem armazenamento persistente (modo privado, cotas, etc.).
+    }
+  }
+}


### PR DESCRIPTION
## Resumo

Esta branch entrega duas frentes (commits separados):

### 1. Planejamento de Embarque / Plano de Estiva (feature principal, frontend + backend)
MVP do fluxo **pátio → navio** com interface gráfica do navio (coordenadas **bay/row/tier**) e controle de saída de estoque.

**Backend (`servico-navio`, módulo `estiva`):**
- Entidades `PlanoEstiva` (um por escala, com dimensões baias×fileiras×camadas e status `RASCUNHO → CONFIRMADO → EM_EXECUCAO → CONCLUIDO`) e `AtribuicaoEstiva` (contêiner numa célula bay/row/tier, com tipo de carga, peso, origem no pátio, sequência e flag de embarque).
- Endpoints REST: criar plano, atribuir contêiner a célula, **registrar embarque** (que representa a baixa do estoque do pátio), remover atribuição e consultar o plano com estatísticas (planejados / embarcados / pendentes / ocupação).
- Validações: célula dentro dos limites do navio, célula não ocupada, contêiner único no plano, não remover contêiner já embarcado.
- Migração Flyway `V3__criar_tabelas_estiva.sql`.

**Frontend (módulo `embarque`):**
- Tela **Planejamento de Embarque**: seleciona a escala, define a grade do navio, mostra a **grade gráfica bay/row/tier** (células coloridas por tipo de carga e marcadas quando embarcadas), o formulário de atribuição pátio→navio (clique na célula livre para escolher a posição) e a lista de carga da baia com ações **Embarcar** / **Remover**.
- Indicadores de controle de estoque: planejados, embarcados (baixa do pátio), pendentes e % de ocupação.
- Nova aba **"Planejamento de Embarque"** no grupo **NAVIO** do menu (seed `V8__inserir_navegacao_embarque.sql` em `servico-autenticacao` + renderização do grupo no navbar).

### 2. Controle de tamanho do texto (acessibilidade)
- Componente `app-controle-tamanho-texto` + `TamanhoTextoService` (escala 80%–150%, passo 10%, persistência em `localStorage`, aplicação via `font-size` da raiz). Integrado ao cabeçalho.

## Testes
- [x] Backend: `mvn compile` do `servico-navio` conclui com sucesso.
- [x] Frontend: `npm run build` conclui com sucesso; o módulo `embarque` é empacotado como chunk lazy.
- [ ] Verificação funcional end-to-end (Postgres + serviços + login) — não executada neste ambiente.

## Observações
- Os endpoints de estiva seguem o padrão de path do `EscalaControlador` (`/escalas/...`), sem prefixo de gateway — coerente com os controladores atuais do `servico-navio`.
- A "baixa de estoque" é modelada pelo embarque da atribuição (status + origem no pátio). A sincronização física com o `servico-yard` (via `OrdemTrabalhoPatio`) pode ser um próximo passo.

https://claude.ai/code/session_01FEDuRJp9CV47Mx1Db4Cvsk