### PR TITLE
Planejamento de descarga (navio → pátio) no plano de estiva

### DIFF
--- a/backend/servico-autenticacao/src/main/resources/db/migration/V9__atualizar_rotulo_estiva.sql
+++ b/backend/servico-autenticacao/src/main/resources/db/migration/V9__atualizar_rotulo_estiva.sql
@@ -1,0 +1,5 @@
+-- A tela de plano de estiva passou a cobrir embarque e descarga; ajusta o rótulo
+-- da aba para refletir as duas operações.
+UPDATE configuracoes_navegacao
+   SET rotulo = 'Planejamento de Embarque/Descarga'
+ WHERE identificador = 'embarque/planejamento';

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/controlador/PlanoEstivaControlador.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/controlador/PlanoEstivaControlador.java
@@ -45,9 +45,9 @@ public class PlanoEstivaControlador {
         return planoEstivaServico.adicionarAtribuicao(escalaId, dto);
     }
 
-    @PatchMapping("/plano-estiva/atribuicoes/{atribuicaoId}/embarcar")
-    public PlanoEstivaDetalheDTO embarcar(@PathVariable Long atribuicaoId) {
-        return planoEstivaServico.embarcar(atribuicaoId);
+    @PatchMapping("/plano-estiva/atribuicoes/{atribuicaoId}/operar")
+    public PlanoEstivaDetalheDTO operar(@PathVariable Long atribuicaoId) {
+        return planoEstivaServico.registrarOperacao(atribuicaoId);
     }
 
     @DeleteMapping("/plano-estiva/atribuicoes/{atribuicaoId}")

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/AtribuicaoEstivaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/AtribuicaoEstivaDTO.java
@@ -2,6 +2,7 @@ package br.com.cloudport.serviconavio.estiva.dto;
 
 import br.com.cloudport.serviconavio.estiva.entidade.AtribuicaoEstiva;
 import br.com.cloudport.serviconavio.estiva.entidade.TipoCargaConteiner;
+import br.com.cloudport.serviconavio.estiva.entidade.TipoOperacaoEstiva;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 public class AtribuicaoEstivaDTO {
 
     private final Long id;
+    private final TipoOperacaoEstiva tipoOperacao;
     private final String codigoConteiner;
     private final TipoCargaConteiner tipoCarga;
     private final BigDecimal pesoToneladas;
@@ -16,12 +18,14 @@ public class AtribuicaoEstivaDTO {
     private final int fileira;
     private final int camada;
     private final String posicaoPatioOrigem;
+    private final String posicaoPatioDestino;
     private final Integer sequenciaEmbarque;
     private final boolean embarcado;
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime embarcadoEm;
 
     public AtribuicaoEstivaDTO(Long id,
+                               TipoOperacaoEstiva tipoOperacao,
                                String codigoConteiner,
                                TipoCargaConteiner tipoCarga,
                                BigDecimal pesoToneladas,
@@ -29,10 +33,12 @@ public class AtribuicaoEstivaDTO {
                                int fileira,
                                int camada,
                                String posicaoPatioOrigem,
+                               String posicaoPatioDestino,
                                Integer sequenciaEmbarque,
                                boolean embarcado,
                                LocalDateTime embarcadoEm) {
         this.id = id;
+        this.tipoOperacao = tipoOperacao;
         this.codigoConteiner = codigoConteiner;
         this.tipoCarga = tipoCarga;
         this.pesoToneladas = pesoToneladas;
@@ -40,6 +46,7 @@ public class AtribuicaoEstivaDTO {
         this.fileira = fileira;
         this.camada = camada;
         this.posicaoPatioOrigem = posicaoPatioOrigem;
+        this.posicaoPatioDestino = posicaoPatioDestino;
         this.sequenciaEmbarque = sequenciaEmbarque;
         this.embarcado = embarcado;
         this.embarcadoEm = embarcadoEm;
@@ -48,6 +55,7 @@ public class AtribuicaoEstivaDTO {
     public static AtribuicaoEstivaDTO deEntidade(AtribuicaoEstiva atribuicao) {
         return new AtribuicaoEstivaDTO(
                 atribuicao.getId(),
+                atribuicao.getTipoOperacao(),
                 atribuicao.getCodigoConteiner(),
                 atribuicao.getTipoCarga(),
                 atribuicao.getPesoToneladas(),
@@ -55,6 +63,7 @@ public class AtribuicaoEstivaDTO {
                 atribuicao.getFileira(),
                 atribuicao.getCamada(),
                 atribuicao.getPosicaoPatioOrigem(),
+                atribuicao.getPosicaoPatioDestino(),
                 atribuicao.getSequenciaEmbarque(),
                 atribuicao.isEmbarcado(),
                 atribuicao.getEmbarcadoEm()
@@ -63,6 +72,10 @@ public class AtribuicaoEstivaDTO {
 
     public Long getId() {
         return id;
+    }
+
+    public TipoOperacaoEstiva getTipoOperacao() {
+        return tipoOperacao;
     }
 
     public String getCodigoConteiner() {
@@ -91,6 +104,10 @@ public class AtribuicaoEstivaDTO {
 
     public String getPosicaoPatioOrigem() {
         return posicaoPatioOrigem;
+    }
+
+    public String getPosicaoPatioDestino() {
+        return posicaoPatioDestino;
     }
 
     public Integer getSequenciaEmbarque() {

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarAtribuicaoEstivaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarAtribuicaoEstivaDTO.java
@@ -1,6 +1,7 @@
 package br.com.cloudport.serviconavio.estiva.dto;
 
 import br.com.cloudport.serviconavio.estiva.entidade.TipoCargaConteiner;
+import br.com.cloudport.serviconavio.estiva.entidade.TipoOperacaoEstiva;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -10,6 +11,9 @@ import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 
 public class CriarAtribuicaoEstivaDTO {
+
+    @NotNull(message = "Informe o tipo de operação (EMBARQUE ou DESCARGA).")
+    private TipoOperacaoEstiva tipoOperacao;
 
     @NotBlank(message = "Informe o código do contêiner.")
     @Size(max = 20, message = "O código do contêiner deve ter no máximo 20 caracteres.")
@@ -37,10 +41,21 @@ public class CriarAtribuicaoEstivaDTO {
     @Size(max = 40, message = "A posição de origem no pátio deve ter no máximo 40 caracteres.")
     private String posicaoPatioOrigem;
 
+    @Size(max = 40, message = "A posição de destino no pátio deve ter no máximo 40 caracteres.")
+    private String posicaoPatioDestino;
+
     @Min(value = 1, message = "A sequência de embarque deve ser maior ou igual a 1.")
     private Integer sequenciaEmbarque;
 
     public CriarAtribuicaoEstivaDTO() {
+    }
+
+    public TipoOperacaoEstiva getTipoOperacao() {
+        return tipoOperacao;
+    }
+
+    public void setTipoOperacao(TipoOperacaoEstiva tipoOperacao) {
+        this.tipoOperacao = tipoOperacao;
     }
 
     public String getCodigoConteiner() {
@@ -97,6 +112,14 @@ public class CriarAtribuicaoEstivaDTO {
 
     public void setPosicaoPatioOrigem(String posicaoPatioOrigem) {
         this.posicaoPatioOrigem = posicaoPatioOrigem;
+    }
+
+    public String getPosicaoPatioDestino() {
+        return posicaoPatioDestino;
+    }
+
+    public void setPosicaoPatioDestino(String posicaoPatioDestino) {
+        this.posicaoPatioDestino = posicaoPatioDestino;
     }
 
     public Integer getSequenciaEmbarque() {

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/PlanoEstivaDetalheDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/PlanoEstivaDetalheDTO.java
@@ -3,6 +3,7 @@ package br.com.cloudport.serviconavio.estiva.dto;
 import br.com.cloudport.serviconavio.escala.entidade.Escala;
 import br.com.cloudport.serviconavio.estiva.entidade.PlanoEstiva;
 import br.com.cloudport.serviconavio.estiva.entidade.StatusPlanoEstiva;
+import br.com.cloudport.serviconavio.estiva.entidade.TipoOperacaoEstiva;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,10 +18,12 @@ public class PlanoEstivaDetalheDTO {
     private final int fileiras;
     private final int camadas;
     private final int capacidadeCelulas;
-    private final int totalPlanejado;
-    private final int totalEmbarcado;
-    private final int totalPendente;
-    private final double ocupacaoPercentual;
+    private final int embarquePlanejado;
+    private final int embarqueExecutado;
+    private final int embarquePendente;
+    private final int descargaPlanejada;
+    private final int descargaExecutada;
+    private final int descargaPendente;
     private final List<AtribuicaoEstivaDTO> atribuicoes;
 
     public PlanoEstivaDetalheDTO(Long id,
@@ -32,10 +35,12 @@ public class PlanoEstivaDetalheDTO {
                                  int fileiras,
                                  int camadas,
                                  int capacidadeCelulas,
-                                 int totalPlanejado,
-                                 int totalEmbarcado,
-                                 int totalPendente,
-                                 double ocupacaoPercentual,
+                                 int embarquePlanejado,
+                                 int embarqueExecutado,
+                                 int embarquePendente,
+                                 int descargaPlanejada,
+                                 int descargaExecutada,
+                                 int descargaPendente,
                                  List<AtribuicaoEstivaDTO> atribuicoes) {
         this.id = id;
         this.escalaId = escalaId;
@@ -46,10 +51,12 @@ public class PlanoEstivaDetalheDTO {
         this.fileiras = fileiras;
         this.camadas = camadas;
         this.capacidadeCelulas = capacidadeCelulas;
-        this.totalPlanejado = totalPlanejado;
-        this.totalEmbarcado = totalEmbarcado;
-        this.totalPendente = totalPendente;
-        this.ocupacaoPercentual = ocupacaoPercentual;
+        this.embarquePlanejado = embarquePlanejado;
+        this.embarqueExecutado = embarqueExecutado;
+        this.embarquePendente = embarquePendente;
+        this.descargaPlanejada = descargaPlanejada;
+        this.descargaExecutada = descargaExecutada;
+        this.descargaPendente = descargaPendente;
         this.atribuicoes = atribuicoes;
     }
 
@@ -57,11 +64,16 @@ public class PlanoEstivaDetalheDTO {
         List<AtribuicaoEstivaDTO> atribuicoes = plano.getAtribuicoes().stream()
                 .map(AtribuicaoEstivaDTO::deEntidade)
                 .collect(Collectors.toList());
-        int totalPlanejado = atribuicoes.size();
-        int totalEmbarcado = (int) atribuicoes.stream().filter(AtribuicaoEstivaDTO::isEmbarcado).count();
-        int capacidade = plano.capacidadeCelulas();
-        double ocupacao = capacidade == 0 ? 0d
-                : Math.round((totalPlanejado * 10000d) / capacidade) / 100d;
+
+        int embarquePlanejado = (int) atribuicoes.stream()
+                .filter(a -> a.getTipoOperacao() == TipoOperacaoEstiva.EMBARQUE).count();
+        int embarqueExecutado = (int) atribuicoes.stream()
+                .filter(a -> a.getTipoOperacao() == TipoOperacaoEstiva.EMBARQUE && a.isEmbarcado()).count();
+        int descargaPlanejada = (int) atribuicoes.stream()
+                .filter(a -> a.getTipoOperacao() == TipoOperacaoEstiva.DESCARGA).count();
+        int descargaExecutada = (int) atribuicoes.stream()
+                .filter(a -> a.getTipoOperacao() == TipoOperacaoEstiva.DESCARGA && a.isEmbarcado()).count();
+
         Escala escala = plano.getEscala();
         return new PlanoEstivaDetalheDTO(
                 plano.getId(),
@@ -72,11 +84,13 @@ public class PlanoEstivaDetalheDTO {
                 plano.getBaias(),
                 plano.getFileiras(),
                 plano.getCamadas(),
-                capacidade,
-                totalPlanejado,
-                totalEmbarcado,
-                totalPlanejado - totalEmbarcado,
-                ocupacao,
+                plano.capacidadeCelulas(),
+                embarquePlanejado,
+                embarqueExecutado,
+                embarquePlanejado - embarqueExecutado,
+                descargaPlanejada,
+                descargaExecutada,
+                descargaPlanejada - descargaExecutada,
                 atribuicoes
         );
     }
@@ -117,20 +131,28 @@ public class PlanoEstivaDetalheDTO {
         return capacidadeCelulas;
     }
 
-    public int getTotalPlanejado() {
-        return totalPlanejado;
+    public int getEmbarquePlanejado() {
+        return embarquePlanejado;
     }
 
-    public int getTotalEmbarcado() {
-        return totalEmbarcado;
+    public int getEmbarqueExecutado() {
+        return embarqueExecutado;
     }
 
-    public int getTotalPendente() {
-        return totalPendente;
+    public int getEmbarquePendente() {
+        return embarquePendente;
     }
 
-    public double getOcupacaoPercentual() {
-        return ocupacaoPercentual;
+    public int getDescargaPlanejada() {
+        return descargaPlanejada;
+    }
+
+    public int getDescargaExecutada() {
+        return descargaExecutada;
+    }
+
+    public int getDescargaPendente() {
+        return descargaPendente;
     }
 
     public List<AtribuicaoEstivaDTO> getAtribuicoes() {

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/AtribuicaoEstiva.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/AtribuicaoEstiva.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Table(name = "atribuicao_estiva", uniqueConstraints = {
-        @UniqueConstraint(name = "uk_atribuicao_celula", columnNames = {"plano_id", "baia", "fileira", "camada"}),
+        @UniqueConstraint(name = "uk_atribuicao_celula", columnNames = {"plano_id", "tipo_operacao", "baia", "fileira", "camada"}),
         @UniqueConstraint(name = "uk_atribuicao_conteiner", columnNames = {"plano_id", "codigo_conteiner"})
 })
 public class AtribuicaoEstiva {
@@ -36,6 +36,10 @@ public class AtribuicaoEstiva {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "plano_id", nullable = false)
     private PlanoEstiva plano;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_operacao", nullable = false, length = 20)
+    private TipoOperacaoEstiva tipoOperacao;
 
     @Column(name = "codigo_conteiner", nullable = false, length = 20)
     private String codigoConteiner;
@@ -58,6 +62,9 @@ public class AtribuicaoEstiva {
 
     @Column(name = "posicao_patio_origem", length = 40)
     private String posicaoPatioOrigem;
+
+    @Column(name = "posicao_patio_destino", length = 40)
+    private String posicaoPatioDestino;
 
     @Column(name = "sequencia_embarque")
     private Integer sequenciaEmbarque;
@@ -88,6 +95,14 @@ public class AtribuicaoEstiva {
 
     public void setPlano(PlanoEstiva plano) {
         this.plano = plano;
+    }
+
+    public TipoOperacaoEstiva getTipoOperacao() {
+        return tipoOperacao;
+    }
+
+    public void setTipoOperacao(TipoOperacaoEstiva tipoOperacao) {
+        this.tipoOperacao = tipoOperacao;
     }
 
     public String getCodigoConteiner() {
@@ -144,6 +159,14 @@ public class AtribuicaoEstiva {
 
     public void setPosicaoPatioOrigem(String posicaoPatioOrigem) {
         this.posicaoPatioOrigem = posicaoPatioOrigem;
+    }
+
+    public String getPosicaoPatioDestino() {
+        return posicaoPatioDestino;
+    }
+
+    public void setPosicaoPatioDestino(String posicaoPatioDestino) {
+        this.posicaoPatioDestino = posicaoPatioDestino;
     }
 
     public Integer getSequenciaEmbarque() {

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/TipoOperacaoEstiva.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/TipoOperacaoEstiva.java
@@ -1,0 +1,11 @@
+package br.com.cloudport.serviconavio.estiva.entidade;
+
+/**
+ * Natureza da operação de uma atribuição de estiva.
+ * EMBARQUE: carga sai do pátio e vai para a célula do navio (baixa do estoque).
+ * DESCARGA: carga sai da célula do navio e vai para o pátio (entrada no estoque).
+ */
+public enum TipoOperacaoEstiva {
+    EMBARQUE,
+    DESCARGA
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/servico/PlanoEstivaServico.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/servico/PlanoEstivaServico.java
@@ -80,16 +80,18 @@ public class PlanoEstivaServico {
                 throw new ResponseStatusException(HttpStatus.CONFLICT,
                         String.format(Locale.ROOT, "O contêiner %s já está atribuído neste plano.", codigo));
             }
-            if (existente.getBaia() == dto.getBaia()
+            if (existente.getTipoOperacao() == dto.getTipoOperacao()
+                    && existente.getBaia() == dto.getBaia()
                     && existente.getFileira() == dto.getFileira()
                     && existente.getCamada() == dto.getCamada()) {
                 throw new ResponseStatusException(HttpStatus.CONFLICT,
-                        String.format(Locale.ROOT, "A célula %d-%d-%d já está ocupada.",
-                                dto.getBaia(), dto.getFileira(), dto.getCamada()));
+                        String.format(Locale.ROOT, "A célula %d-%d-%d já está ocupada para %s.",
+                                dto.getBaia(), dto.getFileira(), dto.getCamada(), dto.getTipoOperacao()));
             }
         }
 
         AtribuicaoEstiva atribuicao = new AtribuicaoEstiva();
+        atribuicao.setTipoOperacao(dto.getTipoOperacao());
         atribuicao.setCodigoConteiner(codigo);
         atribuicao.setTipoCarga(dto.getTipoCarga());
         atribuicao.setPesoToneladas(dto.getPesoToneladas());
@@ -97,6 +99,7 @@ public class PlanoEstivaServico {
         atribuicao.setFileira(dto.getFileira());
         atribuicao.setCamada(dto.getCamada());
         atribuicao.setPosicaoPatioOrigem(tratarTextoOpcional(dto.getPosicaoPatioOrigem()));
+        atribuicao.setPosicaoPatioDestino(tratarTextoOpcional(dto.getPosicaoPatioDestino()));
         atribuicao.setSequenciaEmbarque(dto.getSequenciaEmbarque());
         atribuicao.setEmbarcado(false);
 
@@ -105,14 +108,14 @@ public class PlanoEstivaServico {
     }
 
     @Transactional
-    public PlanoEstivaDetalheDTO embarcar(Long atribuicaoId) {
+    public PlanoEstivaDetalheDTO registrarOperacao(Long atribuicaoId) {
         AtribuicaoEstiva atribuicao = obterAtribuicao(atribuicaoId);
         PlanoEstiva plano = atribuicao.getPlano();
 
         if (!atribuicao.isEmbarcado()) {
             atribuicao.setEmbarcado(true);
             atribuicao.setEmbarcadoEm(LocalDateTime.now());
-            atualizarStatusAposEmbarque(plano);
+            atualizarStatusAposOperacao(plano);
         }
 
         return PlanoEstivaDetalheDTO.deEntidade(plano);
@@ -123,7 +126,7 @@ public class PlanoEstivaServico {
         AtribuicaoEstiva atribuicao = obterAtribuicao(atribuicaoId);
         if (atribuicao.isEmbarcado()) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Não é possível remover um contêiner que já foi embarcado.");
+                    "Não é possível remover um contêiner que já foi embarcado ou descarregado.");
         }
         PlanoEstiva plano = atribuicao.getPlano();
         plano.removerAtribuicao(atribuicao);
@@ -131,7 +134,7 @@ public class PlanoEstivaServico {
         return PlanoEstivaDetalheDTO.deEntidade(planoEstivaRepositorio.save(plano));
     }
 
-    private void atualizarStatusAposEmbarque(PlanoEstiva plano) {
+    private void atualizarStatusAposOperacao(PlanoEstiva plano) {
         boolean todosEmbarcados = !plano.getAtribuicoes().isEmpty()
                 && plano.getAtribuicoes().stream().allMatch(AtribuicaoEstiva::isEmbarcado);
         if (todosEmbarcados) {

--- a/backend/servico-navio/src/main/resources/db/migration/V4__estiva_descarga.sql
+++ b/backend/servico-navio/src/main/resources/db/migration/V4__estiva_descarga.sql
@@ -1,0 +1,21 @@
+-- Habilita o planejamento de descarga (navio -> pátio) reutilizando o plano de
+-- estiva: cada atribuição passa a ter um tipo de operação (EMBARQUE/DESCARGA) e
+-- uma posição de destino no pátio (usada na descarga, que dá entrada no estoque).
+
+ALTER TABLE atribuicao_estiva
+    ADD COLUMN IF NOT EXISTS tipo_operacao VARCHAR(20) NOT NULL DEFAULT 'EMBARQUE';
+
+ALTER TABLE atribuicao_estiva
+    ADD COLUMN IF NOT EXISTS posicao_patio_destino VARCHAR(40);
+
+-- A célula passa a ser única por operação, permitindo planejar a descarga e o
+-- (re)embarque da mesma posição física dentro de uma escala.
+ALTER TABLE atribuicao_estiva DROP CONSTRAINT IF EXISTS uk_atribuicao_celula;
+ALTER TABLE atribuicao_estiva
+    ADD CONSTRAINT uk_atribuicao_celula UNIQUE (plano_id, tipo_operacao, baia, fileira, camada);
+
+-- O valor padrão foi usado apenas para preencher as linhas existentes; a
+-- aplicação sempre informa o tipo explicitamente.
+ALTER TABLE atribuicao_estiva ALTER COLUMN tipo_operacao DROP DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_atribuicao_estiva_operacao ON atribuicao_estiva (tipo_operacao);

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.css
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.css
@@ -91,6 +91,29 @@ select {
   border: 1px solid #cbd2d9;
 }
 
+.modo-operacao {
+  display: inline-flex;
+  border: 1px solid #234986;
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 0.5rem 0 0.25rem;
+}
+
+.modo-operacao button {
+  border: none;
+  background: #ffffff;
+  color: #234986;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+}
+
+.modo-operacao button.ativo {
+  background: #234986;
+  color: #ffffff;
+}
+
 .indicadores {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.html
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.html
@@ -1,8 +1,9 @@
 <section class="embarque">
   <header class="embarque-cabecalho">
-    <h2>Planejamento de Embarque</h2>
+    <h2>Planejamento de Embarque e Descarga</h2>
     <p class="subtitulo">
-      Plano de estiva (bay/row/tier): organize a saída da carga do pátio para o navio e registre o embarque.
+      Plano de estiva (bay/row/tier): planeje a saída da carga do pátio para o navio (embarque)
+      e a retirada da carga do navio para o pátio (descarga).
     </p>
   </header>
 
@@ -41,27 +42,39 @@
   </div>
 
   <ng-container *ngIf="plano">
-    <!-- Indicadores / controle de saída de estoque -->
+    <!-- Alternância entre embarque e descarga -->
+    <div class="modo-operacao">
+      <button type="button" [class.ativo]="!ehDescarga" (click)="alternarModo('EMBARQUE')">
+        Embarque (pátio → navio)
+      </button>
+      <button type="button" [class.ativo]="ehDescarga" (click)="alternarModo('DESCARGA')">
+        Descarga (navio → pátio)
+      </button>
+    </div>
+
+    <!-- Indicadores / controle de estoque -->
     <div class="indicadores">
       <div class="indicador">
         <span class="indicador-valor">{{ plano.status }}</span>
         <span class="indicador-rotulo">Status do plano</span>
       </div>
       <div class="indicador">
-        <span class="indicador-valor">{{ plano.totalPlanejado }}</span>
-        <span class="indicador-rotulo">Planejados</span>
+        <span class="indicador-valor">{{ totalPlanejado }}</span>
+        <span class="indicador-rotulo">Planejados ({{ ehDescarga ? 'descarga' : 'embarque' }})</span>
       </div>
       <div class="indicador embarcado">
-        <span class="indicador-valor">{{ plano.totalEmbarcado }}</span>
-        <span class="indicador-rotulo">Embarcados (baixa do pátio)</span>
+        <span class="indicador-valor">{{ totalExecutado }}</span>
+        <span class="indicador-rotulo">
+          {{ ehDescarga ? 'Descarregados (entrada no pátio)' : 'Embarcados (baixa do pátio)' }}
+        </span>
       </div>
       <div class="indicador">
-        <span class="indicador-valor">{{ plano.totalPendente }}</span>
-        <span class="indicador-rotulo">Pendentes no pátio</span>
+        <span class="indicador-valor">{{ totalPendente }}</span>
+        <span class="indicador-rotulo">{{ ehDescarga ? 'Pendentes a bordo' : 'Pendentes no pátio' }}</span>
       </div>
       <div class="indicador">
-        <span class="indicador-valor">{{ plano.ocupacaoPercentual }}%</span>
-        <span class="indicador-rotulo">Ocupação ({{ plano.capacidadeCelulas }} células)</span>
+        <span class="indicador-valor">{{ plano.capacidadeCelulas }}</span>
+        <span class="indicador-rotulo">Células do navio</span>
       </div>
     </div>
 
@@ -84,7 +97,9 @@
         </div>
 
         <div *ngIf="baiaSelecionada != null" class="grade-navio">
-          <p class="grade-legenda-eixo">Baia {{ baiaSelecionada }} — camadas (tiers) × fileiras (rows)</p>
+          <p class="grade-legenda-eixo">
+            Baia {{ baiaSelecionada }} — camadas (tiers) × fileiras (rows) · modo {{ ehDescarga ? 'DESCARGA' : 'EMBARQUE' }}
+          </p>
           <table class="grade-celulas">
             <tbody>
               <tr *ngFor="let camada of camadasArrayDescendente">
@@ -117,14 +132,14 @@
             <li><span class="amostra tipo-perigoso"></span> Perigoso</li>
             <li><span class="amostra tipo-graneleiro"></span> Granel</li>
             <li><span class="amostra tipo-outro"></span> Outro</li>
-            <li><span class="amostra embarcado"></span> Embarcado</li>
+            <li><span class="amostra embarcado"></span> {{ ehDescarga ? 'Descarregado' : 'Embarcado' }}</li>
           </ul>
         </div>
       </div>
 
-      <!-- Fluxo pátio -> navio -->
+      <!-- Fluxo pátio <-> navio -->
       <div class="cartao fluxo">
-        <h3>Pátio → Navio</h3>
+        <h3>{{ ehDescarga ? 'Navio → Pátio' : 'Pátio → Navio' }}</h3>
         <p class="ajuda">Clique numa célula livre da grade para escolher a posição; preencha os dados do contêiner.</p>
 
         <form class="form-atribuicao" (ngSubmit)="adicionarAtribuicao()">
@@ -139,8 +154,11 @@
           <label>Peso (t)
             <input type="number" min="0" step="0.01" [(ngModel)]="novaAtribuicao.pesoToneladas" name="peso" />
           </label>
-          <label>Origem no pátio
+          <label *ngIf="!ehDescarga">Origem no pátio
             <input type="text" maxlength="40" [(ngModel)]="novaAtribuicao.posicaoPatioOrigem" name="origem" placeholder="ex: A-12-3" />
+          </label>
+          <label *ngIf="ehDescarga">Destino no pátio
+            <input type="text" maxlength="40" [(ngModel)]="novaAtribuicao.posicaoPatioDestino" name="destino" placeholder="ex: B-04-1" />
           </label>
           <div class="posicao-celula">
             <label>Baia
@@ -157,13 +175,13 @@
             </label>
           </div>
           <button type="submit" class="btn-primario" [disabled]="salvando || !novaAtribuicao.codigoConteiner">
-            Atribuir ao navio
+            {{ ehDescarga ? 'Planejar descarga' : 'Atribuir ao navio' }}
           </button>
         </form>
 
-        <h4>Carga da baia {{ baiaSelecionada }}</h4>
+        <h4>Carga da baia {{ baiaSelecionada }} ({{ ehDescarga ? 'descarga' : 'embarque' }})</h4>
         <p *ngIf="baiaSelecionada != null && atribuicoesDaBaia(baiaSelecionada).length === 0" class="vazio">
-          Nenhum contêiner atribuído nesta baia.
+          Nenhum contêiner planejado nesta baia para esta operação.
         </p>
         <ul class="lista-atribuicoes" *ngIf="baiaSelecionada != null">
           <li *ngFor="let item of atribuicoesDaBaia(baiaSelecionada)" [class.embarcado]="item.embarcado">
@@ -171,13 +189,14 @@
               <strong>{{ item.codigoConteiner }}</strong>
               <span class="item-detalhe">
                 {{ rotuloTipo(item.tipoCarga) }} · R{{ item.fileira }}/T{{ item.camada }}
-                <ng-container *ngIf="item.posicaoPatioOrigem"> · pátio {{ item.posicaoPatioOrigem }}</ng-container>
+                <ng-container *ngIf="!ehDescarga && item.posicaoPatioOrigem"> · de {{ item.posicaoPatioOrigem }}</ng-container>
+                <ng-container *ngIf="ehDescarga && item.posicaoPatioDestino"> · para {{ item.posicaoPatioDestino }}</ng-container>
               </span>
             </div>
             <div class="item-acoes">
-              <span *ngIf="item.embarcado" class="tag-embarcado">Embarcado</span>
-              <button *ngIf="!item.embarcado" type="button" class="btn-secundario" [disabled]="salvando" (click)="embarcar(item)">
-                Embarcar
+              <span *ngIf="item.embarcado" class="tag-embarcado">{{ ehDescarga ? 'Descarregado' : 'Embarcado' }}</span>
+              <button *ngIf="!item.embarcado" type="button" class="btn-secundario" [disabled]="salvando" (click)="operar(item)">
+                {{ rotuloAcao }}
               </button>
               <button *ngIf="!item.embarcado" type="button" class="btn-remover" [disabled]="salvando" (click)="remover(item)">
                 Remover

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.ts
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.ts
@@ -7,7 +7,8 @@ import {
   NovoPlanoEstiva,
   PlanoEstivaDetalhe,
   ServicoEstivaService,
-  TipoCargaConteiner
+  TipoCargaConteiner,
+  TipoOperacaoEstiva
 } from '../../service/servico-estiva/servico-estiva.service';
 
 interface OpcaoTipoCarga {
@@ -34,6 +35,8 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
   escalas: EscalaResumo[] = [];
   escalaSelecionadaId: number | null = null;
   plano: PlanoEstivaDetalhe | null = null;
+
+  modoOperacao: TipoOperacaoEstiva = 'EMBARQUE';
 
   carregando = false;
   salvando = false;
@@ -118,6 +121,14 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     });
   }
 
+  alternarModo(modo: TipoOperacaoEstiva): void {
+    if (this.modoOperacao === modo) {
+      return;
+    }
+    this.modoOperacao = modo;
+    this.novaAtribuicao = { ...this.criarAtribuicaoVazia(), baia: this.baiaSelecionada ?? 1 };
+  }
+
   selecionarBaia(baia: number): void {
     this.baiaSelecionada = baia;
     this.novaAtribuicao.baia = baia;
@@ -127,8 +138,7 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     if (this.baiaSelecionada == null) {
       return;
     }
-    const ocupante = this.atribuicaoEm(this.baiaSelecionada, fileira, camada);
-    if (ocupante) {
+    if (this.atribuicaoEm(this.baiaSelecionada, fileira, camada)) {
       return;
     }
     this.novaAtribuicao.baia = this.baiaSelecionada;
@@ -144,8 +154,10 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     this.erro = null;
     const payload: NovaAtribuicaoEstiva = {
       ...this.novaAtribuicao,
+      tipoOperacao: this.modoOperacao,
       pesoToneladas: this.novaAtribuicao.pesoToneladas || null,
       posicaoPatioOrigem: this.novaAtribuicao.posicaoPatioOrigem || null,
+      posicaoPatioDestino: this.novaAtribuicao.posicaoPatioDestino || null,
       sequenciaEmbarque: this.novaAtribuicao.sequenciaEmbarque || null
     };
     this.servicoEstiva.adicionarAtribuicao(this.escalaSelecionadaId, payload).subscribe({
@@ -161,17 +173,17 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     });
   }
 
-  embarcar(atribuicao: AtribuicaoEstiva): void {
+  operar(atribuicao: AtribuicaoEstiva): void {
     this.salvando = true;
     this.erro = null;
-    this.servicoEstiva.embarcar(atribuicao.id).subscribe({
+    this.servicoEstiva.operar(atribuicao.id).subscribe({
       next: (plano) => {
         this.aplicarPlano(plano);
         this.salvando = false;
       },
       error: (erro) => {
         this.salvando = false;
-        this.erro = this.extrairMensagem(erro, 'Não foi possível registrar o embarque.');
+        this.erro = this.extrairMensagem(erro, 'Não foi possível registrar a operação.');
       }
     });
   }
@@ -192,14 +204,15 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
   }
 
   atribuicaoEm(baia: number, fileira: number, camada: number): AtribuicaoEstiva | undefined {
-    return this.celulasOcupadas.get(this.chaveCelula(baia, fileira, camada));
+    return this.celulasOcupadas.get(this.chaveCelula(this.modoOperacao, baia, fileira, camada));
   }
 
   contarNaBaia(baia: number): number {
     if (!this.plano) {
       return 0;
     }
-    return this.plano.atribuicoes.filter((a) => a.baia === baia).length;
+    return this.plano.atribuicoes
+      .filter((a) => a.tipoOperacao === this.modoOperacao && a.baia === baia).length;
   }
 
   atribuicoesDaBaia(baia: number): AtribuicaoEstiva[] {
@@ -207,7 +220,7 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
       return [];
     }
     return this.plano.atribuicoes
-      .filter((a) => a.baia === baia)
+      .filter((a) => a.tipoOperacao === this.modoOperacao && a.baia === baia)
       .sort((a, b) => (a.sequenciaEmbarque ?? 0) - (b.sequenciaEmbarque ?? 0));
   }
 
@@ -221,6 +234,35 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
 
   get camadasArrayDescendente(): number[] {
     return this.intervalo(this.plano?.camadas ?? 0).reverse();
+  }
+
+  get ehDescarga(): boolean {
+    return this.modoOperacao === 'DESCARGA';
+  }
+
+  get rotuloAcao(): string {
+    return this.ehDescarga ? 'Descarregar' : 'Embarcar';
+  }
+
+  get totalPlanejado(): number {
+    if (!this.plano) {
+      return 0;
+    }
+    return this.ehDescarga ? this.plano.descargaPlanejada : this.plano.embarquePlanejado;
+  }
+
+  get totalExecutado(): number {
+    if (!this.plano) {
+      return 0;
+    }
+    return this.ehDescarga ? this.plano.descargaExecutada : this.plano.embarqueExecutado;
+  }
+
+  get totalPendente(): number {
+    if (!this.plano) {
+      return 0;
+    }
+    return this.ehDescarga ? this.plano.descargaPendente : this.plano.embarquePendente;
   }
 
   rotuloTipo(tipo: TipoCargaConteiner): string {
@@ -248,7 +290,7 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     this.celulasOcupadas = new Map<string, AtribuicaoEstiva>();
     for (const atribuicao of plano.atribuicoes) {
       this.celulasOcupadas.set(
-        this.chaveCelula(atribuicao.baia, atribuicao.fileira, atribuicao.camada),
+        this.chaveCelula(atribuicao.tipoOperacao, atribuicao.baia, atribuicao.fileira, atribuicao.camada),
         atribuicao
       );
     }
@@ -267,6 +309,7 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
 
   private criarAtribuicaoVazia(): NovaAtribuicaoEstiva {
     return {
+      tipoOperacao: this.modoOperacao,
       codigoConteiner: '',
       tipoCarga: 'SECO',
       pesoToneladas: null,
@@ -274,6 +317,7 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
       fileira: 1,
       camada: 1,
       posicaoPatioOrigem: null,
+      posicaoPatioDestino: null,
       sequenciaEmbarque: null
     };
   }
@@ -282,8 +326,8 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     return Array.from({ length: Math.max(0, tamanho) }, (_, indice) => indice + 1);
   }
 
-  private chaveCelula(baia: number, fileira: number, camada: number): string {
-    return `${baia}-${fileira}-${camada}`;
+  private chaveCelula(operacao: TipoOperacaoEstiva, baia: number, fileira: number, camada: number): string {
+    return `${operacao}-${baia}-${fileira}-${camada}`;
   }
 
   private extrairMensagem(erro: unknown, padrao: string): string {

--- a/frontend/cloudport/src/app/componentes/service/servico-estiva/servico-estiva.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-estiva/servico-estiva.service.ts
@@ -5,6 +5,7 @@ import { ConfiguracaoAplicacaoService } from '../../../configuracao/configuracao
 
 export type TipoCargaConteiner = 'SECO' | 'REFRIGERADO' | 'PERIGOSO' | 'GRANELEIRO' | 'OUTRO';
 export type StatusPlanoEstiva = 'RASCUNHO' | 'CONFIRMADO' | 'EM_EXECUCAO' | 'CONCLUIDO';
+export type TipoOperacaoEstiva = 'EMBARQUE' | 'DESCARGA';
 
 export interface EscalaResumo {
   id: number;
@@ -19,6 +20,7 @@ export interface EscalaResumo {
 
 export interface AtribuicaoEstiva {
   id: number;
+  tipoOperacao: TipoOperacaoEstiva;
   codigoConteiner: string;
   tipoCarga: TipoCargaConteiner;
   pesoToneladas?: number | null;
@@ -26,6 +28,7 @@ export interface AtribuicaoEstiva {
   fileira: number;
   camada: number;
   posicaoPatioOrigem?: string | null;
+  posicaoPatioDestino?: string | null;
   sequenciaEmbarque?: number | null;
   embarcado: boolean;
   embarcadoEm?: string | null;
@@ -41,10 +44,12 @@ export interface PlanoEstivaDetalhe {
   fileiras: number;
   camadas: number;
   capacidadeCelulas: number;
-  totalPlanejado: number;
-  totalEmbarcado: number;
-  totalPendente: number;
-  ocupacaoPercentual: number;
+  embarquePlanejado: number;
+  embarqueExecutado: number;
+  embarquePendente: number;
+  descargaPlanejada: number;
+  descargaExecutada: number;
+  descargaPendente: number;
   atribuicoes: AtribuicaoEstiva[];
 }
 
@@ -55,6 +60,7 @@ export interface NovoPlanoEstiva {
 }
 
 export interface NovaAtribuicaoEstiva {
+  tipoOperacao: TipoOperacaoEstiva;
   codigoConteiner: string;
   tipoCarga: TipoCargaConteiner;
   pesoToneladas?: number | null;
@@ -62,6 +68,7 @@ export interface NovaAtribuicaoEstiva {
   fileira: number;
   camada: number;
   posicaoPatioOrigem?: string | null;
+  posicaoPatioDestino?: string | null;
   sequenciaEmbarque?: number | null;
 }
 
@@ -93,9 +100,9 @@ export class ServicoEstivaService {
     );
   }
 
-  embarcar(atribuicaoId: number): Observable<PlanoEstivaDetalhe> {
+  operar(atribuicaoId: number): Observable<PlanoEstivaDetalhe> {
     return this.http.patch<PlanoEstivaDetalhe>(
-      this.construirUrl(`/plano-estiva/atribuicoes/${atribuicaoId}/embarcar`),
+      this.construirUrl(`/plano-estiva/atribuicoes/${atribuicaoId}/operar`),
       {}
     );
   }


### PR DESCRIPTION
## Resumo

Estende o plano de estiva para que o planner do terminal faça também a **descarga** (navio → pátio), além do embarque. Mesma tela e mesma grade do navio, com alternância entre as duas operações.

> PR empilhado sobre `claude/dazzling-pasteur-nvn4t` (PR #156, embarque). O diff aqui é só o da descarga; ao fazer merge, mesclar o #156 primeiro (ou retargetar a base para `main`).

## Backend (`servico-navio`, módulo `estiva`)
- Novo enum `TipoOperacaoEstiva` (EMBARQUE / DESCARGA).
- `AtribuicaoEstiva` ganha `tipoOperacao` e `posicaoPatioDestino` (destino no pátio, usado na descarga). A célula passa a ser **única por operação** (`plano_id, tipo_operacao, baia, fileira, camada`), permitindo planejar descarga e (re)embarque da mesma posição física.
- O endpoint de execução vira operação-neutro: `PATCH /plano-estiva/atribuicoes/{id}/operar` (registra a operação concluída — saída do pátio no embarque, entrada no pátio na descarga).
- DTO de detalhe passa a reportar estatísticas por operação: `embarquePlanejado/Executado/Pendente` e `descargaPlanejada/Executada/Pendente`.
- Migração Flyway `V4__estiva_descarga.sql`.

## Frontend (módulo `embarque`)
- Alternância **Embarque (pátio → navio)** / **Descarga (navio → pátio)** na tela de planejamento.
- A grade gráfica do navio e a lista da baia passam a ser filtradas pela operação selecionada; o formulário troca "Origem no pátio" (embarque) por "Destino no pátio" (descarga) e os botões/labels viram "Descarregar/Descarregado".
- Indicadores adaptados: descarregados (entrada no pátio) / pendentes a bordo.
- Migração `V9` (servico-autenticacao) ajusta o rótulo da aba para "Planejamento de Embarque/Descarga".

## Testes
- [x] Backend: `mvn compile` do `servico-navio` conclui com sucesso.
- [x] Frontend: `npm run build` conclui com sucesso (chunk lazy `embarque` empacotado).
- [ ] Verificação funcional end-to-end (Postgres + serviços + login) — não executada neste ambiente.

## Observação
- Para planejar a descarga, o planner registra os contêineres que chegam a bordo (inbound) nas células do navio com o destino no pátio; "Descarregar" dá entrada no estoque. A sincronização física com o `servico-yard` continua como próximo passo.

https://claude.ai/code/session_01FEDuRJp9CV47Mx1Db4Cvsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEDuRJp9CV47Mx1Db4Cvsk)_