### PR TITLE
Estiva: porão × convés, numeração real de tiers e terno (crane split)

### DIFF
--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/controlador/PlanoEstivaControlador.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/controlador/PlanoEstivaControlador.java
@@ -2,6 +2,7 @@ package br.com.cloudport.serviconavio.estiva.controlador;
 
 import br.com.cloudport.serviconavio.estiva.dto.CriarAtribuicaoEstivaDTO;
 import br.com.cloudport.serviconavio.estiva.dto.CriarPlanoEstivaDTO;
+import br.com.cloudport.serviconavio.estiva.dto.CriarTernoDTO;
 import br.com.cloudport.serviconavio.estiva.dto.PlanoEstivaDetalheDTO;
 import br.com.cloudport.serviconavio.estiva.servico.PlanoEstivaServico;
 import javax.validation.Valid;
@@ -53,5 +54,17 @@ public class PlanoEstivaControlador {
     @DeleteMapping("/plano-estiva/atribuicoes/{atribuicaoId}")
     public PlanoEstivaDetalheDTO removerAtribuicao(@PathVariable Long atribuicaoId) {
         return planoEstivaServico.removerAtribuicao(atribuicaoId);
+    }
+
+    @PostMapping("/escalas/{escalaId}/plano-estiva/ternos")
+    @ResponseStatus(HttpStatus.CREATED)
+    public PlanoEstivaDetalheDTO adicionarTerno(@PathVariable Long escalaId,
+                                                @Valid @RequestBody CriarTernoDTO dto) {
+        return planoEstivaServico.adicionarTerno(escalaId, dto);
+    }
+
+    @DeleteMapping("/plano-estiva/ternos/{ternoId}")
+    public PlanoEstivaDetalheDTO removerTerno(@PathVariable Long ternoId) {
+        return planoEstivaServico.removerTerno(ternoId);
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/AtribuicaoEstivaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/AtribuicaoEstivaDTO.java
@@ -1,6 +1,7 @@
 package br.com.cloudport.serviconavio.estiva.dto;
 
 import br.com.cloudport.serviconavio.estiva.entidade.AtribuicaoEstiva;
+import br.com.cloudport.serviconavio.estiva.entidade.ConvesNavio;
 import br.com.cloudport.serviconavio.estiva.entidade.TipoCargaConteiner;
 import br.com.cloudport.serviconavio.estiva.entidade.TipoOperacaoEstiva;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -17,6 +18,7 @@ public class AtribuicaoEstivaDTO {
     private final int baia;
     private final int fileira;
     private final int camada;
+    private final ConvesNavio conves;
     private final String posicaoPatioOrigem;
     private final String posicaoPatioDestino;
     private final Integer sequenciaEmbarque;
@@ -32,6 +34,7 @@ public class AtribuicaoEstivaDTO {
                                int baia,
                                int fileira,
                                int camada,
+                               ConvesNavio conves,
                                String posicaoPatioOrigem,
                                String posicaoPatioDestino,
                                Integer sequenciaEmbarque,
@@ -45,6 +48,7 @@ public class AtribuicaoEstivaDTO {
         this.baia = baia;
         this.fileira = fileira;
         this.camada = camada;
+        this.conves = conves;
         this.posicaoPatioOrigem = posicaoPatioOrigem;
         this.posicaoPatioDestino = posicaoPatioDestino;
         this.sequenciaEmbarque = sequenciaEmbarque;
@@ -62,6 +66,7 @@ public class AtribuicaoEstivaDTO {
                 atribuicao.getBaia(),
                 atribuicao.getFileira(),
                 atribuicao.getCamada(),
+                atribuicao.getConves(),
                 atribuicao.getPosicaoPatioOrigem(),
                 atribuicao.getPosicaoPatioDestino(),
                 atribuicao.getSequenciaEmbarque(),
@@ -100,6 +105,10 @@ public class AtribuicaoEstivaDTO {
 
     public int getCamada() {
         return camada;
+    }
+
+    public ConvesNavio getConves() {
+        return conves;
     }
 
     public String getPosicaoPatioOrigem() {

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarPlanoEstivaDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarPlanoEstivaDTO.java
@@ -16,10 +16,15 @@ public class CriarPlanoEstivaDTO {
     @Max(value = 40, message = "O número de fileiras não pode exceder 40.")
     private Integer fileiras;
 
-    @NotNull(message = "Informe a quantidade de camadas (tiers).")
-    @Min(value = 1, message = "O navio deve ter ao menos 1 camada.")
-    @Max(value = 20, message = "O número de camadas não pode exceder 20.")
-    private Integer camadas;
+    @NotNull(message = "Informe a quantidade de camadas no porão (tiers in-hold).")
+    @Min(value = 0, message = "O número de camadas do porão não pode ser negativo.")
+    @Max(value = 20, message = "O número de camadas do porão não pode exceder 20.")
+    private Integer camadasPorao;
+
+    @NotNull(message = "Informe a quantidade de camadas no convés (tiers on-deck).")
+    @Min(value = 0, message = "O número de camadas do convés não pode ser negativo.")
+    @Max(value = 20, message = "O número de camadas do convés não pode exceder 20.")
+    private Integer camadasConves;
 
     public CriarPlanoEstivaDTO() {
     }
@@ -40,11 +45,19 @@ public class CriarPlanoEstivaDTO {
         this.fileiras = fileiras;
     }
 
-    public Integer getCamadas() {
-        return camadas;
+    public Integer getCamadasPorao() {
+        return camadasPorao;
     }
 
-    public void setCamadas(Integer camadas) {
-        this.camadas = camadas;
+    public void setCamadasPorao(Integer camadasPorao) {
+        this.camadasPorao = camadasPorao;
+    }
+
+    public Integer getCamadasConves() {
+        return camadasConves;
+    }
+
+    public void setCamadasConves(Integer camadasConves) {
+        this.camadasConves = camadasConves;
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarTernoDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/CriarTernoDTO.java
@@ -1,0 +1,60 @@
+package br.com.cloudport.serviconavio.estiva.dto;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class CriarTernoDTO {
+
+    @NotBlank(message = "Informe o identificador do terno.")
+    @Size(max = 40, message = "O identificador do terno deve ter no máximo 40 caracteres.")
+    private String identificador;
+
+    @NotNull(message = "Informe a sequência de operação do terno.")
+    @Min(value = 1, message = "A sequência deve ser maior ou igual a 1.")
+    private Integer sequencia;
+
+    @NotNull(message = "Informe a baia inicial do terno.")
+    @Min(value = 1, message = "A baia inicial deve ser maior ou igual a 1.")
+    private Integer baiaInicial;
+
+    @NotNull(message = "Informe a baia final do terno.")
+    @Min(value = 1, message = "A baia final deve ser maior ou igual a 1.")
+    private Integer baiaFinal;
+
+    public CriarTernoDTO() {
+    }
+
+    public String getIdentificador() {
+        return identificador;
+    }
+
+    public void setIdentificador(String identificador) {
+        this.identificador = identificador;
+    }
+
+    public Integer getSequencia() {
+        return sequencia;
+    }
+
+    public void setSequencia(Integer sequencia) {
+        this.sequencia = sequencia;
+    }
+
+    public Integer getBaiaInicial() {
+        return baiaInicial;
+    }
+
+    public void setBaiaInicial(Integer baiaInicial) {
+        this.baiaInicial = baiaInicial;
+    }
+
+    public Integer getBaiaFinal() {
+        return baiaFinal;
+    }
+
+    public void setBaiaFinal(Integer baiaFinal) {
+        this.baiaFinal = baiaFinal;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/PlanoEstivaDetalheDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/PlanoEstivaDetalheDTO.java
@@ -3,6 +3,7 @@ package br.com.cloudport.serviconavio.estiva.dto;
 import br.com.cloudport.serviconavio.escala.entidade.Escala;
 import br.com.cloudport.serviconavio.estiva.entidade.PlanoEstiva;
 import br.com.cloudport.serviconavio.estiva.entidade.StatusPlanoEstiva;
+import br.com.cloudport.serviconavio.estiva.entidade.TiersEstiva;
 import br.com.cloudport.serviconavio.estiva.entidade.TipoOperacaoEstiva;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,7 +17,10 @@ public class PlanoEstivaDetalheDTO {
     private final StatusPlanoEstiva status;
     private final int baias;
     private final int fileiras;
-    private final int camadas;
+    private final int camadasPorao;
+    private final int camadasConves;
+    private final List<Integer> tiersPorao;
+    private final List<Integer> tiersConves;
     private final int capacidadeCelulas;
     private final int embarquePlanejado;
     private final int embarqueExecutado;
@@ -25,6 +29,7 @@ public class PlanoEstivaDetalheDTO {
     private final int descargaExecutada;
     private final int descargaPendente;
     private final List<AtribuicaoEstivaDTO> atribuicoes;
+    private final List<TernoDTO> ternos;
 
     public PlanoEstivaDetalheDTO(Long id,
                                  Long escalaId,
@@ -33,7 +38,10 @@ public class PlanoEstivaDetalheDTO {
                                  StatusPlanoEstiva status,
                                  int baias,
                                  int fileiras,
-                                 int camadas,
+                                 int camadasPorao,
+                                 int camadasConves,
+                                 List<Integer> tiersPorao,
+                                 List<Integer> tiersConves,
                                  int capacidadeCelulas,
                                  int embarquePlanejado,
                                  int embarqueExecutado,
@@ -41,7 +49,8 @@ public class PlanoEstivaDetalheDTO {
                                  int descargaPlanejada,
                                  int descargaExecutada,
                                  int descargaPendente,
-                                 List<AtribuicaoEstivaDTO> atribuicoes) {
+                                 List<AtribuicaoEstivaDTO> atribuicoes,
+                                 List<TernoDTO> ternos) {
         this.id = id;
         this.escalaId = escalaId;
         this.nomeNavio = nomeNavio;
@@ -49,7 +58,10 @@ public class PlanoEstivaDetalheDTO {
         this.status = status;
         this.baias = baias;
         this.fileiras = fileiras;
-        this.camadas = camadas;
+        this.camadasPorao = camadasPorao;
+        this.camadasConves = camadasConves;
+        this.tiersPorao = tiersPorao;
+        this.tiersConves = tiersConves;
         this.capacidadeCelulas = capacidadeCelulas;
         this.embarquePlanejado = embarquePlanejado;
         this.embarqueExecutado = embarqueExecutado;
@@ -58,6 +70,7 @@ public class PlanoEstivaDetalheDTO {
         this.descargaExecutada = descargaExecutada;
         this.descargaPendente = descargaPendente;
         this.atribuicoes = atribuicoes;
+        this.ternos = ternos;
     }
 
     public static PlanoEstivaDetalheDTO deEntidade(PlanoEstiva plano) {
@@ -74,6 +87,10 @@ public class PlanoEstivaDetalheDTO {
         int descargaExecutada = (int) atribuicoes.stream()
                 .filter(a -> a.getTipoOperacao() == TipoOperacaoEstiva.DESCARGA && a.isEmbarcado()).count();
 
+        List<TernoDTO> ternos = plano.getTernos().stream()
+                .map(TernoDTO::deEntidade)
+                .collect(Collectors.toList());
+
         Escala escala = plano.getEscala();
         return new PlanoEstivaDetalheDTO(
                 plano.getId(),
@@ -83,7 +100,10 @@ public class PlanoEstivaDetalheDTO {
                 plano.getStatus(),
                 plano.getBaias(),
                 plano.getFileiras(),
-                plano.getCamadas(),
+                plano.getCamadasPorao(),
+                plano.getCamadasConves(),
+                TiersEstiva.tiersPorao(plano.getCamadasPorao()),
+                TiersEstiva.tiersConves(plano.getCamadasConves()),
                 plano.capacidadeCelulas(),
                 embarquePlanejado,
                 embarqueExecutado,
@@ -91,7 +111,8 @@ public class PlanoEstivaDetalheDTO {
                 descargaPlanejada,
                 descargaExecutada,
                 descargaPlanejada - descargaExecutada,
-                atribuicoes
+                atribuicoes,
+                ternos
         );
     }
 
@@ -123,8 +144,20 @@ public class PlanoEstivaDetalheDTO {
         return fileiras;
     }
 
-    public int getCamadas() {
-        return camadas;
+    public int getCamadasPorao() {
+        return camadasPorao;
+    }
+
+    public int getCamadasConves() {
+        return camadasConves;
+    }
+
+    public List<Integer> getTiersPorao() {
+        return tiersPorao;
+    }
+
+    public List<Integer> getTiersConves() {
+        return tiersConves;
     }
 
     public int getCapacidadeCelulas() {
@@ -157,5 +190,9 @@ public class PlanoEstivaDetalheDTO {
 
     public List<AtribuicaoEstivaDTO> getAtribuicoes() {
         return atribuicoes;
+    }
+
+    public List<TernoDTO> getTernos() {
+        return ternos;
     }
 }

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/TernoDTO.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/dto/TernoDTO.java
@@ -1,0 +1,50 @@
+package br.com.cloudport.serviconavio.estiva.dto;
+
+import br.com.cloudport.serviconavio.estiva.entidade.Terno;
+
+public class TernoDTO {
+
+    private final Long id;
+    private final String identificador;
+    private final int sequencia;
+    private final int baiaInicial;
+    private final int baiaFinal;
+
+    public TernoDTO(Long id, String identificador, int sequencia, int baiaInicial, int baiaFinal) {
+        this.id = id;
+        this.identificador = identificador;
+        this.sequencia = sequencia;
+        this.baiaInicial = baiaInicial;
+        this.baiaFinal = baiaFinal;
+    }
+
+    public static TernoDTO deEntidade(Terno terno) {
+        return new TernoDTO(
+                terno.getId(),
+                terno.getIdentificador(),
+                terno.getSequencia(),
+                terno.getBaiaInicial(),
+                terno.getBaiaFinal()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getIdentificador() {
+        return identificador;
+    }
+
+    public int getSequencia() {
+        return sequencia;
+    }
+
+    public int getBaiaInicial() {
+        return baiaInicial;
+    }
+
+    public int getBaiaFinal() {
+        return baiaFinal;
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/AtribuicaoEstiva.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/AtribuicaoEstiva.java
@@ -60,6 +60,10 @@ public class AtribuicaoEstiva {
     @Column(name = "camada", nullable = false)
     private int camada;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "conves", nullable = false, length = 10)
+    private ConvesNavio conves;
+
     @Column(name = "posicao_patio_origem", length = 40)
     private String posicaoPatioOrigem;
 
@@ -151,6 +155,14 @@ public class AtribuicaoEstiva {
 
     public void setCamada(int camada) {
         this.camada = camada;
+    }
+
+    public ConvesNavio getConves() {
+        return conves;
+    }
+
+    public void setConves(ConvesNavio conves) {
+        this.conves = conves;
     }
 
     public String getPosicaoPatioOrigem() {

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/ConvesNavio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/ConvesNavio.java
@@ -1,0 +1,11 @@
+package br.com.cloudport.serviconavio.estiva.entidade;
+
+/**
+ * Localização vertical da célula no navio, separada pela tampa de escotilha.
+ * PORAO: abaixo do convés (in-hold), tiers pares iniciando em 02.
+ * CONVES: acima do convés (on-deck), tiers iniciando em 82.
+ */
+public enum ConvesNavio {
+    PORAO,
+    CONVES
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/PlanoEstiva.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/PlanoEstiva.java
@@ -48,12 +48,19 @@ public class PlanoEstiva {
     @Column(name = "fileiras", nullable = false)
     private int fileiras;
 
-    @Column(name = "camadas", nullable = false)
-    private int camadas;
+    @Column(name = "camadas_porao", nullable = false)
+    private int camadasPorao;
+
+    @Column(name = "camadas_conves", nullable = false)
+    private int camadasConves;
 
     @OneToMany(mappedBy = "plano", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @OrderBy("baia ASC, fileira ASC, camada ASC")
     private List<AtribuicaoEstiva> atribuicoes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "plano", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("sequencia ASC, baiaInicial ASC")
+    private List<Terno> ternos = new ArrayList<>();
 
     @Column(name = "criado_em", nullable = false)
     private LocalDateTime criadoEm;
@@ -101,12 +108,20 @@ public class PlanoEstiva {
         this.fileiras = fileiras;
     }
 
-    public int getCamadas() {
-        return camadas;
+    public int getCamadasPorao() {
+        return camadasPorao;
     }
 
-    public void setCamadas(int camadas) {
-        this.camadas = camadas;
+    public void setCamadasPorao(int camadasPorao) {
+        this.camadasPorao = camadasPorao;
+    }
+
+    public int getCamadasConves() {
+        return camadasConves;
+    }
+
+    public void setCamadasConves(int camadasConves) {
+        this.camadasConves = camadasConves;
     }
 
     public List<AtribuicaoEstiva> getAtribuicoes() {
@@ -115,6 +130,24 @@ public class PlanoEstiva {
 
     public void setAtribuicoes(List<AtribuicaoEstiva> atribuicoes) {
         this.atribuicoes = atribuicoes;
+    }
+
+    public List<Terno> getTernos() {
+        return ternos;
+    }
+
+    public void setTernos(List<Terno> ternos) {
+        this.ternos = ternos;
+    }
+
+    public void adicionarTerno(Terno terno) {
+        terno.setPlano(this);
+        this.ternos.add(terno);
+    }
+
+    public void removerTerno(Terno terno) {
+        this.ternos.remove(terno);
+        terno.setPlano(null);
     }
 
     public void adicionarAtribuicao(AtribuicaoEstiva atribuicao) {
@@ -128,7 +161,7 @@ public class PlanoEstiva {
     }
 
     public int capacidadeCelulas() {
-        return baias * fileiras * camadas;
+        return baias * fileiras * (camadasPorao + camadasConves);
     }
 
     public LocalDateTime getCriadoEm() {

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/Terno.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/Terno.java
@@ -1,0 +1,136 @@
+package br.com.cloudport.serviconavio.estiva.entidade;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+
+/**
+ * Terno (crane split / work queue): turma/guindaste que opera um intervalo
+ * contíguo de baias do navio, com uma ordem de execução.
+ */
+@Entity
+@Table(name = "terno", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_terno_identificador", columnNames = {"plano_id", "identificador"})
+})
+public class Terno {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plano_id", nullable = false)
+    private PlanoEstiva plano;
+
+    @Column(name = "identificador", nullable = false, length = 40)
+    private String identificador;
+
+    @Column(name = "sequencia", nullable = false)
+    private int sequencia;
+
+    @Column(name = "baia_inicial", nullable = false)
+    private int baiaInicial;
+
+    @Column(name = "baia_final", nullable = false)
+    private int baiaFinal;
+
+    @Column(name = "criado_em", nullable = false)
+    private LocalDateTime criadoEm;
+
+    @Column(name = "atualizado_em", nullable = false)
+    private LocalDateTime atualizadoEm;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public PlanoEstiva getPlano() {
+        return plano;
+    }
+
+    public void setPlano(PlanoEstiva plano) {
+        this.plano = plano;
+    }
+
+    public String getIdentificador() {
+        return identificador;
+    }
+
+    public void setIdentificador(String identificador) {
+        this.identificador = identificador;
+    }
+
+    public int getSequencia() {
+        return sequencia;
+    }
+
+    public void setSequencia(int sequencia) {
+        this.sequencia = sequencia;
+    }
+
+    public int getBaiaInicial() {
+        return baiaInicial;
+    }
+
+    public void setBaiaInicial(int baiaInicial) {
+        this.baiaInicial = baiaInicial;
+    }
+
+    public int getBaiaFinal() {
+        return baiaFinal;
+    }
+
+    public void setBaiaFinal(int baiaFinal) {
+        this.baiaFinal = baiaFinal;
+    }
+
+    public boolean cobreBaia(int baia) {
+        return baia >= baiaInicial && baia <= baiaFinal;
+    }
+
+    public boolean sobrepoe(int inicio, int fim) {
+        return inicio <= baiaFinal && fim >= baiaInicial;
+    }
+
+    public LocalDateTime getCriadoEm() {
+        return criadoEm;
+    }
+
+    public void setCriadoEm(LocalDateTime criadoEm) {
+        this.criadoEm = criadoEm;
+    }
+
+    public LocalDateTime getAtualizadoEm() {
+        return atualizadoEm;
+    }
+
+    public void setAtualizadoEm(LocalDateTime atualizadoEm) {
+        this.atualizadoEm = atualizadoEm;
+    }
+
+    @PrePersist
+    public void aoCriar() {
+        LocalDateTime agora = LocalDateTime.now();
+        this.criadoEm = agora;
+        this.atualizadoEm = agora;
+    }
+
+    @PreUpdate
+    public void aoAtualizar() {
+        this.atualizadoEm = LocalDateTime.now();
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/TiersEstiva.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/entidade/TiersEstiva.java
@@ -1,0 +1,44 @@
+package br.com.cloudport.serviconavio.estiva.entidade;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Regras de numeração dos tiers no padrão Bay-Row-Tier:
+ * porão usa tiers pares a partir de 02 e o convés a partir de 82,
+ * o que permite derivar automaticamente a localização (PORAO/CONVES).
+ */
+public final class TiersEstiva {
+
+    public static final int PASSO = 2;
+    public static final int BASE_PORAO = 2;
+    public static final int BASE_CONVES = 82;
+    public static final int LIMITE_CONVES = 80;
+
+    private TiersEstiva() {
+    }
+
+    public static List<Integer> tiersPorao(int camadasPorao) {
+        List<Integer> tiers = new ArrayList<>();
+        for (int i = 0; i < camadasPorao; i++) {
+            tiers.add(BASE_PORAO + i * PASSO);
+        }
+        return tiers;
+    }
+
+    public static List<Integer> tiersConves(int camadasConves) {
+        List<Integer> tiers = new ArrayList<>();
+        for (int i = 0; i < camadasConves; i++) {
+            tiers.add(BASE_CONVES + i * PASSO);
+        }
+        return tiers;
+    }
+
+    public static ConvesNavio convesDoTier(int tier) {
+        return tier >= LIMITE_CONVES ? ConvesNavio.CONVES : ConvesNavio.PORAO;
+    }
+
+    public static boolean tierValido(int tier, int camadasPorao, int camadasConves) {
+        return tiersPorao(camadasPorao).contains(tier) || tiersConves(camadasConves).contains(tier);
+    }
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/repositorio/TernoRepositorio.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/repositorio/TernoRepositorio.java
@@ -1,0 +1,7 @@
+package br.com.cloudport.serviconavio.estiva.repositorio;
+
+import br.com.cloudport.serviconavio.estiva.entidade.Terno;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TernoRepositorio extends JpaRepository<Terno, Long> {
+}

--- a/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/servico/PlanoEstivaServico.java
+++ b/backend/servico-navio/src/main/java/br/com/cloudport/serviconavio/estiva/servico/PlanoEstivaServico.java
@@ -5,12 +5,16 @@ import br.com.cloudport.serviconavio.escala.entidade.Escala;
 import br.com.cloudport.serviconavio.escala.repositorio.EscalaRepositorio;
 import br.com.cloudport.serviconavio.estiva.dto.CriarAtribuicaoEstivaDTO;
 import br.com.cloudport.serviconavio.estiva.dto.CriarPlanoEstivaDTO;
+import br.com.cloudport.serviconavio.estiva.dto.CriarTernoDTO;
 import br.com.cloudport.serviconavio.estiva.dto.PlanoEstivaDetalheDTO;
 import br.com.cloudport.serviconavio.estiva.entidade.AtribuicaoEstiva;
 import br.com.cloudport.serviconavio.estiva.entidade.PlanoEstiva;
 import br.com.cloudport.serviconavio.estiva.entidade.StatusPlanoEstiva;
+import br.com.cloudport.serviconavio.estiva.entidade.Terno;
+import br.com.cloudport.serviconavio.estiva.entidade.TiersEstiva;
 import br.com.cloudport.serviconavio.estiva.repositorio.AtribuicaoEstivaRepositorio;
 import br.com.cloudport.serviconavio.estiva.repositorio.PlanoEstivaRepositorio;
+import br.com.cloudport.serviconavio.estiva.repositorio.TernoRepositorio;
 import java.time.LocalDateTime;
 import java.util.Locale;
 import org.springframework.http.HttpStatus;
@@ -24,15 +28,18 @@ public class PlanoEstivaServico {
 
     private final PlanoEstivaRepositorio planoEstivaRepositorio;
     private final AtribuicaoEstivaRepositorio atribuicaoEstivaRepositorio;
+    private final TernoRepositorio ternoRepositorio;
     private final EscalaRepositorio escalaRepositorio;
     private final SanitizadorEntrada sanitizadorEntrada;
 
     public PlanoEstivaServico(PlanoEstivaRepositorio planoEstivaRepositorio,
                               AtribuicaoEstivaRepositorio atribuicaoEstivaRepositorio,
+                              TernoRepositorio ternoRepositorio,
                               EscalaRepositorio escalaRepositorio,
                               SanitizadorEntrada sanitizadorEntrada) {
         this.planoEstivaRepositorio = planoEstivaRepositorio;
         this.atribuicaoEstivaRepositorio = atribuicaoEstivaRepositorio;
+        this.ternoRepositorio = ternoRepositorio;
         this.escalaRepositorio = escalaRepositorio;
         this.sanitizadorEntrada = sanitizadorEntrada;
     }
@@ -51,12 +58,18 @@ public class PlanoEstivaServico {
                     "Esta escala já possui um plano de estiva.");
         }
 
+        if (dto.getCamadasPorao() + dto.getCamadasConves() < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "O navio deve ter ao menos uma camada (porão ou convés).");
+        }
+
         PlanoEstiva plano = new PlanoEstiva();
         plano.setEscala(escala);
         plano.setStatus(StatusPlanoEstiva.RASCUNHO);
         plano.setBaias(dto.getBaias());
         plano.setFileiras(dto.getFileiras());
-        plano.setCamadas(dto.getCamadas());
+        plano.setCamadasPorao(dto.getCamadasPorao());
+        plano.setCamadasConves(dto.getCamadasConves());
 
         return PlanoEstivaDetalheDTO.deEntidade(planoEstivaRepositorio.save(plano));
     }
@@ -98,6 +111,7 @@ public class PlanoEstivaServico {
         atribuicao.setBaia(dto.getBaia());
         atribuicao.setFileira(dto.getFileira());
         atribuicao.setCamada(dto.getCamada());
+        atribuicao.setConves(TiersEstiva.convesDoTier(dto.getCamada()));
         atribuicao.setPosicaoPatioOrigem(tratarTextoOpcional(dto.getPosicaoPatioOrigem()));
         atribuicao.setPosicaoPatioDestino(tratarTextoOpcional(dto.getPosicaoPatioDestino()));
         atribuicao.setSequenciaEmbarque(dto.getSequenciaEmbarque());
@@ -134,6 +148,55 @@ public class PlanoEstivaServico {
         return PlanoEstivaDetalheDTO.deEntidade(planoEstivaRepositorio.save(plano));
     }
 
+    @Transactional
+    public PlanoEstivaDetalheDTO adicionarTerno(Long escalaId, CriarTernoDTO dto) {
+        PlanoEstiva plano = obterPlanoPorEscala(escalaId);
+
+        if (dto.getBaiaInicial() > dto.getBaiaFinal()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "A baia inicial do terno não pode ser maior que a baia final.");
+        }
+        if (dto.getBaiaFinal() > plano.getBaias()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format(Locale.ROOT, "O terno excede o número de baias do navio (%d).", plano.getBaias()));
+        }
+
+        String identificador = sanitizadorEntrada
+                .limparTextoObrigatorio(dto.getIdentificador(), "identificador do terno")
+                .toUpperCase(Locale.ROOT);
+
+        for (Terno existente : plano.getTernos()) {
+            if (existente.getIdentificador().equalsIgnoreCase(identificador)) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        String.format(Locale.ROOT, "Já existe o terno %s neste plano.", identificador));
+            }
+            if (existente.sobrepoe(dto.getBaiaInicial(), dto.getBaiaFinal())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        String.format(Locale.ROOT, "As baias do terno %s se sobrepõem ao terno %s.",
+                                identificador, existente.getIdentificador()));
+            }
+        }
+
+        Terno terno = new Terno();
+        terno.setIdentificador(identificador);
+        terno.setSequencia(dto.getSequencia());
+        terno.setBaiaInicial(dto.getBaiaInicial());
+        terno.setBaiaFinal(dto.getBaiaFinal());
+
+        plano.adicionarTerno(terno);
+        return PlanoEstivaDetalheDTO.deEntidade(planoEstivaRepositorio.save(plano));
+    }
+
+    @Transactional
+    public PlanoEstivaDetalheDTO removerTerno(Long ternoId) {
+        Terno terno = ternoRepositorio.findById(ternoId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Terno não encontrado."));
+        PlanoEstiva plano = terno.getPlano();
+        plano.removerTerno(terno);
+        ternoRepositorio.delete(terno);
+        return PlanoEstivaDetalheDTO.deEntidade(planoEstivaRepositorio.save(plano));
+    }
+
     private void atualizarStatusAposOperacao(PlanoEstiva plano) {
         boolean todosEmbarcados = !plano.getAtribuicoes().isEmpty()
                 && plano.getAtribuicoes().stream().allMatch(AtribuicaoEstiva::isEmbarcado);
@@ -146,11 +209,19 @@ public class PlanoEstivaServico {
     }
 
     private void validarCelulaDentroDosLimites(PlanoEstiva plano, int baia, int fileira, int camada) {
-        if (baia > plano.getBaias() || fileira > plano.getFileiras() || camada > plano.getCamadas()) {
+        if (baia < 1 || baia > plano.getBaias() || fileira < 1 || fileira > plano.getFileiras()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     String.format(Locale.ROOT,
-                            "A célula %d-%d-%d está fora dos limites do navio (%d baias, %d fileiras, %d camadas).",
-                            baia, fileira, camada, plano.getBaias(), plano.getFileiras(), plano.getCamadas()));
+                            "A célula %d-%d-%d está fora dos limites do navio (%d baias, %d fileiras).",
+                            baia, fileira, camada, plano.getBaias(), plano.getFileiras()));
+        }
+        if (!TiersEstiva.tierValido(camada, plano.getCamadasPorao(), plano.getCamadasConves())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format(Locale.ROOT,
+                            "Tier %d inválido. Use porão %s ou convés %s.",
+                            camada,
+                            TiersEstiva.tiersPorao(plano.getCamadasPorao()),
+                            TiersEstiva.tiersConves(plano.getCamadasConves())));
         }
     }
 

--- a/backend/servico-navio/src/main/resources/db/migration/V5__estiva_conves_terno.sql
+++ b/backend/servico-navio/src/main/resources/db/migration/V5__estiva_conves_terno.sql
@@ -1,0 +1,33 @@
+-- Separa as camadas do plano em porão (in-hold) e convés (on-deck), classifica
+-- cada atribuição pela localização e introduz o terno (crane split) que opera
+-- um intervalo contíguo de baias.
+
+-- Camadas por localização (substituem a contagem única de camadas).
+ALTER TABLE plano_estiva ADD COLUMN IF NOT EXISTS camadas_porao INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE plano_estiva ADD COLUMN IF NOT EXISTS camadas_conves INTEGER NOT NULL DEFAULT 0;
+
+UPDATE plano_estiva SET camadas_porao = camadas WHERE camadas IS NOT NULL;
+
+ALTER TABLE plano_estiva ALTER COLUMN camadas_porao DROP DEFAULT;
+ALTER TABLE plano_estiva ALTER COLUMN camadas_conves DROP DEFAULT;
+ALTER TABLE plano_estiva DROP COLUMN IF EXISTS camadas;
+
+-- Localização vertical da célula (derivada do número do tier).
+ALTER TABLE atribuicao_estiva ADD COLUMN IF NOT EXISTS conves VARCHAR(10) NOT NULL DEFAULT 'PORAO';
+UPDATE atribuicao_estiva SET conves = CASE WHEN camada >= 80 THEN 'CONVES' ELSE 'PORAO' END;
+ALTER TABLE atribuicao_estiva ALTER COLUMN conves DROP DEFAULT;
+
+-- Terno / crane split.
+CREATE TABLE IF NOT EXISTS terno (
+    id BIGSERIAL PRIMARY KEY,
+    plano_id BIGINT NOT NULL REFERENCES plano_estiva (id),
+    identificador VARCHAR(40) NOT NULL,
+    sequencia INTEGER NOT NULL,
+    baia_inicial INTEGER NOT NULL,
+    baia_final INTEGER NOT NULL,
+    criado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    atualizado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    CONSTRAINT uk_terno_identificador UNIQUE (plano_id, identificador)
+);
+
+CREATE INDEX IF NOT EXISTS idx_terno_plano ON terno (plano_id);

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.css
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.css
@@ -206,6 +206,58 @@ select {
   border-spacing: 4px;
 }
 
+.linha-escotilha .escotilha {
+  text-align: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: #92400e;
+  background: repeating-linear-gradient(45deg, #fde68a, #fde68a 6px, #fcd34d 6px, #fcd34d 12px);
+  border-radius: 4px;
+  padding: 0.15rem 0;
+}
+
+.chip-terno {
+  background: #f59e0b;
+  color: #1f2933;
+  border-radius: 999px;
+  padding: 0 0.4rem;
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.chip-baia.ativa .chip-terno {
+  color: #1f2933;
+}
+
+.ternos .form-terno {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.lista-ternos {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.lista-ternos li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border: 1px solid #e4e7eb;
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+}
+
 .rotulo-eixo {
   font-size: 0.7rem;
   color: #7b8794;

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.html
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.html
@@ -32,8 +32,11 @@
       <label>Fileiras (rows)
         <input type="number" min="1" max="40" [(ngModel)]="novoPlano.fileiras" />
       </label>
-      <label>Camadas (tiers)
-        <input type="number" min="1" max="20" [(ngModel)]="novoPlano.camadas" />
+      <label>Camadas no porão (tiers 02, 04…)
+        <input type="number" min="0" max="20" [(ngModel)]="novoPlano.camadasPorao" />
+      </label>
+      <label>Camadas no convés (tiers 82, 84…)
+        <input type="number" min="0" max="20" [(ngModel)]="novoPlano.camadasConves" />
       </label>
     </div>
     <button type="button" class="btn-primario" [disabled]="salvando" (click)="criarPlano()">
@@ -78,6 +81,36 @@
       </div>
     </div>
 
+    <!-- Ternos (crane split / work queue) -->
+    <div class="cartao ternos">
+      <h3>Ternos (crane split)</h3>
+      <p class="ajuda">Atribua turmas/guindastes a um intervalo de baias e defina a ordem de operação.</p>
+      <form class="form-terno" (ngSubmit)="adicionarTerno()">
+        <label>Terno
+          <input type="text" maxlength="40" required [(ngModel)]="novoTerno.identificador" name="ternoId" placeholder="ex: GUINDASTE 1" />
+        </label>
+        <label>Sequência
+          <input type="number" min="1" [(ngModel)]="novoTerno.sequencia" name="ternoSeq" />
+        </label>
+        <label>Baia inicial
+          <input type="number" min="1" [(ngModel)]="novoTerno.baiaInicial" name="ternoIni" />
+        </label>
+        <label>Baia final
+          <input type="number" min="1" [(ngModel)]="novoTerno.baiaFinal" name="ternoFim" />
+        </label>
+        <button type="submit" class="btn-primario" [disabled]="salvando || !novoTerno.identificador">
+          Adicionar terno
+        </button>
+      </form>
+      <ul class="lista-ternos">
+        <li *ngFor="let terno of plano.ternos">
+          <span><strong>#{{ terno.sequencia }} {{ terno.identificador }}</strong> · baias {{ terno.baiaInicial }}–{{ terno.baiaFinal }}</span>
+          <button type="button" class="btn-remover" [disabled]="salvando" (click)="removerTerno(terno)">Remover</button>
+        </li>
+        <li *ngIf="!plano.ternos.length" class="vazio">Nenhum terno definido.</li>
+      </ul>
+    </div>
+
     <div class="layout-plano">
       <!-- Visualização gráfica do navio -->
       <div class="cartao navio">
@@ -89,10 +122,12 @@
             type="button"
             class="chip-baia"
             [class.ativa]="baia === baiaSelecionada"
+            [title]="ternoDaBaia(baia) ? ('Terno ' + ternoDaBaia(baia)?.identificador) : 'Sem terno'"
             (click)="selecionarBaia(baia)"
           >
             Baia {{ baia }}
             <span class="chip-contador">{{ contarNaBaia(baia) }}</span>
+            <span *ngIf="ternoDaBaia(baia) as t" class="chip-terno">{{ t.identificador }}</span>
           </button>
         </div>
 
@@ -102,19 +137,40 @@
           </p>
           <table class="grade-celulas">
             <tbody>
-              <tr *ngFor="let camada of camadasArrayDescendente">
-                <th scope="row" class="rotulo-eixo">T{{ camada }}</th>
+              <tr *ngFor="let tier of tiersConvesDesc">
+                <th scope="row" class="rotulo-eixo">T{{ tier }}</th>
                 <td *ngFor="let fileira of fileirasArray">
                   <button
                     type="button"
                     class="celula"
-                    [ngClass]="classeCelula(baiaSelecionada, fileira, camada)"
-                    [class.selecionada]="celulaSelecionadaNoForm(fileira, camada)"
-                    [title]="(atribuicaoEm(baiaSelecionada, fileira, camada)?.codigoConteiner) || ('Fileira ' + fileira + ' / Tier ' + camada)"
-                    (click)="selecionarCelula(fileira, camada)"
+                    [ngClass]="classeCelula(baiaSelecionada, fileira, tier)"
+                    [class.selecionada]="celulaSelecionadaNoForm(fileira, tier)"
+                    [title]="(atribuicaoEm(baiaSelecionada, fileira, tier)?.codigoConteiner) || ('Convés · Fileira ' + fileira + ' / Tier ' + tier)"
+                    (click)="selecionarCelula(fileira, tier)"
                   >
                     <span class="celula-codigo">
-                      {{ atribuicaoEm(baiaSelecionada, fileira, camada)?.codigoConteiner }}
+                      {{ atribuicaoEm(baiaSelecionada, fileira, tier)?.codigoConteiner }}
+                    </span>
+                  </button>
+                </td>
+              </tr>
+              <tr *ngIf="tiersConvesDesc.length && tiersPoraoDesc.length" class="linha-escotilha">
+                <th scope="row" class="rotulo-eixo"></th>
+                <td [attr.colspan]="fileirasArray.length" class="escotilha">tampa de escotilha (convés ↑ · porão ↓)</td>
+              </tr>
+              <tr *ngFor="let tier of tiersPoraoDesc">
+                <th scope="row" class="rotulo-eixo">T{{ tier }}</th>
+                <td *ngFor="let fileira of fileirasArray">
+                  <button
+                    type="button"
+                    class="celula"
+                    [ngClass]="classeCelula(baiaSelecionada, fileira, tier)"
+                    [class.selecionada]="celulaSelecionadaNoForm(fileira, tier)"
+                    [title]="(atribuicaoEm(baiaSelecionada, fileira, tier)?.codigoConteiner) || ('Porão · Fileira ' + fileira + ' / Tier ' + tier)"
+                    (click)="selecionarCelula(fileira, tier)"
+                  >
+                    <span class="celula-codigo">
+                      {{ atribuicaoEm(baiaSelecionada, fileira, tier)?.codigoConteiner }}
                     </span>
                   </button>
                 </td>
@@ -167,8 +223,12 @@
             <label>Fileira
               <input type="number" min="1" [(ngModel)]="novaAtribuicao.fileira" name="fileira" />
             </label>
-            <label>Camada
-              <input type="number" min="1" [(ngModel)]="novaAtribuicao.camada" name="camada" />
+            <label>Camada (tier)
+              <select [(ngModel)]="novaAtribuicao.camada" name="camada">
+                <option *ngFor="let tier of tiersDisponiveis" [ngValue]="tier">
+                  {{ tier }} ({{ tier >= 80 ? 'convés' : 'porão' }})
+                </option>
+              </select>
             </label>
             <label>Sequência
               <input type="number" min="1" [(ngModel)]="novaAtribuicao.sequenciaEmbarque" name="sequencia" />

--- a/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.ts
+++ b/frontend/cloudport/src/app/componentes/embarque/planejamento-embarque/planejamento-embarque.component.ts
@@ -5,8 +5,10 @@ import {
   EscalaResumo,
   NovaAtribuicaoEstiva,
   NovoPlanoEstiva,
+  NovoTerno,
   PlanoEstivaDetalhe,
   ServicoEstivaService,
+  Terno,
   TipoCargaConteiner,
   TipoOperacaoEstiva
 } from '../../service/servico-estiva/servico-estiva.service';
@@ -45,9 +47,11 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
 
   baiaSelecionada: number | null = null;
 
-  novoPlano: NovoPlanoEstiva = { baias: 10, fileiras: 6, camadas: 4 };
+  novoPlano: NovoPlanoEstiva = { baias: 10, fileiras: 6, camadasPorao: 4, camadasConves: 3 };
 
   novaAtribuicao: NovaAtribuicaoEstiva = this.criarAtribuicaoVazia();
+
+  novoTerno: NovoTerno = this.criarTernoVazio();
 
   private celulasOcupadas = new Map<string, AtribuicaoEstiva>();
 
@@ -126,7 +130,7 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
       return;
     }
     this.modoOperacao = modo;
-    this.novaAtribuicao = { ...this.criarAtribuicaoVazia(), baia: this.baiaSelecionada ?? 1 };
+    this.reiniciarFormularioAtribuicao();
   }
 
   selecionarBaia(baia: number): void {
@@ -203,6 +207,44 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     });
   }
 
+  adicionarTerno(): void {
+    if (this.escalaSelecionadaId == null) {
+      return;
+    }
+    this.salvando = true;
+    this.erro = null;
+    this.servicoEstiva.criarTerno(this.escalaSelecionadaId, this.novoTerno).subscribe({
+      next: (plano) => {
+        this.aplicarPlano(plano);
+        this.novoTerno = this.criarTernoVazio();
+        this.salvando = false;
+      },
+      error: (erro) => {
+        this.salvando = false;
+        this.erro = this.extrairMensagem(erro, 'Não foi possível criar o terno.');
+      }
+    });
+  }
+
+  removerTerno(terno: Terno): void {
+    this.salvando = true;
+    this.erro = null;
+    this.servicoEstiva.removerTerno(terno.id).subscribe({
+      next: (plano) => {
+        this.aplicarPlano(plano);
+        this.salvando = false;
+      },
+      error: (erro) => {
+        this.salvando = false;
+        this.erro = this.extrairMensagem(erro, 'Não foi possível remover o terno.');
+      }
+    });
+  }
+
+  ternoDaBaia(baia: number): Terno | undefined {
+    return this.plano?.ternos.find((t) => baia >= t.baiaInicial && baia <= t.baiaFinal);
+  }
+
   atribuicaoEm(baia: number, fileira: number, camada: number): AtribuicaoEstiva | undefined {
     return this.celulasOcupadas.get(this.chaveCelula(this.modoOperacao, baia, fileira, camada));
   }
@@ -232,8 +274,16 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     return this.intervalo(this.plano?.fileiras ?? 0);
   }
 
-  get camadasArrayDescendente(): number[] {
-    return this.intervalo(this.plano?.camadas ?? 0).reverse();
+  get tiersConvesDesc(): number[] {
+    return [...(this.plano?.tiersConves ?? [])].reverse();
+  }
+
+  get tiersPoraoDesc(): number[] {
+    return [...(this.plano?.tiersPorao ?? [])].reverse();
+  }
+
+  get tiersDisponiveis(): number[] {
+    return [...(this.plano?.tiersPorao ?? []), ...(this.plano?.tiersConves ?? [])];
   }
 
   get ehDescarga(): boolean {
@@ -300,11 +350,17 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
     if (this.baiaSelecionada != null) {
       this.novaAtribuicao.baia = this.baiaSelecionada;
     }
+    const tiers = this.tiersDisponiveis;
+    if (tiers.length > 0 && !tiers.includes(this.novaAtribuicao.camada)) {
+      this.novaAtribuicao.camada = tiers[0];
+    }
   }
 
   private reiniciarFormularioAtribuicao(): void {
     const baia = this.baiaSelecionada ?? 1;
-    this.novaAtribuicao = { ...this.criarAtribuicaoVazia(), baia };
+    const tiers = this.tiersDisponiveis;
+    const camada = tiers.length > 0 ? tiers[0] : 2;
+    this.novaAtribuicao = { ...this.criarAtribuicaoVazia(), baia, camada };
   }
 
   private criarAtribuicaoVazia(): NovaAtribuicaoEstiva {
@@ -315,11 +371,15 @@ export class PlanejamentoEmbarqueComponent implements OnInit {
       pesoToneladas: null,
       baia: 1,
       fileira: 1,
-      camada: 1,
+      camada: 2,
       posicaoPatioOrigem: null,
       posicaoPatioDestino: null,
       sequenciaEmbarque: null
     };
+  }
+
+  private criarTernoVazio(): NovoTerno {
+    return { identificador: '', sequencia: 1, baiaInicial: 1, baiaFinal: 1 };
   }
 
   private intervalo(tamanho: number): number[] {

--- a/frontend/cloudport/src/app/componentes/service/servico-estiva/servico-estiva.service.ts
+++ b/frontend/cloudport/src/app/componentes/service/servico-estiva/servico-estiva.service.ts
@@ -6,6 +6,22 @@ import { ConfiguracaoAplicacaoService } from '../../../configuracao/configuracao
 export type TipoCargaConteiner = 'SECO' | 'REFRIGERADO' | 'PERIGOSO' | 'GRANELEIRO' | 'OUTRO';
 export type StatusPlanoEstiva = 'RASCUNHO' | 'CONFIRMADO' | 'EM_EXECUCAO' | 'CONCLUIDO';
 export type TipoOperacaoEstiva = 'EMBARQUE' | 'DESCARGA';
+export type ConvesNavio = 'PORAO' | 'CONVES';
+
+export interface Terno {
+  id: number;
+  identificador: string;
+  sequencia: number;
+  baiaInicial: number;
+  baiaFinal: number;
+}
+
+export interface NovoTerno {
+  identificador: string;
+  sequencia: number;
+  baiaInicial: number;
+  baiaFinal: number;
+}
 
 export interface EscalaResumo {
   id: number;
@@ -27,6 +43,7 @@ export interface AtribuicaoEstiva {
   baia: number;
   fileira: number;
   camada: number;
+  conves: ConvesNavio;
   posicaoPatioOrigem?: string | null;
   posicaoPatioDestino?: string | null;
   sequenciaEmbarque?: number | null;
@@ -42,7 +59,10 @@ export interface PlanoEstivaDetalhe {
   status: StatusPlanoEstiva;
   baias: number;
   fileiras: number;
-  camadas: number;
+  camadasPorao: number;
+  camadasConves: number;
+  tiersPorao: number[];
+  tiersConves: number[];
   capacidadeCelulas: number;
   embarquePlanejado: number;
   embarqueExecutado: number;
@@ -51,12 +71,14 @@ export interface PlanoEstivaDetalhe {
   descargaExecutada: number;
   descargaPendente: number;
   atribuicoes: AtribuicaoEstiva[];
+  ternos: Terno[];
 }
 
 export interface NovoPlanoEstiva {
   baias: number;
   fileiras: number;
-  camadas: number;
+  camadasPorao: number;
+  camadasConves: number;
 }
 
 export interface NovaAtribuicaoEstiva {
@@ -110,6 +132,19 @@ export class ServicoEstivaService {
   removerAtribuicao(atribuicaoId: number): Observable<PlanoEstivaDetalhe> {
     return this.http.delete<PlanoEstivaDetalhe>(
       this.construirUrl(`/plano-estiva/atribuicoes/${atribuicaoId}`)
+    );
+  }
+
+  criarTerno(escalaId: number, payload: NovoTerno): Observable<PlanoEstivaDetalhe> {
+    return this.http.post<PlanoEstivaDetalhe>(
+      this.construirUrl(`/escalas/${escalaId}/plano-estiva/ternos`),
+      payload
+    );
+  }
+
+  removerTerno(ternoId: number): Observable<PlanoEstivaDetalhe> {
+    return this.http.delete<PlanoEstivaDetalhe>(
+      this.construirUrl(`/plano-estiva/ternos/${ternoId}`)
     );
   }
 


### PR DESCRIPTION
## Resumo

Aprimora o plano de estiva com três conceitos pedidos pelo planner, baseados no padrão Bay-Row-Tier e no Navis N4:

1. **Porão × Convés (deck/hold):** cada célula passa a ter localização `PORAO`/`CONVES`.
2. **Numeração real de tiers:** porão usa tiers `02, 04, 06…` e convés `82, 84, 86…`; a localização é derivada automaticamente do número do tier e o tier informado é validado.
3. **Terno (crane split / work queue):** turma/guindaste que opera um intervalo contíguo de baias com ordem de execução.

> PR empilhado sobre `claude/planejamento-descarga` (PR #157). O diff aqui é só destas mudanças. Ao mesclar, seguir a ordem: #156 → #157 → este (ou retargetar a base).

## Backend (`servico-navio`, módulo `estiva`)
- `PlanoEstiva`: `camadas` vira `camadasPorao` + `camadasConves`; capacidade considera os dois.
- `AtribuicaoEstiva`: novo campo `conves` (derivado do tier); a célula é única por operação **e** o tier é validado contra os tiers válidos do plano.
- Novo `TiersEstiva` (regras de numeração) e enum `ConvesNavio`.
- Nova entidade `Terno` + repositório + DTOs + endpoints: `POST /escalas/{id}/plano-estiva/ternos` e `DELETE /plano-estiva/ternos/{id}`, com validação de intervalo de baias, sobreposição e identificador único.
- `PlanoEstivaDetalheDTO` passa a expor `tiersPorao`, `tiersConves` e a lista de `ternos`.
- Migração Flyway `V5__estiva_conves_terno.sql`.

## Frontend (módulo `embarque`)
- A grade do navio agora mostra o **convés acima** da linha de **tampa de escotilha** e o **porão abaixo**, com os tiers reais (T82… / T02…).
- O campo de célula vira seleção de tier válido (porão/convés).
- Form de criação do plano pede camadas de porão e de convés.
- Painel de **Ternos**: cria/remove ternos; os chips de baia mostram o terno que cobre cada baia.

## Testes
- [x] Backend: `mvn compile` do `servico-navio` conclui com sucesso.
- [x] Frontend: `npm run build` conclui com sucesso (chunk lazy `embarque`).
- [ ] Verificação funcional end-to-end (Postgres + serviços + login) — não executada neste ambiente.

## Observações
- O terno é modelado como intervalo contíguo de baias (`baiaInicial`–`baiaFinal`) com `sequencia` de operação, alinhado ao conceito de crane split / work queue do N4. Sequenciamento detalhado por guindaste (anti-colisão, etc.) fica como evolução futura.
- Referências do usuário (Navis N4 Vessel e doc de stowing/securing) foram usadas para alinhar a terminologia de hold/deck, hatch cover e crane split.

https://claude.ai/code/session_01FEDuRJp9CV47Mx1Db4Cvsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEDuRJp9CV47Mx1Db4Cvsk)_